### PR TITLE
better error message when passing an invalid value to ros2 topic pub

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -66,6 +66,8 @@ def publisher(message_type, topic_name, values):
     module = importlib.import_module(package_name + '.msg')
     msg_module = getattr(module, message_name)
     values_dictionary = yaml.load(values)
+    if not isinstance(values_dictionary, dict):
+        return 'The passed value needs to be a dictionary in YAML format'
 
     rclpy.init()
 


### PR DESCRIPTION
Instead of showing a stacktrace with the following exception:

```
AttributeError: 'str' object has no attribute 'items'
```

this patch prints an error message ~~which includes an example value for the specified message type~~.