### PR TITLE
update ros2 param list output for a specific node

### DIFF
--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -79,7 +79,8 @@ class ListVerb(VerbExtension):
             for node_name in sorted(futures.keys()):
                 future = futures[node_name]
                 if future.result() is not None:
-                    print('{node_name}:'.format_map(locals()))
+                    if not args.node_name:
+                        print('{node_name}:'.format_map(locals()))
                     response = future.result()
                     for name in sorted(response.result.names):
                         print('  {name}'.format_map(locals()))


### PR DESCRIPTION
Not showing the node name when a specific node was requested.

Follow up of #95.