### PR TITLE
use rmw agnostic daemon URL

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -78,8 +78,7 @@ def main(*, script_name='_ros2_daemon', argv=None):
                 shutdown = True
             server.register_function(shutdown_handler, 'system.shutdown')
 
-            print('Serving XML-RPC on %s:%d/%s/' % (
-                addr[0], addr[1], rclpy.get_rmw_implementation_identifier()))
+            print('Serving XML-RPC on %s:%d/ros2cli/' % (addr[0], addr[1]))
             try:
                 while not shutdown:
                     server.handle_request()
@@ -104,7 +103,7 @@ def get_daemon_port():
 
 
 class RequestHandler(SimpleXMLRPCRequestHandler):
-    rpc_paths = ('/%s/' % rclpy.get_rmw_implementation_identifier(),)
+    rpc_paths = ('/ros2cli/',)
 
 
 def _print_invoked_function_name(func):

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -86,8 +86,7 @@ class DaemonNode:
     def __init__(self, args):
         self._args = args
         self._proxy = ServerProxy(
-            'http://localhost:%d/%s/' %
-            (get_daemon_port(), rclpy.get_rmw_implementation_identifier()),
+            'http://localhost:%d/ros2cli/' % get_daemon_port(),
             allow_none=True)
         self._methods = []
 


### PR DESCRIPTION
Removes the rmw impl. specific path from the daemon URL. This allows a client with any rmw impl. to talk to a daemon with any rmw impl.

Fixes #69.