### PR TITLE
Block literal printing for std_msgs.msg.String

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -25,6 +25,7 @@ from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
+from std_msgs.msg import String
 import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
@@ -140,7 +141,17 @@ def subscriber(node, topic_name, message_type, callback):
 def subscriber_cb(args):
     def cb(msg):
         nonlocal args
-        print(msg_to_yaml(args, msg))
+        if (type(msg) == String):
+            # emulate block literal yaml format, but accept unicode
+            # chars that yaml does not yet
+            if len(msg.data.splitlines()) > 1:
+                print("data: |-" )
+                for line in msg.data.splitlines():
+                    print("  {}".format(line))
+            else:
+                print("data: {}".format(msg.data))
+        else:
+            print(msg_to_yaml(args, msg))
     return cb
 
 


### PR DESCRIPTION
**Tentative!**

I really don't like this hack and would like to trigger a discussion (hopefully the ugliness will encourage that!).

**Goal**

Enable `ros2cli topic echo /chatter` to format the string messages that are sent across the nether so that we can have easy-to-read informative latched publishers that help describe / introspect the system at runtime. Currently the strings are completely unformatted (in particular, newlines and console sequences for colouring would be handy). 

**Background**

ROS1 could do this and it was very useful. It didn't take advantage of `yaml.dump` though, so no assistance there.

**Problems**

As mentioned in #154, we could use a customs str representer that sets an appropriate block literal style, but yaml will override our override in certain situations. So, as a last resort, the patch here would be the minimal that will at least enable formatting for strings in `std_msgs.msg.String` (as opposed to any embedded string) by avoiding any entanglement with yaml altogether.

**Considerations**

* Effort upstream to get things fixed in yaml, that's not going to help in the short term though
* Could alternatively use the representers as demonstrated in #154 and monkeypatch the yaml `Emitter` class here as a temporary fix (dangerous, since the Emitter class could change without our knowing)
* If anything temporary is done, make sure to have comments directing people to the golden path when it is available.
* Other?



