### PR TITLE
[ros2node] Make `ros2 node list` list namespaces as well as names

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -57,6 +57,8 @@ def main(*, script_name='_ros2_daemon', argv=None):
             server.register_function(
                 _print_invoked_function_name(node.get_node_names))
             server.register_function(
+                _print_invoked_function_name(node.get_node_names_and_namespaces))
+            server.register_function(
                 _print_invoked_function_name(node.get_topic_names_and_types))
             server.register_function(
                 _print_invoked_function_name(node.get_service_names_and_types))

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -26,14 +26,17 @@ def get_node_names(*, node, include_hidden_nodes=False):
             if n and not n.startswith(HIDDEN_NODE_PREFIX)]
     return node_names
 
-def get_node_names_and_namespaces(*, node, include_hidden_nodes=False):
-    node_names_and_ns = node.get_node_names_and_namespaces()
-    if not include_hidden_nodes:
-        node_names_and_ns = [
-            n for n in node_names_and_ns
-            if n[0] and not n[0].startswith(HIDDEN_NODE_PREFIX)]
-    return node_names_and_ns
-
+def get_node_namespaced_names(*, node, include_hidden_nodes=False):
+    node_names_ns = node.get_node_names_and_namespaces()
+    namespaced_nodes = []
+    for (node_name, node_ns) in node_names_ns:
+        if not include_hidden_nodes and node_name.startswith(HIDDEN_NODE_PREFIX):
+            continue
+        if node_ns == '/':
+            namespaced_nodes.append('/' + node_name)
+        else:
+            namespaced_nodes.append(node_ns + '/' + node_name)
+    return namespaced_nodes
 
 class NodeNameCompleter:
     """Callable returning a list of node names."""
@@ -43,7 +46,7 @@ class NodeNameCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         with NodeStrategy(parsed_args) as node:
-            return get_node_names(
+            return get_node_namespaced_names(
                 node=node,
                 include_hidden_nodes=getattr(
                     parsed_args, self.include_hidden_nodes_key))

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -26,6 +26,7 @@ def get_node_names(*, node, include_hidden_nodes=False):
             if n and not n.startswith(HIDDEN_NODE_PREFIX)]
     return node_names
 
+
 def get_node_namespaced_names(*, node, include_hidden_nodes=False):
     node_names_ns = node.get_node_names_and_namespaces()
     namespaced_nodes = []
@@ -37,6 +38,7 @@ def get_node_namespaced_names(*, node, include_hidden_nodes=False):
         else:
             namespaced_nodes.append(node_ns + '/' + node_name)
     return namespaced_nodes
+
 
 class NodeNameCompleter:
     """Callable returning a list of node names."""

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -26,6 +26,14 @@ def get_node_names(*, node, include_hidden_nodes=False):
             if n and not n.startswith(HIDDEN_NODE_PREFIX)]
     return node_names
 
+def get_node_names_and_namespaces(*, node, include_hidden_nodes=False):
+    node_names_and_ns = node.get_node_names_and_namespaces()
+    if not include_hidden_nodes:
+        node_names_and_ns = [
+            n for n in node_names_and_ns
+            if n[0] and not n[0].startswith(HIDDEN_NODE_PREFIX)]
+    return node_names_and_ns
+
 
 class NodeNameCompleter:
     """Callable returning a list of node names."""

--- a/ros2node/ros2node/verb/list.py
+++ b/ros2node/ros2node/verb/list.py
@@ -14,7 +14,7 @@
 
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_node_names_and_namespaces
+from ros2node.api import get_node_namespaced_names
 from ros2node.verb import VerbExtension
 
 
@@ -32,9 +32,9 @@ class ListVerb(VerbExtension):
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
-            node_names_ns = get_node_names_and_namespaces(node=node, include_hidden_nodes=args.all)
+            node_names = get_node_namespaced_names(node=node, include_hidden_nodes=args.all)
 
         if args.count_nodes:
             print(len(node_names))
         elif node_names:
-            print(*[n[1] + '/'+ n[0] for n in node_names_ns], sep='\n')
+            print(*node_names, sep='\n')

--- a/ros2node/ros2node/verb/list.py
+++ b/ros2node/ros2node/verb/list.py
@@ -14,7 +14,7 @@
 
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_node_names
+from ros2node.api import get_node_names_and_namespaces
 from ros2node.verb import VerbExtension
 
 
@@ -32,9 +32,9 @@ class ListVerb(VerbExtension):
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
-            node_names = get_node_names(node=node, include_hidden_nodes=args.all)
+            node_names_ns = get_node_names_and_namespaces(node=node, include_hidden_nodes=args.all)
 
         if args.count_nodes:
             print(len(node_names))
         elif node_names:
-            print(*node_names, sep='\n')
+            print(*[n[1] + '/'+ n[0] for n in node_names_ns], sep='\n')


### PR DESCRIPTION
Fixes #105 

To test:
```
ros2 run demo_nodes_cpp talker __ns:=/demo & 
ros2 run demo_nodes_cpp talker
```

Expected output:
```
➜ ros2 node list
/talker
/demo/talker
```
