### PR TITLE
Improve executable selection

### DIFF
--- a/ros2run/ros2run/api/__init__.py
+++ b/ros2run/ros2run/api/__init__.py
@@ -15,7 +15,6 @@
 import os
 import subprocess
 
-from ros2cli.node.strategy import NodeStrategy
 from ros2pkg.api import get_prefix_path
 
 
@@ -31,7 +30,7 @@ class PackageNotFound(Exception):
         self.package_name = package_name
 
 
-def get_executable_paths(*, node, package_name):
+def get_executable_paths(*, package_name):
     prefix_path = get_prefix_path(package_name)
     if prefix_path is None:
         raise PackageNotFound(package_name)
@@ -49,8 +48,8 @@ def get_executable_paths(*, node, package_name):
     return executable_paths
 
 
-def get_executable_path(*, node, package_name, executable_name):
-    paths = get_executable_paths(node=node, package_name=package_name)
+def get_executable_path(*, package_name, executable_name):
+    paths = get_executable_paths(package_name=package_name)
     paths2base = {
         p: os.path.basename(p) for p in paths
         if os.path.basename(p) == executable_name}
@@ -74,10 +73,8 @@ class ExecutableNameCompleter(object):
 
     def __call__(self, prefix, parsed_args, **kwargs):
         package_name = getattr(parsed_args, self.package_name_key)
-        with NodeStrategy(parsed_args) as node:
-            try:
-                paths = get_executable_paths(
-                    node=node, package_name=package_name)
-            except PackageNotFound:
-                return []
-            return [os.path.basename(p) for p in paths]
+        try:
+            paths = get_executable_paths(package_name=package_name)
+        except PackageNotFound:
+            return []
+        return [os.path.basename(p) for p in paths]


### PR DESCRIPTION
The first commit removes the unused `node` argument from the signatures.

The second commit considers `PATHEXT` on Windows to allow calling e.g. `ros2 run demo_nodes_py talker` (rather than needing to type `ros2 run demo_nodes_py talker.exe`).