### PR TITLE
add suffix to node name in daemon

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -15,6 +15,8 @@
 import argparse
 import os
 
+from collections import namedtuple
+
 from ros2cli.node.direct import DirectNode
 from xmlrpc.server import SimpleXMLRPCServer
 
@@ -28,7 +30,9 @@ def main(*, script_name='_ros2_daemon', argv=None):
     args = parser.parse_args(args=argv)
 
     addr = ('localhost', get_daemon_port())
-    with DirectNode({}) as node:
+    NodeArgs = namedtuple('NodeArgs', 'node_name_suffix')
+    node_args = NodeArgs(node_name_suffix='_daemon')
+    with DirectNode(node_args) as node:
         server = SimpleXMLRPCServer(addr, logRequests=False)
 
         try:

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -31,7 +31,8 @@ class DirectNode(object):
 
         rclpy.init()
 
-        self.node = rclpy.create_node(HIDDEN_NODE_PREFIX + 'ros2cli_node')
+        node_name_suffix = getattr(args, 'node_name_suffix', '')
+        self.node = rclpy.create_node(HIDDEN_NODE_PREFIX + 'ros2cli_node' + node_name_suffix)
         timeout = getattr(args, 'spin_time', DEFAULT_TIMEOUT)
         self.timer = self.node.create_timer(timeout, timer_callback)
 


### PR DESCRIPTION
I needed this to distinguish between the daemon and the ros2 tool when debugging with `ros2 node list -a`.

Also, this will be good to have as an option when/if node names become unique.