### PR TITLE
Add capability to use ros2 param set for array types

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -61,22 +61,6 @@ def get_parameter_value(*, string_value):
     return value
 
 
-def _is_integer(string_value):
-    try:
-        integer_value = int(string_value)
-    except ValueError:
-        return False
-    return str(integer_value) == string_value
-
-
-def _is_float(string_value):
-    try:
-        float(string_value)
-    except ValueError:
-        return False
-    return True
-
-
 def call_get_parameters(*, node, node_name, parameter_names):
     # create client
     client = node.create_client(

--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -35,10 +35,10 @@ def get_parameter_value(*, string_value):
         value.bool_value = yaml_value
     elif isinstance(yaml_value, int):
         value.type = ParameterType.PARAMETER_INTEGER
-        value.integer_value = int(string_value)
+        value.integer_value = yaml_value
     elif isinstance(yaml_value, float):
         value.type = ParameterType.PARAMETER_DOUBLE
-        value.double_value = float(string_value)
+        value.double_value = yaml_value
     elif isinstance(yaml_value, list):
         if all([isinstance(v, bool) for v in yaml_value]):
             value.type = ParameterType.PARAMETER_BOOL_ARRAY

--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -40,16 +40,16 @@ def get_parameter_value(*, string_value):
         value.type = ParameterType.PARAMETER_DOUBLE
         value.double_value = yaml_value
     elif isinstance(yaml_value, list):
-        if all([isinstance(v, bool) for v in yaml_value]):
+        if all((isinstance(v, bool) for v in yaml_value)):
             value.type = ParameterType.PARAMETER_BOOL_ARRAY
             value.bool_array_value = yaml_value
-        elif all([isinstance(v, int) for v in yaml_value]):
+        elif all((isinstance(v, int) for v in yaml_value)):
             value.type = ParameterType.PARAMETER_INTEGER_ARRAY
             value.integer_array_value = yaml_value
-        elif all([isinstance(v, float) for v in yaml_value]):
+        elif all((isinstance(v, float) for v in yaml_value)):
             value.type = ParameterType.PARAMETER_DOUBLE_ARRAY
             value.double_array_value = yaml_value
-        elif all([isinstance(v, str) for v in yaml_value]):
+        elif all((isinstance(v, str) for v in yaml_value)):
             value.type = ParameterType.PARAMETER_STRING_ARRAY
             value.string_array_value = yaml_value
         else:

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ros2param.api import get_parameter_value
 from rcl_interfaces.msg import ParameterType
+from ros2param.api import get_parameter_value
 
 
 def test_bool():

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -12,83 +12,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from rcl_interfaces.msg import ParameterType
 from ros2param.api import get_parameter_value
 
 
-def test_bool():
-    value = get_parameter_value(string_value='true')
-    assert value.type == ParameterType.PARAMETER_BOOL
-    assert value.bool_value is True
+@pytest.mark.parametrize(
+    'string_value,expected_type,value_attribute,expected_value',
+    [
+        ('true', ParameterType.PARAMETER_BOOL, 'bool_value', True),
+        ('false', ParameterType.PARAMETER_BOOL, 'bool_value', False),
 
-    value = get_parameter_value(string_value='false')
-    assert value.type == ParameterType.PARAMETER_BOOL
-    assert value.bool_value is False
+        ('1', ParameterType.PARAMETER_INTEGER, 'integer_value', 1),
+        ('0', ParameterType.PARAMETER_INTEGER, 'integer_value', 0),
+        ('-1', ParameterType.PARAMETER_INTEGER, 'integer_value', -1),
 
+        ('1.0', ParameterType.PARAMETER_DOUBLE, 'double_value', 1.0),
+        ('0.0', ParameterType.PARAMETER_DOUBLE, 'double_value', 0.0),
+        ('-1.0', ParameterType.PARAMETER_DOUBLE, 'double_value', -1.0),
+        ('1.1234', ParameterType.PARAMETER_DOUBLE, 'double_value', 1.1234),
 
-def test_integer():
-    value = get_parameter_value(string_value='1')
-    assert value.type == ParameterType.PARAMETER_INTEGER
-    assert value.integer_value == 1
-
-    value = get_parameter_value(string_value='0')
-    assert value.type == ParameterType.PARAMETER_INTEGER
-    assert value.integer_value == 0
-
-    value = get_parameter_value(string_value='-1')
-    assert value.type == ParameterType.PARAMETER_INTEGER
-    assert value.integer_value == -1
-
-
-def test_double():
-    value = get_parameter_value(string_value='1.0')
-    assert value.type == ParameterType.PARAMETER_DOUBLE
-    assert value.double_value == 1
-
-    value = get_parameter_value(string_value='0.0')
-    assert value.type == ParameterType.PARAMETER_DOUBLE
-    assert value.double_value == 0
-
-    value = get_parameter_value(string_value='-1.0')
-    assert value.type == ParameterType.PARAMETER_DOUBLE
-    assert value.double_value == -1
-
-    value = get_parameter_value(string_value='1.1234')
-    assert value.type == ParameterType.PARAMETER_DOUBLE
-    assert value.double_value == 1.1234
-
-
-def test_string():
-    value = get_parameter_value(string_value='foo')
-    assert value.type == ParameterType.PARAMETER_STRING
-    assert value.string_value == 'foo'
-
-
-def test_bool_array():
-    value = get_parameter_value(string_value='[false, true]')
-    assert value.type == ParameterType.PARAMETER_BOOL_ARRAY
-    assert value.bool_array_value == [False, True]
-
-
-def test_integer_array():
-    value = get_parameter_value(string_value='[-1, 0, 1]')
-    assert value.type == ParameterType.PARAMETER_INTEGER_ARRAY
-    assert value.integer_array_value == [-1, 0, 1]
-
-
-def test_float_array():
-    value = get_parameter_value(string_value='[-1.0, 0.0, 1.0, 1.234]')
-    assert value.type == ParameterType.PARAMETER_DOUBLE_ARRAY
-    assert value.double_array_value == [-1.0, 0.0, 1.0, 1.234]
-
-
-def test_string_array():
-    value = get_parameter_value(string_value='["foo", "bar", "buzz"]')
-    assert value.type == ParameterType.PARAMETER_STRING_ARRAY
-    assert value.string_array_value == ['foo', 'bar', 'buzz']
-
-
-def test_malformed_yaml():
-    value = get_parameter_value(string_value='["foo","bar","buzz"')
-    assert value.type == ParameterType.PARAMETER_STRING
-    assert value.string_value == '["foo","bar","buzz"'
+        ('foo', ParameterType.PARAMETER_STRING, 'string_value', 'foo'),
+        (
+            '[false, true]',
+            ParameterType.PARAMETER_BOOL_ARRAY,
+            'bool_array_value',
+            [False, True]
+        ),
+        (
+            '[-1, 0, 1]',
+            ParameterType.PARAMETER_INTEGER_ARRAY,
+            'integer_array_value',
+            [-1, 0, 1]
+        ),
+        (
+            '[-1.0, 0.0, 1.0, 1.1234]',
+            ParameterType.PARAMETER_DOUBLE_ARRAY,
+            'double_array_value',
+            [-1.0, 0.0, 1.0, 1.1234]
+        ),
+        (
+            '["foo", "bar", "buzz"]',
+            ParameterType.PARAMETER_STRING_ARRAY,
+            'string_array_value',
+            ['foo', 'bar', 'buzz']
+        ),
+        (  # Invalid YAML remains a string
+            '["foo", "bar", "buzz"',
+            ParameterType.PARAMETER_STRING,
+            'string_value',
+            '["foo", "bar", "buzz"'
+        ),
+    ],
+)
+def test_get_parameter_value(
+    string_value, expected_type, value_attribute, expected_value
+):
+    value = get_parameter_value(string_value=string_value)
+    assert value.type == expected_type
+    assert getattr(value, value_attribute) == expected_value

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -1,0 +1,94 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2param.api import get_parameter_value
+from rcl_interfaces.msg import ParameterType
+
+
+def test_bool():
+    value = get_parameter_value(string_value='true')
+    assert value.type == ParameterType.PARAMETER_BOOL
+    assert value.bool_value is True
+
+    value = get_parameter_value(string_value='false')
+    assert value.type == ParameterType.PARAMETER_BOOL
+    assert value.bool_value is False
+
+
+def test_integer():
+    value = get_parameter_value(string_value='1')
+    assert value.type == ParameterType.PARAMETER_INTEGER
+    assert value.integer_value == 1
+
+    value = get_parameter_value(string_value='0')
+    assert value.type == ParameterType.PARAMETER_INTEGER
+    assert value.integer_value == 0
+
+    value = get_parameter_value(string_value='-1')
+    assert value.type == ParameterType.PARAMETER_INTEGER
+    assert value.integer_value == -1
+
+
+def test_double():
+    value = get_parameter_value(string_value='1.0')
+    assert value.type == ParameterType.PARAMETER_DOUBLE
+    assert value.double_value == 1
+
+    value = get_parameter_value(string_value='0.0')
+    assert value.type == ParameterType.PARAMETER_DOUBLE
+    assert value.double_value == 0
+
+    value = get_parameter_value(string_value='-1.0')
+    assert value.type == ParameterType.PARAMETER_DOUBLE
+    assert value.double_value == -1
+
+    value = get_parameter_value(string_value='1.1234')
+    assert value.type == ParameterType.PARAMETER_DOUBLE
+    assert value.double_value == 1.1234
+
+
+def test_string():
+    value = get_parameter_value(string_value="foo")
+    assert value.type == ParameterType.PARAMETER_STRING
+    assert value.string_value == "foo"
+
+
+def test_bool_array():
+    value = get_parameter_value(string_value='[false, true]')
+    assert value.type == ParameterType.PARAMETER_BOOL_ARRAY
+    assert value.bool_array_value == [False, True]
+
+
+def test_integer_array():
+    value = get_parameter_value(string_value='[-1, 0, 1]')
+    assert value.type == ParameterType.PARAMETER_INTEGER_ARRAY
+    assert value.integer_array_value == [-1, 0, 1]
+
+
+def test_float_array():
+    value = get_parameter_value(string_value='[-1.0, 0.0, 1.0, 1.234]')
+    assert value.type == ParameterType.PARAMETER_DOUBLE_ARRAY
+    assert value.double_array_value == [-1.0, 0.0, 1.0, 1.234]
+
+
+def test_string_array():
+    value = get_parameter_value(string_value='["foo", "bar", "buzz"]')
+    assert value.type == ParameterType.PARAMETER_STRING_ARRAY
+    assert value.string_array_value == ["foo", "bar", "buzz"]
+
+
+def test_malformed_yaml():
+    value = get_parameter_value(string_value='["foo","bar","buzz"')
+    assert value.type == ParameterType.PARAMETER_STRING
+    assert value.string_value == '["foo","bar","buzz"'

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -59,9 +59,9 @@ def test_double():
 
 
 def test_string():
-    value = get_parameter_value(string_value="foo")
+    value = get_parameter_value(string_value='foo')
     assert value.type == ParameterType.PARAMETER_STRING
-    assert value.string_value == "foo"
+    assert value.string_value == 'foo'
 
 
 def test_bool_array():
@@ -85,7 +85,7 @@ def test_float_array():
 def test_string_array():
     value = get_parameter_value(string_value='["foo", "bar", "buzz"]')
     assert value.type == ParameterType.PARAMETER_STRING_ARRAY
-    assert value.string_array_value == ["foo", "bar", "buzz"]
+    assert value.string_array_value == ['foo', 'bar', 'buzz']
 
 
 def test_malformed_yaml():

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import array
+
 import pytest
 
 from rcl_interfaces.msg import ParameterType
@@ -38,31 +40,31 @@ from ros2param.api import get_parameter_value
             '[false, true]',
             ParameterType.PARAMETER_BOOL_ARRAY,
             'bool_array_value',
-            [False, True]
+            [False, True],
         ),
         (
             '[-1, 0, 1]',
             ParameterType.PARAMETER_INTEGER_ARRAY,
             'integer_array_value',
-            [-1, 0, 1]
+            array.array('q', (-1, 0, 1))
         ),
         (
             '[-1.0, 0.0, 1.0, 1.1234]',
             ParameterType.PARAMETER_DOUBLE_ARRAY,
             'double_array_value',
-            [-1.0, 0.0, 1.0, 1.1234]
+            array.array('d', (-1.0, 0.0, 1.0, 1.1234)),
         ),
         (
             '["foo", "bar", "buzz"]',
             ParameterType.PARAMETER_STRING_ARRAY,
             'string_array_value',
-            ['foo', 'bar', 'buzz']
+            ['foo', 'bar', 'buzz'],
         ),
         (  # Invalid YAML remains a string
             '["foo", "bar", "buzz"',
             ParameterType.PARAMETER_STRING,
             'string_value',
-            '["foo", "bar", "buzz"'
+            '["foo", "bar", "buzz"',
         ),
     ],
 )


### PR DESCRIPTION
Using YAML parsing to determine the value parameter type, the supported parameter types are extended to array types. Only the byte array type is excluded, I don't see a way of expressing that in YAML in an unambiguous way.

Fixes #198 