### PR TITLE
Fix echo for big array messages

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -148,7 +148,7 @@ def msg_to_yaml(args, msg):
     return yaml.dump(
         msg_to_ordereddict(
             msg,
-            truncate_length=args.truncate_length if args.full_length else None
+            truncate_length=args.truncate_length if not args.full_length else None
         ), width=sys.maxsize)
 
 
@@ -201,7 +201,7 @@ def msg_to_ordereddict(msg, truncate_length=None):
     # We rely on __slots__ retaining the order of the fields in the .msg file.
     for field_name in msg.__slots__:
         value = getattr(msg, field_name, None)
-        value = _convert_value(value)
+        value = _convert_value(value, truncate_length=truncate_length)
         # remove leading underscore from field name
         d[field_name[1:]] = value
     return d


### PR DESCRIPTION
Issue1: ros2 topic echo pointcould2(big arrays), has no response, updated the logical to make more sensible.

    a. (by default) full_length=false, truncate_length=128, then print max 128 (fix big arrays issue)

    b. pass truncate_length=X, then print max X.

    c. pass full_length=true (whatever truncate_length), then set truncate_length=None and print full_length.

Issue2: pass truncate_length to _convert_value(), this should be required.

Signed-off-by: Chris Ye <chris.ye@intel.com>

connect to ros2/ros2cli#127