### PR TITLE
Fix flake8 error due to overindentation

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -211,10 +211,10 @@ def _convert_value(value, truncate_length=None):
             value = value[:truncate_length] + '...'
     elif isinstance(value, tuple) or isinstance(value, list):
         if truncate_length is not None and len(value) > truncate_length:
-                # Truncate the sequence
-                value = value[:truncate_length]
-                # Truncate every item in the sequence
-                value = type(value)([_convert_value(v, truncate_length) for v in value] + ['...'])
+            # Truncate the sequence
+            value = value[:truncate_length]
+            # Truncate every item in the sequence
+            value = type(value)([_convert_value(v, truncate_length) for v in value] + ['...'])
         else:
             # Truncate every item in the list
             value = type(value)([_convert_value(v, truncate_length) for v in value])


### PR DESCRIPTION
Failures in [nightly_linux-aarch64_debug #713](https://ci.ros2.org/job/nightly_linux-aarch64_debug/713), [nightly_linux-aarch64_extra_rmw_release #245](https://ci.ros2.org/job/nightly_linux-aarch64_extra_rmw_release/245), [nightly_linux-aarch64_release #673](https://ci.ros2.org/job/nightly_linux-aarch64_release/673), [nightly_linux_debug #1088](https://ci.ros2.org/job/nightly_linux_debug/1088), [nightly_linux_extra_rmw_release #241](https://ci.ros2.org/job/nightly_linux_extra_rmw_release/241), [nightly_linux_release #1069](https://ci.ros2.org/job/nightly_linux_release/1069), [nightly_osx_debug #1143](https://ci.ros2.org/job/nightly_osx_debug/1143), [nightly_osx_extra_rmw_release #279](https://ci.ros2.org/job/nightly_osx_extra_rmw_release/279), [nightly_osx_release #1151](https://ci.ros2.org/job/nightly_osx_release/1151), [nightly_win_deb #1143](https://ci.ros2.org/job/nightly_win_deb/1143), [nightly_win_extra_rmw_rel #248](https://ci.ros2.org/job/nightly_win_extra_rmw_rel/248), [nightly_win_rel #1082](https://ci.ros2.org/job/nightly_win_rel/1082), [nightly_xenial_linux-aarch64_release #243](https://ci.ros2.org/job/nightly_xenial_linux-aarch64_release/243), [nightly_xenial_linux_release #234](https://ci.ros2.org/job/nightly_xenial_linux_release/234)

More PRs coming shortly