### PR TITLE
Avoid use of license as variable name

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -142,7 +142,7 @@ class CreateVerb(VerbExtension):
         print('version:', package.version)
         print('description:', package.description)
         print('maintainer:', [str(maintainer) for maintainer in package.maintainers])
-        print('licenses:', [license for license in package.licenses])
+        print('licenses:', [license_ for license_ in package.licenses])
         print('build type:', package.get_build_type())
         print('dependencies:', [str(dependency) for dependency in package.build_depends])
         if args.cpp_node_name:


### PR DESCRIPTION
`flake8-builtins` >=1.2 will report this now