### PR TITLE
add missing arg to ros2 service list

### DIFF
--- a/ros2service/ros2service/verb/list.py
+++ b/ros2service/ros2service/verb/list.py
@@ -29,11 +29,15 @@ class ListVerb(VerbExtension):
         parser.add_argument(
             '-c', '--count-services', action='store_true',
             help='Only display the number of services discovered')
+        parser.add_argument(
+            '--include-hidden-services', action='store_true',
+            help='Consider hidden services as well')
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
             service_names_and_types = get_service_names_and_types(
-                node=node, include_hidden_services=args.include_hidden_services)
+                node=node,
+                include_hidden_services=args.include_hidden_services)
 
         if args.count_services:
             print(len(service_names_and_types))


### PR DESCRIPTION
While `args.include_hidden_services` was already passed to `get_service_names_and_types` there was no such argument.