### PR TITLE
Make listing hidden services symmetric with topics

### DIFF
--- a/ros2service/ros2service/verb/list.py
+++ b/ros2service/ros2service/verb/list.py
@@ -29,9 +29,6 @@ class ListVerb(VerbExtension):
         parser.add_argument(
             '-c', '--count-services', action='store_true',
             help='Only display the number of services discovered')
-        parser.add_argument(
-            '--include-hidden-services', action='store_true',
-            help='Consider hidden services as well')
 
     def main(self, *, args):
         with NodeStrategy(args) as node:


### PR DESCRIPTION
The `ros2 service` command and `ros2 service list` command both had `--include-hidden-services` arguments. Because of the latter the first argument did nothing. This makes listing hidden services the same as listing hidden topics

Before

``` bash
# this would show no error, and not show hidden services
ros2 service --include-hidden-services list
# this would show hidden services
ros2 service list --include-hidden-services
```

With this PR
```bash
# this shows hidden services.
ros2 service --include-hidden-services list
# this shows hidden topics
ros2 topic --include-hidden-topics list
```
