### PR TITLE
Don't truncate dictionary keys

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -229,8 +229,8 @@ def _convert_value(value, truncate_length=None):
         # convert each key and value in the mapping
         new_value = {} if isinstance(value, dict) else OrderedDict()
         for k, v in value.items():
-            new_value[_convert_value(k, truncate_length=truncate_length)] = _convert_value(
-                v, truncate_length=truncate_length)
+            # don't truncate keys because that could result in key collisions and data loss
+            new_value[_convert_value(k)] = _convert_value(v, truncate_length=truncate_length)
         value = new_value
     elif not any(isinstance(value, t) for t in (bool, float, int)):
         # assuming value is a message

--- a/ros2topic/test/test_echo.py
+++ b/ros2topic/test/test_echo.py
@@ -73,7 +73,7 @@ def test_convert_ordered_dict():
         OrderedDict([(1, 'a'), ('2', 'b')]), truncate_length=1)
     assert OrderedDict([(1, 'a'), ('2', 'b')]) == _convert_value(
         OrderedDict([(1, 'a'), ('2', 'b')]), truncate_length=1000)
-    assert OrderedDict([(1, 'a...'), ('2...', 'b...')]) == _convert_value(
+    assert OrderedDict([(1, 'a...'), ('234', 'b...')]) == _convert_value(
         OrderedDict([(1, 'abc'), ('234', 'bcd')]), truncate_length=1)
 
 
@@ -81,5 +81,5 @@ def test_convert_dict():
     assert {1: 'a', '2': 'b'} == _convert_value({1: 'a', '2': 'b'})
     assert {1: 'a', '2': 'b'} == _convert_value({1: 'a', '2': 'b'}, truncate_length=1)
     assert {1: 'a', '2': 'b'} == _convert_value({1: 'a', '2': 'b'}, truncate_length=1000)
-    assert {1: 'a...', '2...': 'b...'} == _convert_value(
+    assert {1: 'a...', '234': 'b...'} == _convert_value(
         {1: 'abc', '234': 'bcd'}, truncate_length=1)


### PR DESCRIPTION
Fixes bug introduced by #135 
https://github.com/ros2/ros2cli/pull/135#discussion_r210660143

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5057)](http://ci.ros2.org/job/ci_linux/5057/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1853)](http://ci.ros2.org/job/ci_linux-aarch64/1853/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4199)](http://ci.ros2.org/job/ci_osx/4199/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5051)](http://ci.ros2.org/job/ci_windows/5051/)