### PR TITLE
Add ros2 node info verb

### DIFF
--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -20,7 +20,19 @@ from ros2cli.node.strategy import NodeStrategy
 HIDDEN_NODE_PREFIX = '_'
 
 NodeName = namedtuple('NodeName', ('name', 'namespace', 'full_name'))
+TopicInfo = namedtuple('Topic', ('name', 'types'))
 
+
+def parse_node_name(full_node_name):
+    tokens = full_node_name.split("/");
+    if 1 > len(tokens):
+        raise Exception("Invalid node name")
+    node_name = full_node_name
+    namespace = "/"
+    if len(tokens) > 1:
+        node_name = tokens[-1]
+        namespace = "/".join(tokens[:-1])
+    return NodeName(node_name, namespace, full_node_name)
 
 def get_node_names(*, node, include_hidden_nodes=False):
     node_names_and_namespaces = node.get_node_names_and_namespaces()
@@ -36,6 +48,23 @@ def get_node_names(*, node, include_hidden_nodes=False):
         )
     ]
 
+def get_topics(remote_node_name, func):
+    node = parse_node_name(remote_node_name)
+    names_and_types = func(node.name, node.namespace)
+    return [
+        TopicInfo(
+            name=t[0],
+            types=t[1])
+        for t in names_and_types]
+
+def get_subscriber_info(*, node, remote_node_name):
+    return get_topics(remote_node_name, node.get_subscriber_names_and_types_by_node)
+
+def get_publisher_info(*, node, remote_node_name):
+    return get_topics(remote_node_name, node.get_publisher_names_and_types_by_node)
+
+def get_service_info(*, node, remote_node_name):
+    return get_topics(remote_node_name, node.get_service_names_and_types_by_node)
 
 class NodeNameCompleter:
     """Callable returning a list of node names."""

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -24,15 +24,16 @@ TopicInfo = namedtuple('Topic', ('name', 'types'))
 
 
 def parse_node_name(full_node_name):
-    tokens = full_node_name.split("/");
+    tokens = full_node_name.split('/')
     if 1 > len(tokens):
-        raise Exception("Invalid node name")
+        raise Exception('Invalid node name')
     node_name = full_node_name
-    namespace = "/"
+    namespace = '/'
     if len(tokens) > 1:
         node_name = tokens[-1]
-        namespace = "/".join(tokens[:-1])
+        namespace = '/'.join(tokens[:-1])
     return NodeName(node_name, namespace, full_node_name)
+
 
 def get_node_names(*, node, include_hidden_nodes=False):
     node_names_and_namespaces = node.get_node_names_and_namespaces()
@@ -48,6 +49,7 @@ def get_node_names(*, node, include_hidden_nodes=False):
         )
     ]
 
+
 def get_topics(remote_node_name, func):
     node = parse_node_name(remote_node_name)
     names_and_types = func(node.name, node.namespace)
@@ -57,14 +59,18 @@ def get_topics(remote_node_name, func):
             types=t[1])
         for t in names_and_types]
 
+
 def get_subscriber_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_subscriber_names_and_types_by_node)
+
 
 def get_publisher_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_publisher_names_and_types_by_node)
 
+
 def get_service_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_service_names_and_types_by_node)
+
 
 class NodeNameCompleter:
     """Callable returning a list of node names."""

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -26,7 +26,7 @@ TopicInfo = namedtuple('Topic', ('name', 'types'))
 def parse_node_name(full_node_name):
     tokens = full_node_name.split('/')
     if 1 > len(tokens):
-        raise Exception('Invalid node name')
+        raise RuntimeError('Invalid node name: ' + full_node_name)
     node_name = full_node_name
     namespace = '/'
     if len(tokens) > 1:

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -54,4 +54,4 @@ class InfoVerb(VerbExtension):
             print('All nodes found:')
             print(*[n.full_name for n in node_names], sep=', ')
             print('Unable to find node ' + args.node_name)
-            return
+            return 'Unable to find node'

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2node.api import get_node_names
-from ros2node.api import get_subscriber_info
 from ros2node.api import get_publisher_info
 from ros2node.api import get_service_info
-from ros2cli.node.direct import DirectNode
+from ros2node.api import get_subscriber_info
 from ros2node.verb import VerbExtension
 
 
 def print_names_and_types(names_and_types):
