### PR TITLE
cancel timer before letting caller use the node to avoid spurious wakeups for consumers

### DIFF
--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -37,11 +37,12 @@ class DirectNode:
             args, 'node_name_suffix', '_%d' % os.getpid())
         self.node = rclpy.create_node(HIDDEN_NODE_PREFIX + 'ros2cli_node' + node_name_suffix)
         timeout = getattr(args, 'spin_time', DEFAULT_TIMEOUT)
-        self.timer = self.node.create_timer(timeout, timer_callback)
+        timer = self.node.create_timer(timeout, timer_callback)
 
         while not timeout_reached:
             rclpy.spin_once(self.node)
-        self.timer.cancel()
+
+        self.node.destroy_timer(timer)
 
     def __enter__(self):
         return self
@@ -53,7 +54,6 @@ class DirectNode:
         return getattr(self.node, name)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.node.destroy_timer(self.timer)
         self.node.destroy_node()
         rclpy.shutdown()
 

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -41,6 +41,7 @@ class DirectNode:
 
         while not timeout_reached:
             rclpy.spin_once(self.node)
+        self.timer.cancel()
 
     def __enter__(self):
         return self


### PR DESCRIPTION
@dirk-thomas Is this timer intended to stay alive and be used by consumers?

Otherwise I can update this PR to destroy the timer before exiting the init function