### PR TITLE
use catkin pkg instead of ament_package

### DIFF
--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -12,7 +12,7 @@
   <depend>ros2cli</depend>
 
   <exec_depend>ament_index_python</exec_depend>
-  <exec_depend>ament_package</exec_depend>
+  <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-empy</exec_depend>
   <exec_depend>python3-pkg-resources</exec_depend>
 

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -17,10 +17,10 @@ import os
 import subprocess
 import sys
 
-from ament_package.dependency import Dependency
-from ament_package.export import Export
-from ament_package.package import Package
-from ament_package.person import Person
+from catkin_pkg.package import Dependency
+from catkin_pkg.package import Export
+from catkin_pkg.package import Package
+from catkin_pkg.package import Person
 
 from ros2pkg.api.create import create_package_environment
 from ros2pkg.api.create import populate_ament_cmake


### PR DESCRIPTION
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4510)](https://ci.ros2.org/job/ci_linux/4510/)

Uses the new rosdep key proposed in ros/rosdistro#18093.