### PR TITLE
Support non-absolute topic names.

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -18,8 +18,9 @@ import importlib
 import sys
 
 import rclpy
-from rclpy.qos import qos_profile_sensor_data
 from rclpy.expand_topic_name import expand_topic_name
+from rclpy.qos import qos_profile_sensor_data
+from rclpy.validate_full_topic_name import validate_full_topic_name
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
@@ -99,6 +100,7 @@ def subscriber(node, topic_name, message_type, callback):
     if message_type is None:
         topic_names_and_types = get_topic_names_and_types(node=node)
         expanded_name = expand_topic_name(topic_name, node.get_name(), node.get_namespace())
+        validate_full_topic_name(expanded_name, is_service=False)
         for n, t in topic_names_and_types:
             if n == expanded_name:
                 if len(t) > 1:

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -100,7 +100,7 @@ def subscriber(node, topic_name, message_type, callback):
     if message_type is None:
         topic_names_and_types = get_topic_names_and_types(node=node)
         expanded_name = expand_topic_name(topic_name, node.get_name(), node.get_namespace())
-        validate_full_topic_name(expanded_name, is_service=False)
+        validate_full_topic_name(expanded_name)
         for n, t in topic_names_and_types:
             if n == expanded_name:
                 if len(t) > 1:

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -19,6 +19,7 @@ import sys
 
 import rclpy
 from rclpy.qos import qos_profile_sensor_data
+from rclpy.expand_topic_name import expand_topic_name
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
@@ -97,8 +98,9 @@ def represent_ordereddict(dumper, data):
 def subscriber(node, topic_name, message_type, callback):
     if message_type is None:
         topic_names_and_types = get_topic_names_and_types(node=node)
+        expanded_name = expand_topic_name(topic_name, node.get_name(), node.get_namespace())
         for n, t in topic_names_and_types:
-            if n == topic_name or n == '/' + topic_name:
+            if n == expanded_name:
                 if len(t) > 1:
                     raise RuntimeError(
                         "Cannot echo topic '%s', as it contains more than one type: [%s]" %

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -98,7 +98,7 @@ def subscriber(node, topic_name, message_type, callback):
     if message_type is None:
         topic_names_and_types = get_topic_names_and_types(node=node)
         for n, t in topic_names_and_types:
-            if n == topic_name:
+            if n == topic_name or n == '/' + topic_name:
                 if len(t) > 1:
                     raise RuntimeError(
                         "Cannot echo topic '%s', as it contains more than one type: [%s]" %


### PR DESCRIPTION
If the user passes "/topic_name" to the ros2 echo
command, it works properly.  If they pass "topic_name"
to the ros2 echo command, it fails to match.  This
change just allows us to deal with non-absolute topic
names.

This should fix #54 .  I ran the tests against the ros2cli package locally,
with no errors.  No CI since this is python code and it won't tell us very much.

Signed-off-by: Chris Lalancette <clalancette@gmail.com>