### PR TITLE
[ros2 topic pub] allow to pass a node name to ros2 topic pub

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -49,6 +49,9 @@ class PubVerb(VerbExtension):
         parser.add_argument(
             '-1', '--once', action='store_true',
             help='Publish one message and exit')
+        parser.add_argument(
+            '-n', '--node-name', type=str, default='',
+            help='Name of the created publishing node')
 
     def main(self, *, args):
         if args.rate <= 0:
@@ -58,10 +61,12 @@ class PubVerb(VerbExtension):
 
 
 def main(args):
-    return publisher(args.message_type, args.topic_name, args.values, 1. / args.rate, args.once)
+    return publisher(
+        args.message_type, args.topic_name, args.values,
+        args.node_name, 1. / args.rate, args.once)
 
 
-def publisher(message_type, topic_name, values, period, once):
+def publisher(message_type, topic_name, values, node_name, period, once):
     # TODO(dirk-thomas) this logic should come from a rosidl related package
     try:
         package_name, message_name = message_type.split('/', 2)
@@ -74,10 +79,11 @@ def publisher(message_type, topic_name, values, period, once):
     values_dictionary = yaml.load(values)
     if not isinstance(values_dictionary, dict):
         return 'The passed value needs to be a dictionary in YAML format'
-
+    if node_name == '':
+        node_name = 'publisher_%s_%s' % (package_name, message_name)
     rclpy.init()
 
-    node = rclpy.create_node('publisher_%s_%s' % (package_name, message_name))
+    node = rclpy.create_node(node_name)
 
     pub = node.create_publisher(msg_module, topic_name)
 


### PR DESCRIPTION
I needed this for testing and figured I'll just submit it. Ideally we would do the same for `echo` but as it uses [DirectNode](https://github.com/ros2/ros2cli/blob/6b18ca7814a14d3e9b949523ccaf1e44a592fe8d/ros2topic/ros2topic/verb/echo.py#L79) and create nodes based on process ID that will be a bit more intricated so I settled on this incremental PR for now.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4029)](http://ci.ros2.org/job/ci_linux/4029/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1121)](http://ci.ros2.org/job/ci_linux-aarch64/1121/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3359)](http://ci.ros2.org/job/ci_osx/3359/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4122)](http://ci.ros2.org/job/ci_windows/4122/)