### PR TITLE
use all linters by default

### DIFF
--- a/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
@@ -87,11 +87,11 @@ install(TARGETS @(cpp_node_name)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # remove the line when a copyright and license is present in all source files
-  set(ament_cmake_copyright_FOUND TRUE)
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
   # the following line skips cpplint (only works in a git repo)
-  # remove the line when this package is a git repo
-  set(ament_cmake_cpplint_FOUND TRUE)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 @[if cpp_library_name]@


### PR DESCRIPTION
Imo all linters should be enabled by default with the comment being available how to skip them. Otherwise the high probability is that they won't we used by users which just expand the template but don't edit the file.