### PR TITLE
[ros2param] Make param respect node namespaces

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -57,6 +57,8 @@ def main(*, script_name='_ros2_daemon', argv=None):
             server.register_function(
                 _print_invoked_function_name(node.get_node_names))
             server.register_function(
+                _print_invoked_function_name(node.get_node_names_and_namespaces))
+            server.register_function(
                 _print_invoked_function_name(node.get_topic_names_and_types))
             server.register_function(
                 _print_invoked_function_name(node.get_service_names_and_types))

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -26,14 +26,17 @@ def get_node_names(*, node, include_hidden_nodes=False):
             if n and not n.startswith(HIDDEN_NODE_PREFIX)]
     return node_names
 
-def get_node_names_and_namespaces(*, node, include_hidden_nodes=False):
-    node_names_and_ns = node.get_node_names_and_namespaces()
-    if not include_hidden_nodes:
-        node_names_and_ns = [
-            n for n in node_names_and_ns
-            if n[0] and not n[0].startswith(HIDDEN_NODE_PREFIX)]
-    return node_names_and_ns
-
+def get_node_namespaced_names(*, node, include_hidden_nodes=False):
+    node_names_ns = node.get_node_names_and_namespaces()
+    namespaced_nodes = []
+    for (node_name, node_ns) in node_names_ns:
+        if not include_hidden_nodes and node_name.startswith(HIDDEN_NODE_PREFIX):
+            continue
+        if node_ns == '/':
+            namespaced_nodes.append('/' + node_name)
+        else:
+            namespaced_nodes.append(node_ns + '/' + node_name)
+    return namespaced_nodes
 
 class NodeNameCompleter:
     """Callable returning a list of node names."""
@@ -43,7 +46,7 @@ class NodeNameCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         with NodeStrategy(parsed_args) as node:
-            return get_node_names(
+            return get_node_namespaced_names(
                 node=node,
                 include_hidden_nodes=getattr(
                     parsed_args, self.include_hidden_nodes_key))

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -26,6 +26,7 @@ def get_node_names(*, node, include_hidden_nodes=False):
             if n and not n.startswith(HIDDEN_NODE_PREFIX)]
     return node_names
 
+
 def get_node_namespaced_names(*, node, include_hidden_nodes=False):
     node_names_ns = node.get_node_names_and_namespaces()
     namespaced_nodes = []
@@ -37,6 +38,7 @@ def get_node_namespaced_names(*, node, include_hidden_nodes=False):
         else:
             namespaced_nodes.append(node_ns + '/' + node_name)
     return namespaced_nodes
+
 
 class NodeNameCompleter:
     """Callable returning a list of node names."""

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -26,6 +26,14 @@ def get_node_names(*, node, include_hidden_nodes=False):
             if n and not n.startswith(HIDDEN_NODE_PREFIX)]
     return node_names
 
+def get_node_names_and_namespaces(*, node, include_hidden_nodes=False):
+    node_names_and_ns = node.get_node_names_and_namespaces()
+    if not include_hidden_nodes:
+        node_names_and_ns = [
+            n for n in node_names_and_ns
+            if n[0] and not n[0].startswith(HIDDEN_NODE_PREFIX)]
+    return node_names_and_ns
+
 
 class NodeNameCompleter:
     """Callable returning a list of node names."""

--- a/ros2node/ros2node/verb/list.py
+++ b/ros2node/ros2node/verb/list.py
@@ -14,7 +14,7 @@
 
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_node_names_and_namespaces
+from ros2node.api import get_node_namespaced_names
 from ros2node.verb import VerbExtension
 
 
@@ -32,9 +32,9 @@ class ListVerb(VerbExtension):
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
-            node_names_ns = get_node_names_and_namespaces(node=node, include_hidden_nodes=args.all)
+            node_names = get_node_namespaced_names(node=node, include_hidden_nodes=args.all)
 
         if args.count_nodes:
             print(len(node_names))
         elif node_names:
-            print(*[n[1] + '/'+ n[0] for n in node_names_ns], sep='\n')
+            print(*node_names, sep='\n')

--- a/ros2node/ros2node/verb/list.py
+++ b/ros2node/ros2node/verb/list.py
@@ -14,7 +14,7 @@
 
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_node_names
+from ros2node.api import get_node_names_and_namespaces
 from ros2node.verb import VerbExtension
 
 
@@ -32,9 +32,9 @@ class ListVerb(VerbExtension):
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
-            node_names = get_node_names(node=node, include_hidden_nodes=args.all)
+            node_names_ns = get_node_names_and_namespaces(node=node, include_hidden_nodes=args.all)
 
         if args.count_nodes:
             print(len(node_names))
         elif node_names:
-            print(*node_names, sep='\n')
+            print(*[n[1] + '/'+ n[0] for n in node_names_ns], sep='\n')

--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -57,7 +57,7 @@ def call_get_parameters(*, node, node_name, parameter_names):
     # create client
     client = node.create_client(
         GetParameters,
-        '/{node_name}/get_parameters'.format_map(locals()))
+        '{node_name}/get_parameters'.format_map(locals()))
 
     # call as soon as ready
     ready = client.wait_for_service(timeout_sec=5.0)
