### PR TITLE
Update matching for lifecycle service types to support Opensplice

### DIFF
--- a/ros2lifecycle/ros2lifecycle/api/__init__.py
+++ b/ros2lifecycle/ros2lifecycle/api/__init__.py
@@ -35,7 +35,8 @@ def _has_lifecycle(node_name, service_names_and_types):
     for (service_name, service_types) in service_names_and_types:
         if (
             service_name == '/{node_name}/get_state'.format_map(locals()) and
-            'lifecycle_msgs/GetState' in service_types
+            ('lifecycle_msgs/GetState' in service_types or
+                'lifecycle_msgs/Sample_GetState' in service_types)  # Format used by OpenSplice
         ):
             return True
     return False


### PR DESCRIPTION
@ironmig noticed that `ros2 service list` wasn't reporting Opensplice lifecycle nodes properly (e.g. `ros2 run lifecycle lifecycle_talker`).

The service name and type for opensplice that's reported by `get_service_names_and_types` is:

```
Topic: /lc_talker/get_state
Type: 'lifecycle_msgs/Sample_GetState'
```

I took a quick look at the opensplice typesupport, and it seems to be on purpose that we [use samples vs msgs names](https://github.com/ros2/rmw_opensplice/blob/e0696909726cce9240ce7e9a20de17421f60daf2/rosidl_typesupport_opensplice_cpp/resource/srv__type_support.cpp.em#L235) so I assume that that is a requirement of opensplice's typesupport. As such this PR loosens the check to match it, rather than attempting to remove Sample_ from the type. It may very well be feasible to make `get_service_names_and_types` report the type without having Sample_ in it, but if so we can do that at a later date IMO.