### PR TITLE
Check rmw identifier

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -35,7 +35,7 @@ def main(*, script_name='_ros2_daemon', argv=None):
              'ROS_DOMAIN_ID)')
     parser.add_argument(
         '--timeout', metavar='N', type=int, default=2 * 60 * 60,
-        help='Shutdown the daemin after N seconds of inactivity')
+        help='Shutdown the daemon after N seconds of inactivity')
     args = parser.parse_args(args=argv)
 
     # the arguments are only passed for visibility in e.g. the process list

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -65,9 +65,16 @@ def spawn_daemon(args, wait_until_spawned=None):
         kwargs['startupinfo'] = si
         # don't keep handle of current working directory in daemon process
         kwargs.update(cwd=os.environ.get('SYSTEMROOT', None))
+
+    rmw_implementation_identifier = rclpy.get_rmw_implementation_identifier()
+    if rmw_implementation_identifier is None:
+        raise RuntimeError(
+            'Unable to get rmw_implementation_identifier,'
+            ' try specifying the implementation to use via the'
+            " 'RMW_IMPLEMENTATION' environment variable")
     subprocess.Popen(cmd + [
         # the arguments are only passed for visibility in e.g. the process list
-        '--rmw-implementation', rclpy.get_rmw_implementation_identifier(),
+        '--rmw-implementation', rmw_implementation_identifier,
         '--ros-domain-id', str(ros_domain_id)],
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **kwargs)
 

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -69,9 +69,9 @@ def spawn_daemon(args, wait_until_spawned=None):
     rmw_implementation_identifier = rclpy.get_rmw_implementation_identifier()
     if rmw_implementation_identifier is None:
         raise RuntimeError(
-            'Unable to get rmw_implementation_identifier,'
-            ' try specifying the implementation to use via the'
-            " 'RMW_IMPLEMENTATION' environment variable")
+            'Unable to get rmw_implementation_identifier, '
+            'try specifying the implementation to use via the '
+            "'RMW_IMPLEMENTATION' environment variable")
     subprocess.Popen(cmd + [
         # the arguments are only passed for visibility in e.g. the process list
         '--rmw-implementation', rmw_implementation_identifier,


### PR DESCRIPTION
Potential fix for #120 

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4848)](http://ci.ros2.org/job/ci_linux/4848/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1701)](http://ci.ros2.org/job/ci_linux-aarch64/1701/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4026)](http://ci.ros2.org/job/ci_osx/4026/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4892)](http://ci.ros2.org/job/ci_windows/4892/)

without the patch:
```bash
Traceback (most recent call last):
  File "/opt/ros/bouncy/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli==0.5.2', 'console_scripts', 'ros2')()
  File "/opt/ros/bouncy/lib/python3.6/site-packages/ros2cli/cli.py", line 69, in main
    rc = extension.main(parser=parser, args=args)
  File "/opt/ros/bouncy/lib/python3.6/site-packages/ros2node/command/node.py", line 39, in main
    return extension.main(args=args)
  File "/opt/ros/bouncy/lib/python3.6/site-packages/ros2node/verb/list.py", line 34, in main
    with NodeStrategy(args) as node:
  File "/opt/ros/bouncy/lib/python3.6/site-packages/ros2cli/node/strategy.py", line 29, in __init__
    spawn_daemon(args)
  File "/opt/ros/bouncy/lib/python3.6/site-packages/ros2cli/node/daemon.py", line 72, in spawn_daemon
    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **kwargs)
  File "/usr/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1275, in _execute_child
    restore_signals, start_new_session, preexec_fn)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

with the patch:
```bash
# ros2 node list
Unable to get rmw_implementation_identifier, try specifying the implementation to use via the 'RMW_IMPLEMENTATION' environment variable
```