### PR TITLE
[ros2topic] add missing rclpy dependency

### DIFF
--- a/ros2topic/package.xml
+++ b/ros2topic/package.xml
@@ -12,6 +12,7 @@
   <depend>ros2cli</depend>
 
   <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2msg</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
this package uses `rclpy`  to publish and subscribe