### PR TITLE
print full help when no command is passed

### DIFF
--- a/ros2cli/ros2cli/cli.py
+++ b/ros2cli/ros2cli/cli.py
@@ -41,7 +41,8 @@ def main(*, script_name='ros2', argv=None, description=None, extension=None):
         add_subparsers(
             parser, script_name, selected_extension_key, extensions,
             # hide the special commands in the help
-            hide_extensions=['extension_points', 'extensions'])
+            hide_extensions=['extension_points', 'extensions'],
+            required=False)
 
     # register argcomplete hook if available
     try:
@@ -55,9 +56,13 @@ def main(*, script_name='ros2', argv=None, description=None, extension=None):
     args = parser.parse_args(args=argv)
 
     if extension is None:
-        # the attribute should always exist
-        # otherwise argparse should have exited
-        extension = getattr(args, selected_extension_key)
+        # get extension identified by the passed command (if available)
+        extension = getattr(args, selected_extension_key, None)
+
+    # handle the case that no command was passed
+    if extension is None:
+        parser.print_help()
+        return 0
 
     # call the main method of the extension
     try:

--- a/ros2cli/ros2cli/command/__init__.py
+++ b/ros2cli/ros2cli/command/__init__.py
@@ -57,7 +57,8 @@ def get_command_extensions(group_name):
 
 
 def add_subparsers(
-    parser, cli_name, dest, command_extensions, hide_extensions=None
+    parser, cli_name, dest, command_extensions, hide_extensions=None,
+    required=True
 ):
     """
     Create argparse subparser for each extension.
@@ -96,7 +97,7 @@ def add_subparsers(
     # use a name which doesn't collide with any argument
     # but is readable when shown as part of the the usage information
     subparser.dest = ' ' + dest.lstrip('_')
-    subparser.required = True
+    subparser.required = required
 
     # add extension specific sub-parser with its arguments
     for name in sorted(command_extensions.keys()):
@@ -109,3 +110,5 @@ def add_subparsers(
         if hasattr(extension, 'add_arguments'):
             extension.add_arguments(
                 command_parser, '{cli_name} {name}'.format_map(locals()))
+
+    return subparser

--- a/ros2cli/ros2cli/command/daemon.py
+++ b/ros2cli/ros2cli/command/daemon.py
@@ -22,13 +22,18 @@ class DaemonCommand(CommandExtension):
     """Various daemon related sub-commands."""
 
     def add_arguments(self, parser, cli_name):
+        self._subparser = parser
         # get verb extensions and let them add their arguments
         verb_extensions = get_verb_extensions('ros2cli.daemon.verb')
-        add_subparsers(parser, cli_name, '_verb', verb_extensions)
+        add_subparsers(
+            parser, cli_name, '_verb', verb_extensions, required=False)
 
     def main(self, *, parser, args):
-        # the attribute should always exist
-        # otherwise argparse should have exited
+        if not hasattr(args, '_verb'):
+            # in case no verb was passed
+            self._subparser.print_help()
+            return 0
+
         extension = getattr(args, '_verb')
 
         # call the verb's main method

--- a/ros2msg/ros2msg/command/msg.py
+++ b/ros2msg/ros2msg/command/msg.py
@@ -21,13 +21,18 @@ class MsgCommand(CommandExtension):
     """Various msg related sub-commands."""
 
     def add_arguments(self, parser, cli_name):
+        self._subparser = parser
         # get verb extensions and let them add their arguments
         verb_extensions = get_verb_extensions('ros2msg.verb')
-        add_subparsers(parser, cli_name, '_verb', verb_extensions)
+        add_subparsers(
+            parser, cli_name, '_verb', verb_extensions, required=False)
 
     def main(self, *, parser, args):
-        # the attribute should always exist
-        # otherwise argparse should have exited
+        if not hasattr(args, '_verb'):
+            # in case no verb was passed
+            self._subparser.print_help()
+            return 0
+
         extension = getattr(args, '_verb')
 
         # call the verb's main method

--- a/ros2node/ros2node/command/node.py
+++ b/ros2node/ros2node/command/node.py
@@ -21,13 +21,18 @@ class NodeCommand(CommandExtension):
     """Various node related sub-commands."""
 
     def add_arguments(self, parser, cli_name):
+        self._subparser = parser
         # get verb extensions and let them add their arguments
         verb_extensions = get_verb_extensions('ros2node.verb')
-        add_subparsers(parser, cli_name, '_verb', verb_extensions)
+        add_subparsers(
+            parser, cli_name, '_verb', verb_extensions, required=False)
 
     def main(self, *, parser, args):
-        # the attribute should always exist
-        # otherwise argparse should have exited
+        if not hasattr(args, '_verb'):
+            # in case no verb was passed
+            self._subparser.print_help()
+            return 0
+
         extension = getattr(args, '_verb')
 
         # call the verb's main method

--- a/ros2pkg/ros2pkg/command/pkg.py
+++ b/ros2pkg/ros2pkg/command/pkg.py
@@ -21,13 +21,18 @@ class PkgCommand(CommandExtension):
     """Various package related sub-commands."""
 
     def add_arguments(self, parser, cli_name):
+        self._subparser = parser
         # get verb extensions and let them add their arguments
         verb_extensions = get_verb_extensions('ros2pkg.verb')
-        add_subparsers(parser, cli_name, '_verb', verb_extensions)
+        add_subparsers(
+            parser, cli_name, '_verb', verb_extensions, required=False)
 
     def main(self, *, parser, args):
-        # the attribute should always exist
-        # otherwise argparse should have exited
+        if not hasattr(args, '_verb'):
+            # in case no verb was passed
+            self._subparser.print_help()
+            return 0
+
         extension = getattr(args, '_verb')
 
         # call the verb's main method

--- a/ros2service/ros2service/command/service.py
+++ b/ros2service/ros2service/command/service.py
@@ -21,17 +21,22 @@ class ServiceCommand(CommandExtension):
     """Various service related sub-commands."""
 
     def add_arguments(self, parser, cli_name):
+        self._subparser = parser
         parser.add_argument(
             '--include-hidden-services', action='store_true',
             help='Consider hidden services as well')
 
         # get verb extensions and let them add their arguments
         verb_extensions = get_verb_extensions('ros2service.verb')
-        add_subparsers(parser, cli_name, '_verb', verb_extensions)
+        add_subparsers(
+            parser, cli_name, '_verb', verb_extensions, required=False)
 
     def main(self, *, parser, args):
-        # the attribute should always exist
-        # otherwise argparse should have exited
+        if not hasattr(args, '_verb'):
+            # in case no verb was passed
+            self._subparser.print_help()
+            return 0
+
         extension = getattr(args, '_verb')
 
         # call the verb's main method

--- a/ros2srv/ros2srv/command/srv.py
+++ b/ros2srv/ros2srv/command/srv.py
@@ -21,13 +21,18 @@ class SrvCommand(CommandExtension):
     """Various srv related sub-commands."""
 
     def add_arguments(self, parser, cli_name):
+        self._subparser = parser
         # get verb extensions and let them add their arguments
         verb_extensions = get_verb_extensions('ros2srv.verb')
-        add_subparsers(parser, cli_name, '_verb', verb_extensions)
+        add_subparsers(
+            parser, cli_name, '_verb', verb_extensions, required=False)
 
     def main(self, *, parser, args):
-        # the attribute should always exist
-        # otherwise argparse should have exited
+        if not hasattr(args, '_verb'):
+            # in case no verb was passed
+            self._subparser.print_help()
+            return 0
+
         extension = getattr(args, '_verb')
 
         # call the verb's main method

--- a/ros2topic/ros2topic/command/topic.py
+++ b/ros2topic/ros2topic/command/topic.py
@@ -21,17 +21,22 @@ class TopicCommand(CommandExtension):
     """Various topic related sub-commands."""
 
     def add_arguments(self, parser, cli_name):
+        self._subparser = parser
         parser.add_argument(
             '--include-hidden-topics', action='store_true',
             help='Consider hidden topics as well')
 
         # get verb extensions and let them add their arguments
         verb_extensions = get_verb_extensions('ros2topic.verb')
-        add_subparsers(parser, cli_name, '_verb', verb_extensions)
+        add_subparsers(
+            parser, cli_name, '_verb', verb_extensions, required=False)
 
     def main(self, *, parser, args):
-        # the attribute should always exist
-        # otherwise argparse should have exited
+        if not hasattr(args, '_verb'):
+            # in case no verb was passed
+            self._subparser.print_help()
+            return 0
+
         extension = getattr(args, '_verb')
 
         # call the verb's main method


### PR DESCRIPTION
When no `command` / `verb` is passed the full help is printed as if the user would have passed `--help`.

Fixes #74.

The API is backward compatible so that the behavior of existing extensions isn't changes. Extensions implemented in other repositories could be updated in the same way (not to require the `verb`) if they want to show the full help text in that case.