### PR TITLE
fix tests to use packages which register themselves at the index

### DIFF
--- a/ros2msg/package.xml
+++ b/ros2msg/package.xml
@@ -18,6 +18,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>std_msgs</test_depend>
+  <test_depend>std_srvs</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2msg/test/test_api.py
+++ b/ros2msg/test/test_api.py
@@ -51,7 +51,7 @@ def test_api():
         pass
 
     # check package with doesn't have messages
-    message_names = get_message_types('ament_index_python')
+    message_names = get_message_types('std_srvs')
     assert len(message_names) == 0
 
     # check known package for not existing message name

--- a/ros2pkg/test/test_api.py
+++ b/ros2pkg/test/test_api.py
@@ -24,13 +24,10 @@ def test_api():
     assert isinstance(package_names, Iterable)
 
     # explicit dependencies of this package will for sure be available
-    known_package_names = (
-        'ament_copyright', 'ament_flake8', 'ament_pep257', 'ros2cli')
-    for known_package_name in known_package_names:
-        assert known_package_name in package_names
+    assert 'ros2cli' in package_names
 
-        prefix_path = get_prefix_path(known_package_name)
-        assert os.path.isdir(prefix_path)
+    prefix_path = get_prefix_path('ros2cli')
+    assert os.path.isdir(prefix_path)
 
     prefix_path = get_prefix_path('_not_existing_package_name')
     assert prefix_path is None

--- a/ros2pkg/test/test_cli.py
+++ b/ros2pkg/test/test_cli.py
@@ -22,17 +22,14 @@ def test_cli():
     package_names = list_result.stdout.decode().splitlines()
 
     # explicit dependencies of this package will for sure be available
-    known_package_names = (
-        'ament_copyright', 'ament_flake8', 'ament_pep257', 'ros2cli')
-    for known_package_name in known_package_names:
-        assert known_package_name in package_names
+    assert 'ros2cli' in package_names
 
-        prefix_cmd = ['ros2', 'pkg', 'prefix', known_package_name]
-        prefix_result = subprocess.run(
-            prefix_cmd, stdout=subprocess.PIPE, check=True)
-        prefix_path = prefix_result.stdout.decode().splitlines()
-        assert len(prefix_path) == 1
-        assert os.path.isdir(prefix_path[0])
+    prefix_cmd = ['ros2', 'pkg', 'prefix', 'ros2cli']
+    prefix_result = subprocess.run(
+        prefix_cmd, stdout=subprocess.PIPE, check=True)
+    prefix_path = prefix_result.stdout.decode().splitlines()
+    assert len(prefix_path) == 1
+    assert os.path.isdir(prefix_path[0])
 
     prefix_cmd = ['ros2', 'pkg', 'prefix', '_not_existing_package_name']
     prefix_result = subprocess.run(

--- a/ros2srv/package.xml
+++ b/ros2srv/package.xml
@@ -17,6 +17,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>
 
   <export>

--- a/ros2srv/test/test_api.py
+++ b/ros2srv/test/test_api.py
@@ -51,7 +51,7 @@ def test_api():
         pass
 
     # check package with doesn't have services
-    service_names = get_service_types('ament_index_python')
+    service_names = get_service_types('std_msgs')
     assert len(service_names) == 0
 
     # check known package for not existing service name


### PR DESCRIPTION
Before: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Bdev__ros2cli__ubuntu_bionic_amd64&build=1)](http://build.ros2.org/job/Bdev__ros2cli__ubuntu_bionic_amd64/1/)
After: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Bdev__ros2cli__ubuntu_bionic_amd64&build=2)](http://build.ros2.org/job/Bdev__ros2cli__ubuntu_bionic_amd64/2/)