### PR TITLE
Check in action module if action service

### DIFF
--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -64,7 +64,13 @@ def requester(service_type, service_name, values, period):
             raise ValueError()
     except ValueError:
         raise RuntimeError('The passed service type is invalid')
-    module = importlib.import_module(package_name + '.srv')
+
+    # TODO(sloretz) node API to get topic types should indicate if action or srv
+    middle_module = 'srv'
+    if service_name.endswith('/_action/get_result') or service_name.endswith('/_action/send_goal'):
+        middle_module = 'action'
+
+    module = importlib.import_module(package_name + '.' + middle_module)
     srv_module = getattr(module, srv_name)
     values_dictionary = yaml.load(values)
 


### PR DESCRIPTION
Like 417d46f3a5caf2458e6eadeb52d2ae435782bcf1 but for services. This imports the service type from `.action` if the service name indicates it's an action service.

To manually test:
1. Checkout  https://github.com/ros2/examples/pull/220
1. run the server
   ```
   ros2 run examples_rclcpp_minimal_action_server action_server_not_composable
   ```
1. try to call the send goal service
   ```
   ros2 service call /fibonacci/_action/send_goal example_interfaces/Fibonacci_Goal
   ```
1. try to call the get result service
   ```
   ros2 service call /fibonacci/_action/get_result example_interfaces/Fibonacci_Result
   ```