### PR TITLE
source bash completion script from setup file

### DIFF
--- a/ros2cli/resource/local_setup.bash
+++ b/ros2cli/resource/local_setup.bash
@@ -1,0 +1,37 @@
+# reduced from ament_package/template/package_level/local_setup.bash.in
+
+# provide AMENT_CURRENT_PREFIX to shell script
+AMENT_CURRENT_PREFIX=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`/../.." && pwd)
+# store AMENT_CURRENT_PREFIX to restore it before each environment hook
+_package_local_setup_AMENT_CURRENT_PREFIX=$AMENT_CURRENT_PREFIX
+
+# unset AMENT_ENVIRONMENT_HOOKS
+# if not appending to them for return
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+# restore AMENT_CURRENT_PREFIX before evaluating the environment hooks
+AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
+# list all environment hooks of this package
+ament_append_value AMENT_ENVIRONMENT_HOOKS "$AMENT_CURRENT_PREFIX/share/ros2cli/environment/ros2-argcomplete.bash"
+# source all shell-specific environment hooks of this package
+# if not returning them
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  _package_local_setup_IFS=$IFS
+  IFS=":"
+  for _hook in $AMENT_ENVIRONMENT_HOOKS; do
+    # restore AMENT_CURRENT_PREFIX for each environment hook
+    AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
+    # restore IFS before sourcing other files
+    IFS=$_package_local_setup_IFS
+    . "$_hook"
+  done
+  unset _hook
+  IFS=$_package_local_setup_IFS
+  unset _package_local_setup_IFS
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+unset _package_local_setup_AMENT_CURRENT_PREFIX
+unset AMENT_CURRENT_PREFIX

--- a/ros2cli/resource/local_setup.zsh
+++ b/ros2cli/resource/local_setup.zsh
@@ -1,0 +1,47 @@
+# reduced from ament_package/template/package_level/local_setup.zsh.in
+
+# provide AMENT_CURRENT_PREFIX to shell script
+AMENT_CURRENT_PREFIX=$(builtin cd -q "`dirname "${(%):-%N}"`/../.." > /dev/null && pwd)
+# store AMENT_CURRENT_PREFIX to restore it before each environment hook
+_package_local_setup_AMENT_CURRENT_PREFIX=$AMENT_CURRENT_PREFIX
+
+# function to convert array-like strings into arrays
+# to wordaround SH_WORD_SPLIT not being set
+ament_zsh_to_array() {
+  local _listname=$1
+  local _dollar="$"
+  local _split="{="
+  local _to_array="(\"$_dollar$_split$_listname}\")"
+  eval $_listname=$_to_array
+}
+
+# unset AMENT_ENVIRONMENT_HOOKS
+# if not appending to them for return
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+# restore AMENT_CURRENT_PREFIX before evaluating the environment hooks
+AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
+# list all environment hooks of this package
+ament_zsh_to_array AMENT_ENVIRONMENT_HOOKS "$AMENT_CURRENT_PREFIX/share/ros2cli/environment/ros2-argcomplete.zsh"
+# source all shell-specific environment hooks of this package
+# if not returning them
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  _package_local_setup_IFS=$IFS
+  IFS=":"
+  for _hook in $AMENT_ENVIRONMENT_HOOKS; do
+    # restore AMENT_CURRENT_PREFIX for each environment hook
+    AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
+    # restore IFS before sourcing other files
+    IFS=$_package_local_setup_IFS
+    . "$_hook"
+  done
+  unset _hook
+  IFS=$_package_local_setup_IFS
+  unset _package_local_setup_IFS
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+unset _package_local_setup_AMENT_CURRENT_PREFIX
+unset AMENT_CURRENT_PREFIX

--- a/ros2cli/setup.py
+++ b/ros2cli/setup.py
@@ -9,6 +9,12 @@ setup(
         'completion': ['argcomplete'],
     },
     data_files=[
+        ('share/ament_index/resource_index/packages', [
+            'resource/ros2cli',
+        ]),
+        ('share/ros2cli', [
+            'resource/local_setup.bash',
+        ]),
         ('share/ros2cli/environment', [
             'completion/ros2-argcomplete.bash',
             'completion/ros2-argcomplete.zsh'

--- a/ros2cli/setup.py
+++ b/ros2cli/setup.py
@@ -14,6 +14,7 @@ setup(
         ]),
         ('share/ros2cli', [
             'resource/local_setup.bash',
+            'resource/local_setup.zsh',
         ]),
         ('share/ros2cli/environment', [
             'completion/ros2-argcomplete.bash',


### PR DESCRIPTION
Fixes ros2/ros2cli#78. Connect to ros2/ros2cli#78.

I have applied the same changes to the installed location in `/opt/ros/ardent` which made it work for me from Debian packages when sourcing `/opt/ros/ardent/local_setup.bash`.