-    print(*[2*'  ' + s.name + ': ' + ', '.join(s.types) for s in names_and_types], sep='\n')
+    print(*[2 * '  ' + s.name + ': ' + ', '.join(s.types) for s in names_and_types], sep='\n')
 
 
 class InfoVerb(VerbExtension):
@@ -51,7 +51,7 @@ class InfoVerb(VerbExtension):
                 print('  Services:')
                 print_names_and_types(services)
         else:
-            print("All nodes found:")
-            print(*[n.full_name for n in node_names],  sep=', ')
-            print("Unable to find node " + args.node_name)
+            print('All nodes found:')
+            print(*[n.full_name for n in node_names], sep=', ')
+            print('Unable to find node ' + args.node_name)
             return

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -51,7 +51,4 @@ class InfoVerb(VerbExtension):
                 print('  Services:')
                 print_names_and_types(services)
         else:
-            print('All nodes found:')
-            print(*[n.full_name for n in node_names], sep=', ')
-            print('Unable to find node ' + args.node_name)
-            return 'Unable to find node'
+            return "Unable to find node '" + args.node_name + "'"

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -1,5 +1,4 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -1,0 +1,58 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2cli.node.strategy import add_arguments
+from ros2cli.node.strategy import NodeStrategy
+from ros2node.api import get_node_names
+from ros2node.api import get_subscriber_info
+from ros2node.api import get_publisher_info
+from ros2node.api import get_service_info
+from ros2cli.node.direct import DirectNode
+from ros2node.verb import VerbExtension
+
+
+def print_names_and_types(names_and_types):
+    print(*[2*'  ' + s.name + ': ' + ', '.join(s.types) for s in names_and_types], sep='\n')
+
+
+class InfoVerb(VerbExtension):
+    """Output a list of available nodes."""
+
+    def add_arguments(self, parser, cli_name):
+        add_arguments(parser)
+        parser.add_argument(
+            'node_name',
+            help='Node name to request information')
+
+    def main(self, *, args):
+        with NodeStrategy(args) as node:
+            node_names = get_node_names(node=node, include_hidden_nodes=True)
+        if args.node_name in [n.full_name for n in node_names]:
+            with DirectNode(args) as node:
+                print(args.node_name)
+                subscribers = get_subscriber_info(node=node, remote_node_name=args.node_name[1:])
+                print('  Subscribers:')
+                print_names_and_types(subscribers)
+                publishers = get_publisher_info(node=node, remote_node_name=args.node_name[1:])
+                print('  Publishers:')
+                print_names_and_types(publishers)
+                services = get_service_info(node=node, remote_node_name=args.node_name[1:])
+                print('  Services:')
+                print_names_and_types(services)
+        else:
+            print("All nodes found:")
+            print(*[n.full_name for n in node_names],  sep=', ')
+            print("Unable to find node " + args.node_name)
+            return

--- a/ros2node/setup.py
+++ b/ros2node/setup.py
@@ -34,6 +34,7 @@ The package provides the node command for the ROS 2 command line tools.""",
         ],
         'ros2node.verb': [
             'list = ros2node.verb.list:ListVerb',
+            'info = ros2node.verb.info:InfoVerb',
         ],
     }
 )


### PR DESCRIPTION
*Summary:* Provide the info verb under the node command

`ros2 node info /minimal_publisher`

Example:
```
/minimal_publisher
  Subscribers:
    /parameter_events: rcl_interfaces/ParameterEvent
  Publishers:
    /parameter_events: rcl_interfaces/ParameterEvent
    /topic: std_msgs/String
  Services:
    /minimal_publisher/describe_parameters: rcl_interfaces/DescribeParameters
    /minimal_publisher/get_parameter_types: rcl_interfaces/GetParameterTypes
    /minimal_publisher/get_parameters: rcl_interfaces/GetParameters
    /minimal_publisher/list_parameters: rcl_interfaces/ListParameters
    /minimal_publisher/set_parameters: rcl_interfaces/SetParameters
    /minimal_publisher/set_parameters_atomically: rcl_interfaces/SetParametersAtomically
```

Connects to ros2/rcl#333