### PR TITLE
support python3-argcomplete

### DIFF
--- a/ros2cli/completion/ros2-argcomplete.bash
+++ b/ros2cli/completion/ros2-argcomplete.bash
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if type register-python-argcomplete > /dev/null 2>&1; then
+if type register-python-argcomplete3 > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete3 ros2)"
+elif type register-python-argcomplete > /dev/null 2>&1; then
   eval "$(register-python-argcomplete ros2)"
 fi


### PR DESCRIPTION
Check for Python 3 variation of bash function first.

Fixes #25.

Ready for review.