### PR TITLE
added --prefix argument to ros2 run

### DIFF
--- a/ros2run/ros2run/api/__init__.py
+++ b/ros2run/ros2run/api/__init__.py
@@ -48,8 +48,10 @@ def get_executable_path(*, package_name, executable_name):
     return list(paths2base.keys())[0]
 
 
-def run_executable(*, prefix, path, argv):
-    cmd = ([path] + argv) if prefix is '' else (prefix.split(' ') + [path] + argv)
+def run_executable(*, path, argv, prefix=None):
+    cmd = [path] + argv
+    if prefix is not None:
+        cmd = prefix + cmd
     completed_process = subprocess.run(cmd)
     return completed_process.returncode
 

--- a/ros2run/ros2run/api/__init__.py
+++ b/ros2run/ros2run/api/__init__.py
@@ -48,8 +48,9 @@ def get_executable_path(*, package_name, executable_name):
     return list(paths2base.keys())[0]
 
 
-def run_executable(*, path, argv):
-    completed_process = subprocess.run([path] + argv)
+def run_executable(*, prefix, path, argv):
+    cmd = ([path] + argv) if prefix is '' else (prefix.split(' ') + [path] + argv)
+    completed_process = subprocess.run(cmd)
     return completed_process.returncode
 
 

--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shlex
+
 from ros2cli.command import CommandExtension
 from ros2pkg.api import package_name_completer
 from ros2pkg.api import PackageNotFound
@@ -26,9 +28,10 @@ class RunCommand(CommandExtension):
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
-            '--prefix', nargs=1,
+            '--prefix',
             help="Prefix command, which should go before the executable, "
-                 "like gdb or valgrind (e.g. --prefix \'gdb -ex run --args\').")
+                 "like gdb or valgrind. Command must be wrapped in quotes "
+                 "(e.g. --prefix 'gdb -ex run --args').")
         arg = parser.add_argument(
             'package_name',
             help="Name of the ROS package")
@@ -60,5 +63,5 @@ class RunCommand(CommandExtension):
             raise RuntimeError(msg)
         if path is None:
             return 'No executable found'
-        prefix=args.prefix[0] if args.prefix is not None else ''
-        return run_executable(prefix=prefix, path=path, argv=args.argv)
+        prefix = shlex.split(args.prefix) if args.prefix is not None else None
+        return run_executable(path=path, argv=args.argv, prefix=prefix)

--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -29,8 +29,8 @@ class RunCommand(CommandExtension):
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
             '--prefix',
-            help="Prefix command, which should go before the executable, "
-                 "like gdb or valgrind. Command must be wrapped in quotes "
+            help="Prefix command, which should go before the executable. "
+                 "Command must be wrapped in quotes if it contains spaces"
                  "(e.g. --prefix 'gdb -ex run --args').")
         arg = parser.add_argument(
             'package_name',

--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -26,6 +26,10 @@ class RunCommand(CommandExtension):
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
+            '--prefix', nargs=1,
+            help="Prefix command, which should go before the executable, "
+                 "like gdb or valgrind (e.g. --prefix \'gdb -ex run --args\').")
+        arg = parser.add_argument(
             'package_name',
             help="Name of the ROS package")
         arg.completer = package_name_completer
@@ -37,7 +41,7 @@ class RunCommand(CommandExtension):
         parser.add_argument(
             'argv', nargs='*',
             help="Pass arbitrary arguments to the executable (use '--' before "
-                 "these arguments to ensure they are not handle by this "
+                 "these arguments to ensure they are not handled by this "
                  "command)")
 
     def main(self, *, parser, args):
@@ -56,4 +60,5 @@ class RunCommand(CommandExtension):
             raise RuntimeError(msg)
         if path is None:
             return 'No executable found'
-        return run_executable(path=path, argv=args.argv)
+        prefix=args.prefix[0] if args.prefix is not None else ''
+        return run_executable(prefix=prefix, path=path, argv=args.argv)

--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -30,7 +30,7 @@ class RunCommand(CommandExtension):
         arg = parser.add_argument(
             '--prefix',
             help="Prefix command, which should go before the executable. "
-                 "Command must be wrapped in quotes if it contains spaces"
+                 "Command must be wrapped in quotes if it contains spaces "
                  "(e.g. --prefix 'gdb -ex run --args').")
         arg = parser.add_argument(
             'package_name',


### PR DESCRIPTION
According to the proposal by @wjwwood on my [question](http://answers.ros.org/question/267261/how-can-i-run-ros2-nodes-in-a-debugger-eg-gdb/), I am providing a pull request to add the '--prefix' argument from 'rosrun' to 'ros2 run'.