### PR TITLE
update logger.warn (deprecated) to logger.warning

### DIFF
--- a/ros2cli/ros2cli/entry_points.py
+++ b/ros2cli/ros2cli/entry_points.py
@@ -84,7 +84,7 @@ def load_entry_points(group_name):
         try:
             extension_type = entry_point.load()
         except Exception as e:  # noqa: F841
-            logger.warn(
+            logger.warning(
                 "Failed to load entry point '{entry_point.name}': {e}"
                 .format_map(locals()))
             continue

--- a/ros2cli/ros2cli/plugin_system.py
+++ b/ros2cli/ros2cli/plugin_system.py
@@ -61,7 +61,7 @@ def _instantiate_extension(
     try:
         extension_instance = extension_class()
     except PluginException as e:  # noqa: F841
-        logger.warn(
+        logger.warning(
             "Failed to instantiate '{group_name}' extension "
             "'{extension_name}': {e}".format_map(locals()))
         return None


### PR DESCRIPTION
Use [non-deprecated method](https://docs.python.org/3.7/library/logging.html#logging.Logger.warning).

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6367)](https://ci.ros2.org/job/ci_linux/6367/)