### PR TITLE
Improve parameters passing to node in ros2run

### DIFF
--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -23,6 +23,7 @@ from ros2run.api import MultipleExecutables
 from ros2run.api import run_executable
 from argparse import REMAINDER
 
+
 class RunCommand(CommandExtension):
     """Run a package specific executable."""
 

--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -21,7 +21,7 @@ from ros2run.api import ExecutableNameCompleter
 from ros2run.api import get_executable_path
 from ros2run.api import MultipleExecutables
 from ros2run.api import run_executable
-
+from argparse import REMAINDER
 
 class RunCommand(CommandExtension):
     """Run a package specific executable."""
@@ -48,10 +48,8 @@ class RunCommand(CommandExtension):
         arg.completer = ExecutableNameCompleter(
             package_name_key='package_name')
         parser.add_argument(
-            'argv', nargs='*',
-            help="Pass arbitrary arguments to the executable (use '--' before "
-                 'these arguments to ensure they are not handled by this '
-                 'command)')
+            'argv', nargs=REMAINDER,
+            help="Pass arbitrary arguments to the executable")
 
     def main(self, *, parser, args):
         try:

--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from argparse import REMAINDER
 import shlex
 
-from argparse import REMAINDER
 from ros2cli.command import CommandExtension
 from ros2pkg.api import package_name_completer
 from ros2pkg.api import PackageNotFound

--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -14,6 +14,7 @@
 
 import shlex
 
+from argparse import REMAINDER
 from ros2cli.command import CommandExtension
 from ros2pkg.api import package_name_completer
 from ros2pkg.api import PackageNotFound
@@ -21,7 +22,6 @@ from ros2run.api import ExecutableNameCompleter
 from ros2run.api import get_executable_path
 from ros2run.api import MultipleExecutables
 from ros2run.api import run_executable
-from argparse import REMAINDER
 
 
 class RunCommand(CommandExtension):
@@ -50,7 +50,7 @@ class RunCommand(CommandExtension):
             package_name_key='package_name')
         parser.add_argument(
             'argv', nargs=REMAINDER,
-            help="Pass arbitrary arguments to the executable")
+            help='Pass arbitrary arguments to the executable')
 
     def main(self, *, parser, args):
         try:


### PR DESCRIPTION
This pull request try to improve on #40.
The use of narg=REMAINDER in [argparse](https://docs.python.org/3.5/library/argparse.html#nargs) exhibit the wanted behavior where every parameters after the node name are passed to the node without the need of the -- separator.
The prefix parameter (--prefix) still need to be placed before package and node to not be passed to the node. May be it is useful to print a warning if the prefix is had at the end of the command line ?

Let me know if i have missed something here.