### PR TITLE
register 'get_node_names' function, used by ros2cli node info tool.

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -61,6 +61,8 @@ def main(*, script_name='_ros2_daemon', argv=None):
                 _print_invoked_function_name(node.get_topic_names_and_types))
             server.register_function(
                 _print_invoked_function_name(node.get_service_names_and_types))
+            server.register_function(
+                _print_invoked_function_name(node.get_node_names))
 
             shutdown = False
 


### PR DESCRIPTION
The PR will solve python error which occures on running the `ros2cli node info` tool. 