### PR TITLE
add exec_depend on python3-pkg-resources

### DIFF
--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -9,6 +9,7 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <exec_depend>python3-pkg-resources</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
the rosdep key has been added in https://github.com/ros/rosdistro/pull/15406