### PR TITLE
add error message when trying to stop a daemon using a different rmw implementation

### DIFF
--- a/ros2cli/ros2cli/verb/daemon/stop.py
+++ b/ros2cli/ros2cli/verb/daemon/stop.py
@@ -27,5 +27,10 @@ class StopVerb(VerbExtension):
             return
 
         with DaemonNode(args) as daemon:
-            daemon.system.shutdown()
+            try:
+                shutdown = daemon.system.shutdown
+            except AttributeError:
+                return 'Failed to shutdown daemon, ' \
+                    'it might be using a different rmw implementation'
+            shutdown()
         print('The daemon has been stopped')


### PR DESCRIPTION
Instead of showing a stacktrace with the following exception:

```
AttributeError: 'Node' object has no attribute 'system'
```

this patch prints an error message describing why it failed.