@@ -83,7 +83,7 @@ def call_set_parameters(*, node, node_name, parameters):
     # create client
     client = node.create_client(
         SetParameters,
-        '/{node_name}/set_parameters'.format_map(locals()))
+        '{node_name}/set_parameters'.format_map(locals()))
 
     # call as soon as ready
     ready = client.wait_for_service(timeout_sec=5.0)

--- a/ros2param/ros2param/verb/delete.py
+++ b/ros2param/ros2param/verb/delete.py
@@ -20,7 +20,7 @@ from rcl_interfaces.msg import ParameterValue
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_node_names
+from ros2node.api import get_node_namespaced_names
 from ros2node.api import NodeNameCompleter
 from ros2param.api import call_set_parameters
 from ros2param.verb import VerbExtension
@@ -43,9 +43,11 @@ class DeleteVerb(VerbExtension):
 
     def main(self, *, args):  # noqa: D102
         with NodeStrategy(args) as node:
-            node_names = get_node_names(
+            node_names = get_node_namespaced_names(
                 node=node, include_hidden_nodes=args.include_hidden_nodes)
 
+        if not args.node_name.startswith('/'):
+            args.node_name = '/' + args.node_name
         if args.node_name not in node_names:
             return 'Node not found'
 

--- a/ros2param/ros2param/verb/get.py
+++ b/ros2param/ros2param/verb/get.py
@@ -16,7 +16,7 @@ from rcl_interfaces.msg import ParameterType
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_node_names
+from ros2node.api import get_node_namespaced_names
 from ros2node.api import NodeNameCompleter
 from ros2param.api import call_get_parameters
 from ros2param.verb import VerbExtension
@@ -42,9 +42,11 @@ class GetVerb(VerbExtension):
 
     def main(self, *, args):  # noqa: D102
         with NodeStrategy(args) as node:
-            node_names = get_node_names(
+            node_names = get_node_namespaced_names(
                 node=node, include_hidden_nodes=args.include_hidden_nodes)
 
+        if not args.node_name.startswith('/'):
+            args.node_name = '/' + args.node_name
         if args.node_name not in node_names:
             return 'Node not found'
 

--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -19,7 +19,7 @@ import rclpy
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_node_names
+from ros2node.api import get_node_namespaced_names
 from ros2node.api import NodeNameCompleter
 from ros2param.verb import VerbExtension
 
@@ -42,10 +42,12 @@ class ListVerb(VerbExtension):
 
     def main(self, *, args):  # noqa: D102
         with NodeStrategy(args) as node:
-            node_names = get_node_names(
+            node_names = get_node_namespaced_names(
                 node=node, include_hidden_nodes=args.include_hidden_nodes)
 
         if args.node_name:
+            if not args.node_name.startswith('/'):
+                args.node_name = '/' + args.node_name
             if args.node_name not in node_names:
                 return 'Node not found'
             node_names = [args.node_name]
@@ -57,7 +59,7 @@ class ListVerb(VerbExtension):
             for node_name in node_names:
                 client = node.create_client(
                     ListParameters,
-                    '/{node_name}/list_parameters'.format_map(locals()))
+                    '{node_name}/list_parameters'.format_map(locals()))
                 clients[node_name] = client
 
             # wait until all clients have been called

--- a/ros2param/ros2param/verb/set.py
+++ b/ros2param/ros2param/verb/set.py
@@ -18,7 +18,7 @@ from rcl_interfaces.msg import Parameter
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_node_names
+from ros2node.api import get_node_namespaced_names
 from ros2node.api import NodeNameCompleter
 from ros2param.api import call_set_parameters
 from ros2param.api import get_parameter_value
@@ -44,9 +44,11 @@ class SetVerb(VerbExtension):
 
     def main(self, *, args):  # noqa: D102
         with NodeStrategy(args) as node:
-            node_names = get_node_names(
+            node_names = get_node_namespaced_names(
                 node=node, include_hidden_nodes=args.include_hidden_nodes)
 
+        if not args.node_name.startswith('/'):
+            args.node_name = '/' + args.node_name
         if args.node_name not in node_names:
             return 'Node not found'
 


### PR DESCRIPTION
Fixes #128 

To test:
In one terminal:
```
ros2 run demo_nodes_cpp talker __ns:=/demo & 
ros2 run demo_nodes_cpp talker
```

In another terminal:
```
➜  ~ ros2 node list
/talker
/demo/talker
➜  ~ ros2 param list
/demo/talker:
/talker:
➜  ~ ros2 param set talker foo true
Set parameter successful
➜  ~ ros2 param set demo/talker foo2 true
Set parameter successful
➜  ~ ros2 param set /demo/talker foo3 true
Set parameter successful
➜  ~ ros2 param set /talker foo4 true 
Set parameter successful
➜  ~ ros2 param list
/demo/talker:
  foo2
  foo3
/talker:
  foo
  foo4
➜  ~ ros2 param list demo/talker
  foo2
  foo3
➜  ~ ros2 param list talker     
  foo
  foo4
➜  ~ ros2 param list /talker
  foo
  foo4
➜  ~ ros2 param get demo/talker foo2
Boolean value is: True
➜  ~ ros2 param delete talker foo
Deleted parameter successfully
➜  ~ ros2 param list
/demo/talker:
  foo2
  foo3
/talker:
  foo4
```