### PR TITLE
also handle ValueError nicely

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -99,6 +99,8 @@ def set_msg_fields(msg, values):
                 raise SetFieldError(
                     '{field_name}.{e.field_name}'.format_map(locals()),
                     e.exception)
+        except ValueError as e:
+            raise SetFieldError(field_name, e)
         try:
             setattr(msg, field_name, value)
         except Exception as e:


### PR DESCRIPTION
Follow up of #24.

This handles `ValueErrors` as well. To reproduce try:

```
ros2 topic pub initialpose geometry_msgs/PoseWithCovarianceStamped "header:
  stamp:
    sec: 'sec'
    nanosec: 0.5
  frame_id: 'map'   
pose:
  pose:
    position: {x: 5.5, y: 4.5, z: 0.0}
    orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}
  covariance: [0.5, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0,    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
    0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"
```