### PR TITLE
fix SIGINT handling in ros2 run

### DIFF
--- a/ros2run/ros2run/api/__init__.py
+++ b/ros2run/ros2run/api/__init__.py
@@ -52,8 +52,16 @@ def run_executable(*, path, argv, prefix=None):
     cmd = [path] + argv
     if prefix is not None:
         cmd = prefix + cmd
-    completed_process = subprocess.run(cmd)
-    return completed_process.returncode
+
+    process = subprocess.Popen(cmd)
+    while process.returncode is None:
+        try:
+            process.communicate()
+        except KeyboardInterrupt:
+            # the subprocess will also receive the signal and should shut down
+            # therefore we continue here until the process has finished
+            pass
+    return process.returncode
 
 
 class ExecutableNameCompleter:


### PR DESCRIPTION
Without this patch when running an executable using `ros2 run` and hitting `Ctrl-C` / sending a `SIGINT` the `ros2cli` Python script would raise a `KeyboardInterrupt` in the line invoking `subprocess.run(...)`. This immediately stop any further processing. This can be seen easily when running `ros2 run demo_nodes_cpp allocator_tutorial` and pressing `Ctrl-C`. Depending on the timing you might not see any statistic output, maybe some of it, or the complete statistic.

This patch wraps the subprocess invocation in a loop and continue on `KeyboardInterrupt`. The process should exit on its own since it is also receiving the `SIGINT`. If not the user can always kill the process explicitly (e.g. using `Ctrl-\`).

This is very similar to ros2/launch#58.