### PR TITLE
Ignore folder in rosidl_interfaces to fix CI

### DIFF
--- a/ros2msg/ros2msg/api/__init__.py
+++ b/ros2msg/ros2msg/api/__init__.py
@@ -43,8 +43,6 @@ def get_message_types(package_name):
 
 def get_message_path(package_name, message_name):
     message_types = get_message_types(package_name)
-    import sys
-    sys.stderr.write('Message types ' + repr(message_types) + '\n')
     if message_name not in message_types:
         raise LookupError('Unknown message name')
     prefix_path = has_resource('packages', package_name)

--- a/ros2msg/ros2msg/api/__init__.py
+++ b/ros2msg/ros2msg/api/__init__.py
@@ -37,11 +37,14 @@ def get_message_types(package_name):
         return []
     interface_names = content.splitlines()
     # TODO(dirk-thomas) this logic should come from a rosidl related package
-    return [n[:-4] for n in interface_names if n.endswith('.msg')]
+    # Only return messages in msg folder
+    return [n[4:-4] for n in interface_names if n.startswith('msg/') and n.endswith('.msg')]
 
 
 def get_message_path(package_name, message_name):
     message_types = get_message_types(package_name)
+    import sys
+    sys.stderr.write('Message types ' + repr(message_types) + '\n')
     if message_name not in message_types:
         raise LookupError('Unknown message name')
     prefix_path = has_resource('packages', package_name)

--- a/ros2srv/ros2srv/api/__init__.py
+++ b/ros2srv/ros2srv/api/__init__.py
@@ -37,7 +37,8 @@ def get_service_types(package_name):
         return []
     interface_names = content.splitlines()
     # TODO(dirk-thomas) this logic should come from a rosidl related package
-    return [n[:-4] for n in interface_names if n.endswith('.srv')]
+    # Only return services in srv folder
+    return [n[4:-4] for n in interface_names if n.startswith('srv/') and n.endswith('.srv')]
 
 
 def get_service_path(package_name, service_name):


### PR DESCRIPTION
ros2/rosidl#308 added the folder a message or service lives in to the ament resource named to `rosidl_interfaces`. This broke tests for ros2msg and ros2srv. This PR fixes those tests by stripping the folder from the interface names.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5422)](http://ci.ros2.org/job/ci_linux/5422/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2129)](http://ci.ros2.org/job/ci_linux-aarch64/2129/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4496)](http://ci.ros2.org/job/ci_osx/4496/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5363)](http://ci.ros2.org/job/ci_windows/5363/)