### PR TITLE
Fix ros2 topic echo, delay, hz with hidden topics + fix for action feedback topic

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -101,14 +101,14 @@ def set_msg_fields(msg, values):
             raise SetFieldError(field_name, e)
 
 
-def get_msg_class(node, topic, blocking=False):
-    msg_class = _get_msg_class(node, topic)
+def get_msg_class(node, topic, blocking=False, include_hidden_topics=False):
+    msg_class = _get_msg_class(node, topic, include_hidden_topics)
     if msg_class:
         return msg_class
     elif blocking:
         print('WARNING: topic [%s] does not appear to be published yet' % topic)
         while rclpy.ok():
-            msg_class = _get_msg_class(node, topic)
+            msg_class = _get_msg_class(node, topic, include_hidden_topics)
             if msg_class:
                 return msg_class
             else:
@@ -118,13 +118,14 @@ def get_msg_class(node, topic, blocking=False):
     return None
 
 
-def _get_msg_class(node, topic):
+def _get_msg_class(node, topic, include_hidden_topics):
     """
     Get message module based on topic name.
 
     :param topic: topic name, ``list`` of ``str``
     """
-    topic_names_and_types = get_topic_names_and_types(node=node)
+    topic_names_and_types = get_topic_names_and_types(
+        node=node, include_hidden_topics=include_hidden_topics)
     try:
         expanded_name = expand_topic_name(topic, node.get_name(), node.get_namespace())
     except ValueError as e:

--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -78,7 +78,8 @@ class DelayVerb(VerbExtension):
 
 def main(args):
     with DirectNode(args) as node:
-        _rostopic_delay(node.node, args.topic, window_size=args.window)
+        _rostopic_delay(
+            node.node, args.topic, window_size=args.window)
 
 
 class ROSTopicDelay(object):
@@ -175,7 +176,7 @@ def _rostopic_delay(node, topic, window_size=DEFAULT_WINDOW_SIZE):
     :param blocking: pause delay until topic is published, ``bool``
     """
     # pause hz until topic is published
-    msg_class = get_msg_class(node, topic, blocking=True)
+    msg_class = get_msg_class(node, topic, blocking=True, include_hidden_topics=True)
 
     if msg_class is None:
         node.destroy_node()

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -77,7 +77,8 @@ def main(args):
     else:
         callback = subscriber_cb_csv(args)
     with DirectNode(args) as node:
-        subscriber(node.node, args.topic_name, args.message_type, callback)
+        subscriber(
+            node.node, args.topic_name, args.message_type, callback)
 
 
 def register_yaml_representer():
@@ -98,7 +99,7 @@ def represent_ordereddict(dumper, data):
 
 def subscriber(node, topic_name, message_type, callback):
     if message_type is None:
-        topic_names_and_types = get_topic_names_and_types(node=node)
+        topic_names_and_types = get_topic_names_and_types(node=node, include_hidden_topics=True)
         try:
             expanded_name = expand_topic_name(topic_name, node.get_name(), node.get_namespace())
         except ValueError as e:

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -14,7 +14,6 @@
 
 from argparse import ArgumentTypeError
 from collections import OrderedDict
-import importlib
 import sys
 
 import rclpy
@@ -23,6 +22,7 @@ from rclpy.qos import qos_profile_sensor_data
 from rclpy.validate_full_topic_name import validate_full_topic_name
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
+from ros2topic.api import import_message_type
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 import yaml
@@ -121,15 +121,7 @@ def subscriber(node, topic_name, message_type, callback):
             raise RuntimeError(
                 'Could not determine the type for the passed topic')
 
-    # TODO(dirk-thomas) this logic should come from a rosidl related package
-    try:
-        package_name, message_name = message_type.split('/', 2)
-        if not package_name or not message_name:
-            raise ValueError()
-    except ValueError:
-        raise RuntimeError('The passed message type is invalid')
-    module = importlib.import_module(package_name + '.msg')
-    msg_module = getattr(module, message_name)
+    msg_module = import_message_type(topic_name, message_type)
 
     node.create_subscription(
         msg_module, topic_name, callback, qos_profile=qos_profile_sensor_data)

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -257,7 +257,8 @@ def _rostopic_hz(node, topic, window_size=DEFAULT_WINDOW_SIZE, filter_expr=None,
     :param filter_expr: Python filter expression that is called with m, the message instance
     """
     # pause hz until topic is published
-    msg_class = get_msg_class(node, topic, blocking=True)
+    msg_class = get_msg_class(
+        node, topic, blocking=True, include_hidden_topics=True)
 
     if msg_class is None:
         node.destroy_node()

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
 import time
 
 import rclpy
+from ros2topic.api import import_message_type
 from ros2topic.api import set_msg_fields
 from ros2topic.api import SetFieldError
 from ros2topic.api import TopicNameCompleter
@@ -72,20 +72,12 @@ def main(args):
 def publisher(
     message_type, topic_name, values, node_name, period, print_nth, once
 ):
-    # TODO(dirk-thomas) this logic should come from a rosidl related package
-    try:
-        package_name, message_name = message_type.split('/', 2)
-        if not package_name or not message_name:
-            raise ValueError()
-    except ValueError:
-        raise RuntimeError('The passed message type is invalid')
-    module = importlib.import_module(package_name + '.msg')
-    msg_module = getattr(module, message_name)
+    msg_module = import_message_type(topic_name, message_type)
     values_dictionary = yaml.load(values)
     if not isinstance(values_dictionary, dict):
         return 'The passed value needs to be a dictionary in YAML format'
     if not node_name:
-        node_name = 'publisher_%s_%s' % (package_name, message_name)
+        node_name = 'publisher_%s' % (message_type.replace('/', '_'),)
     rclpy.init()
 
     node = rclpy.create_node(node_name)


### PR DESCRIPTION
The first commit fixes a bug where the option `--include-hidden-topics` wasn't being passed to the call to `get_topic_names_and_types()` or `get_msg_class()`. This prevented `ros2 topic echo/delay/hz` from working with hidden topics. I looked at adding a test, but it's non-trivial. Instead here are manual tests.

Publish on a hidden topic
```
ros2 topic pub /fibonacci/_action/status action_msgs/GoalStatusArray
```

Try to do these
```
ros2 topic --include-hidden-topics echo /fibonacci/_action/status
# note message doesn't have a header, but it can at least determine the type now
ros2 topic --include-hidden-topics delay /fibonacci/_action/status
ros2 topic --include-hidden-topics hz /fibonacci/_action/status
```

The second commit allows import action types which come from the module `.action` instead of `.msg`.

Publish on a hidden topic with a generated action message.
```
ros2 topic pub /fibonacci/_action/feedback example_interfaces/Fibonacci_Feedback
```

Try to do these
```
ros2 topic --include-hidden-topics echo /fibonacci/_action/feedback
ros2 topic --include-hidden-topics delay /fibonacci/_action/feedback
ros2 topic --include-hidden-topics hz /fibonacci/_action/feedback
```