### PR TITLE
use yaml for parsing msg and srv values

### DIFF
--- a/ros2service/package.xml
+++ b/ros2service/package.xml
@@ -12,6 +12,8 @@
   <depend>rclpy</depend>
   <depend>ros2cli</depend>
 
+  <exec_depend>python3-yaml</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -14,12 +14,12 @@
 
 import argparse
 import importlib
-import json
 import time
 
 import rclpy
 from ros2service.api import ServiceNameCompleter
 from ros2service.verb import VerbExtension
+import yaml
 
 
 class CallVerb(VerbExtension):
@@ -36,8 +36,8 @@ class CallVerb(VerbExtension):
             help="Type of the ROS service (e.g. 'std_srvs/Empty')")
         parser.add_argument(
             'values', nargs='?', default='{}',
-            help='Values to fill the service request with in JSON format ' +
-                 '(e.g. \'{"a": 1, "b": 2}\'), ' +
+            help='Values to fill the service request with in YAML format ' +
+                 '(e.g. "{a: 1, b: 2}"), ' +
                  'otherwise the service request will be published with default values')
 
         def float_or_int(input_string):
@@ -63,7 +63,7 @@ def requester(service_type, service_name, values, repeat):
         raise RuntimeError('The passed service type is invalid')
     module = importlib.import_module(package_name + '.srv')
     srv_module = getattr(module, srv_name)
-    values_dictionary = json.loads(values)
+    values_dictionary = yaml.load(values)
 
     rclpy.init()
 

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import importlib
-import json
 import time
 
 import rclpy
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
+import yaml
 
 
 class PubVerb(VerbExtension):
@@ -35,8 +35,8 @@ class PubVerb(VerbExtension):
             help="Type of the ROS message (e.g. 'std_msgs/String')")
         parser.add_argument(
             'values', nargs='?', default='{}',
-            help='Values to fill the message with in JSON format ' +
-                 '(e.g. \'{"data": "Hello World"}\'), ' +
+            help='Values to fill the message with in YAML format ' +
+                 '(e.g. "data: Hello World"), ' +
                  'otherwise the message will be published with default values')
 
     def main(self, *, args):
@@ -55,7 +55,7 @@ def publisher(message_type, topic_name, values):
         raise RuntimeError('The passed message type is invalid')
     module = importlib.import_module(package_name + '.msg')
     msg_module = getattr(module, message_name)
-    values_dictionary = json.loads(values)
+    values_dictionary = yaml.load(values)
 
     rclpy.init()
 


### PR DESCRIPTION
This should be backwards compatible with the JSON style inputs. Also, these packages already needed yaml, so it's not a new dependency. It also makes using this feature on Windows easier since you don't have to so quote escaping in a lot of cases.

@Kukanani FYI you should be able to do `ros2 topic pub /chatter std_msgs/String "data: Hello world"` with this pr.