### PR TITLE
Consistent node naming

### DIFF
--- a/ros2cli/ros2cli/node/__init__.py
+++ b/ros2cli/ros2cli/node/__init__.py
@@ -1,2 +1,16 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# TODO(mikaelarguedas) revisit this once it's specified
 HIDDEN_NODE_PREFIX = '_'
 CLI_NODE_NAME_PREFIX = 'ros2cli_node'

--- a/ros2cli/ros2cli/node/__init__.py
+++ b/ros2cli/ros2cli/node/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 # TODO(mikaelarguedas) revisit this once it's specified
 HIDDEN_NODE_PREFIX = '_'
-CLI_NODE_NAME_PREFIX = 'ros2cli_node'
+CLI_NODE_NAME_PREFIX = HIDDEN_NODE_PREFIX + 'ros2cli_node'

--- a/ros2cli/ros2cli/node/__init__.py
+++ b/ros2cli/ros2cli/node/__init__.py
@@ -1,0 +1,2 @@
+HIDDEN_NODE_PREFIX = '_'
+CLI_NODE_NAME_PREFIX = 'ros2cli_node'

--- a/ros2cli/ros2cli/node/__init__.py
+++ b/ros2cli/ros2cli/node/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 # TODO(mikaelarguedas) revisit this once it's specified
 HIDDEN_NODE_PREFIX = '_'
-CLI_NODE_NAME_PREFIX = HIDDEN_NODE_PREFIX + 'ros2cli_node'
+CLI_NODE_NAME_PREFIX = HIDDEN_NODE_PREFIX + 'ros2cli'

--- a/ros2cli/ros2cli/node/__init__.py
+++ b/ros2cli/ros2cli/node/__init__.py
@@ -11,6 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# TODO(mikaelarguedas) revisit this once it's specified
-HIDDEN_NODE_PREFIX = '_'
-CLI_NODE_NAME_PREFIX = HIDDEN_NODE_PREFIX + 'ros2cli'
+from rclpy.node import HIDDEN_NODE_PREFIX
+NODE_NAME_PREFIX = HIDDEN_NODE_PREFIX + 'ros2cli'

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -16,9 +16,9 @@ import os
 
 import rclpy
 
-# TODO(mikaelarguedas) revisit this once it's specified
-HIDDEN_NODE_PREFIX = '_'
-
+#HIDDEN_NODE_PREFIX = '_'
+#from ros2node.api import HIDDEN_NODE_PREFIX
+from ros2cli.node import HIDDEN_NODE_PREFIX, CLI_NODE_NAME_PREFIX
 DEFAULT_TIMEOUT = 0.5
 
 
@@ -35,7 +35,8 @@ class DirectNode:
 
         node_name_suffix = getattr(
             args, 'node_name_suffix', '_%d' % os.getpid())
-        self.node = rclpy.create_node(HIDDEN_NODE_PREFIX + 'ros2cli_node' + node_name_suffix)
+        node_name_prefix = HIDDEN_NODE_PREFIX + CLI_NODE_NAME_PREFIX
+        self.node = rclpy.create_node(node_name_prefix + node_name_suffix)
         timeout = getattr(args, 'spin_time', DEFAULT_TIMEOUT)
         timer = self.node.create_timer(timeout, timer_callback)
 

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -16,7 +16,7 @@ import os
 
 import rclpy
 
-from ros2cli.node import CLI_NODE_NAME_PREFIX
+from ros2cli.node import NODE_NAME_PREFIX
 DEFAULT_TIMEOUT = 0.5
 
 
@@ -33,7 +33,7 @@ class DirectNode:
 
         node_name_suffix = getattr(
             args, 'node_name_suffix', '_%d' % os.getpid())
-        self.node = rclpy.create_node(CLI_NODE_NAME_PREFIX + node_name_suffix)
+        self.node = rclpy.create_node(NODE_NAME_PREFIX + node_name_suffix)
         timeout = getattr(args, 'spin_time', DEFAULT_TIMEOUT)
         timer = self.node.create_timer(timeout, timer_callback)
 

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -16,8 +16,6 @@ import os
 
 import rclpy
 
-#HIDDEN_NODE_PREFIX = '_'
-#from ros2node.api import HIDDEN_NODE_PREFIX
 from ros2cli.node import HIDDEN_NODE_PREFIX, CLI_NODE_NAME_PREFIX
 DEFAULT_TIMEOUT = 0.5
 

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -16,7 +16,7 @@ import os
 
 import rclpy
 
-from ros2cli.node import HIDDEN_NODE_PREFIX, CLI_NODE_NAME_PREFIX
+from ros2cli.node import CLI_NODE_NAME_PREFIX
 DEFAULT_TIMEOUT = 0.5
 
 
@@ -33,8 +33,7 @@ class DirectNode:
 
         node_name_suffix = getattr(
             args, 'node_name_suffix', '_%d' % os.getpid())
-        node_name_prefix = HIDDEN_NODE_PREFIX + CLI_NODE_NAME_PREFIX
-        self.node = rclpy.create_node(node_name_prefix + node_name_suffix)
+        self.node = rclpy.create_node(CLI_NODE_NAME_PREFIX + node_name_suffix)
         timeout = getattr(args, 'spin_time', DEFAULT_TIMEOUT)
         timer = self.node.create_timer(timeout, timer_callback)
 

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -15,9 +15,7 @@
 from collections import namedtuple
 
 from ros2cli.node.strategy import NodeStrategy
