### PR TITLE
use (bash)compinit for zsh completion

### DIFF
--- a/ros2cli/completion/ros2-argcomplete.zsh
+++ b/ros2cli/completion/ros2-argcomplete.zsh
@@ -1,4 +1,4 @@
-# Copyright 2017 Open Source Robotics Foundation, Inc.
+# Copyright 2017-2018 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
 
 # Get this scripts directory
 __ros2cli_completion_dir=${0:a:h}


### PR DESCRIPTION
Without this sourcing the `zsh` file results in:

```command not found: complete```