### PR TITLE
hide help options from completion

### DIFF
--- a/ros2cli/ros2cli/cli.py
+++ b/ros2cli/ros2cli/cli.py
@@ -49,7 +49,7 @@ def main(*, script_name='ros2', argv=None, description=None, extension=None):
     except ImportError:
         pass
     else:
-        autocomplete(parser)
+        autocomplete(parser, exclude=['-h', '--help'])
 
     # parse the command line arguments
     args = parser.parse_args(args=argv)


### PR DESCRIPTION
E.g. for `ros2 run pkgname <tab>` this will ensure that only executable names will show up. For other commands / verbs that will still show other options. `run` just doesn't have any other ones beside `-h` and `--help`.