-
-# TODO(mikaelarguedas) revisit this once it's specified
-HIDDEN_NODE_PREFIX = '_'
+from ros2cli.node import HIDDEN_NODE_PREFIX
 
 NodeName = namedtuple('NodeName', ('name', 'namespace', 'full_name'))
 TopicInfo = namedtuple('Topic', ('name', 'types'))

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -14,8 +14,8 @@
 
 from collections import namedtuple
 
-from ros2cli.node.strategy import NodeStrategy
 from rclpy.node import HIDDEN_NODE_PREFIX
+from ros2cli.node.strategy import NodeStrategy
 
 NodeName = namedtuple('NodeName', ('name', 'namespace', 'full_name'))
 TopicInfo = namedtuple('Topic', ('name', 'types'))

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -15,7 +15,7 @@
 from collections import namedtuple
 
 from ros2cli.node.strategy import NodeStrategy
-from ros2cli.node import HIDDEN_NODE_PREFIX
+from rclpy.node import HIDDEN_NODE_PREFIX
 
 NodeName = namedtuple('NodeName', ('name', 'namespace', 'full_name'))
 TopicInfo = namedtuple('Topic', ('name', 'types'))

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -21,7 +21,7 @@ from ros2service.api import ServiceTypeCompleter
 from ros2service.verb import VerbExtension
 from ros2topic.api import set_msg_fields
 from ros2topic.api import SetFieldError
-from ros2cli.node import CLI_NODE_NAME_PREFIX
+from ros2cli.node import NODE_NAME_PREFIX
 import yaml
 
 
@@ -77,7 +77,7 @@ def requester(service_type, service_name, values, period):
 
     rclpy.init()
 
-    node = rclpy.create_node(CLI_NODE_NAME_PREFIX + '_requester_%s_%s' % (package_name, srv_name))
+    node = rclpy.create_node(NODE_NAME_PREFIX + '_requester_%s_%s' % (package_name, srv_name))
 
     cli = node.create_client(srv_module, service_name)
 

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -16,12 +16,12 @@ import importlib
 import time
 
 import rclpy
+from ros2cli.node import NODE_NAME_PREFIX
 from ros2service.api import ServiceNameCompleter
 from ros2service.api import ServiceTypeCompleter
 from ros2service.verb import VerbExtension
 from ros2topic.api import set_msg_fields
 from ros2topic.api import SetFieldError
-from ros2cli.node import NODE_NAME_PREFIX
 import yaml
 
 

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -21,6 +21,7 @@ from ros2service.api import ServiceTypeCompleter
 from ros2service.verb import VerbExtension
 from ros2topic.api import set_msg_fields
 from ros2topic.api import SetFieldError
+from ros2cli.node import CLI_NODE_NAME_PREFIX
 import yaml
 
 
@@ -76,7 +77,7 @@ def requester(service_type, service_name, values, period):
 
     rclpy.init()
 
-    node = rclpy.create_node('requester_%s_%s' % (package_name, srv_name))
+    node = rclpy.create_node(CLI_NODE_NAME_PREFIX + '_requester_%s_%s' % (package_name, srv_name))
 
     cli = node.create_client(srv_module, service_name)
 

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -15,13 +15,13 @@
 import time
 
 import rclpy
+from ros2cli.node import NODE_NAME_PREFIX
 from ros2topic.api import import_message_type
 from ros2topic.api import set_msg_fields
 from ros2topic.api import SetFieldError
 from ros2topic.api import TopicNameCompleter
 from ros2topic.api import TopicTypeCompleter
 from ros2topic.verb import VerbExtension
-from ros2cli.node import NODE_NAME_PREFIX
 import yaml
 
 

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -21,6 +21,7 @@ from ros2topic.api import SetFieldError
 from ros2topic.api import TopicNameCompleter
 from ros2topic.api import TopicTypeCompleter
 from ros2topic.verb import VerbExtension
+from ros2cli.node import CLI_NODE_NAME_PREFIX
 import yaml
 
 
@@ -77,7 +78,7 @@ def publisher(
     if not isinstance(values_dictionary, dict):
         return 'The passed value needs to be a dictionary in YAML format'
     if not node_name:
-        node_name = 'publisher_%s' % (message_type.replace('/', '_'),)
+        node_name = CLI_NODE_NAME_PREFIX + '_publisher_%s' % (message_type.replace('/', '_'), )
     rclpy.init()
 
     node = rclpy.create_node(node_name)

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -21,7 +21,7 @@ from ros2topic.api import SetFieldError
 from ros2topic.api import TopicNameCompleter
 from ros2topic.api import TopicTypeCompleter
 from ros2topic.verb import VerbExtension
-from ros2cli.node import CLI_NODE_NAME_PREFIX
+from ros2cli.node import NODE_NAME_PREFIX
 import yaml
 
 
@@ -78,7 +78,7 @@ def publisher(
     if not isinstance(values_dictionary, dict):
         return 'The passed value needs to be a dictionary in YAML format'
     if not node_name:
-        node_name = CLI_NODE_NAME_PREFIX + '_publisher_%s' % (message_type.replace('/', '_'), )
+        node_name = NODE_NAME_PREFIX + '_publisher_%s' % (message_type.replace('/', '_'), )
     rclpy.init()
 
     node = rclpy.create_node(node_name)


### PR DESCRIPTION
### Summary ###
This is part of the improvements suggested [here](https://discourse.ros.org/t/ros2-security-cli-tools/6647/) mainly intended for CLI tools' usability with security.
* All ros2cli nodes will start with prefix `ros2cli_node`. 

#### Related changes ####
* https://github.com/ros2/rcl/pull/332
* https://github.com/ros2/rosbag2/pull/60

#### Refer to ####
https://discourse.ros.org/t/ros2-security-cli-tools/6647/
https://github.com/ros2/sros2/issues/69