### PR TITLE
 [topic pub] add option to limit printing published msgs

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -53,7 +53,7 @@ class PubVerb(VerbExtension):
             '-1', '--once', action='store_true',
             help='Publish one message and exit')
         parser.add_argument(
-            '-n', '--node-name', type=str, default='',
+            '-n', '--node-name', type=str,
             help='Name of the created publishing node')
 
     def main(self, *, args):
@@ -84,7 +84,7 @@ def publisher(
     values_dictionary = yaml.load(values)
     if not isinstance(values_dictionary, dict):
         return 'The passed value needs to be a dictionary in YAML format'
-    if node_name == '':
+    if not node_name:
         node_name = 'publisher_%s_%s' % (package_name, message_name)
     rclpy.init()
 


### PR DESCRIPTION
I found myself patching the code several times when I wanted to publish messages with a higher rate but without the overhead of flooding the console (which essentially slows down the loop). Hence the first commit adds an option to control how many published message should be printed (e.g. try `-r 1000 -p 250`).

The second commit only removes a default value which doesn't make sense. The default node name is not as indicated and empty string but is being set by the script later if no not-empty node name is provided.