### PR TITLE
[ros2topic] fix pub rate reduced issue

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -101,14 +101,21 @@ def publisher(
 
     print('publisher: beginning loop')
     count = 0
-    while rclpy.ok():
+
+    def timer_callback():
+        nonlocal count
         count += 1
         if print_nth and count % print_nth == 0:
             print('publishing #%d: %r\n' % (count, msg))
         pub.publish(msg)
-        if once:
-            time.sleep(0.1)  # make sure the message reaches the wire before exiting
-            break
-        time.sleep(period)
+
+    timer = node.create_timer(period, timer_callback)
+    if once:
+        rclpy.spin_once(node)
+        time.sleep(0.1)  # make sure the message reaches the wire before exiting
+    else:
+        rclpy.spin(node)
+
+    node.destroy_timer(timer)
     node.destroy_node()
     rclpy.shutdown()


### PR DESCRIPTION
when rate is 1000, time.sleep() in main loop will cost about 150ms every 1s, use time comparison instead of time.sleep(), save sleep cycle time lossing

Signed-off-by: Chris Ye <chris.ye@intel.com>