### PR TITLE
Solved bug when trying to find node info in namespaces

### DIFF
--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -29,16 +29,18 @@ def get_absolute_node_name(node_name):
     return node_name
 
 
-def parse_node_name(full_node_name):
-    tokens = full_node_name.split('/')
-    if 1 > len(tokens):
-        raise RuntimeError('Invalid node name: ' + full_node_name)
-    node_name = full_node_name
-    namespace = '/'
+def parse_node_name(node_name):
+    if (node_name[0] == '/'):
+        node_name = node_name[1:]
+    tokens = node_name.split('/')
+    node_basename = tokens[-1]
     if len(tokens) > 1:
-        node_name = tokens[-1]
         namespace = '/' + '/'.join(tokens[:-1])
-    return NodeName(node_name, namespace, '/' + full_node_name)
+        full_node_name = namespace + '/' + node_basename
+    else:
+        namespace = '/'
+        full_node_name = '/' + node_basename
+    return NodeName(node_basename, namespace, full_node_name)
 
 
 def get_node_names(*, node, include_hidden_nodes=False):

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -30,16 +30,15 @@ def get_absolute_node_name(node_name):
 
 
 def parse_node_name(node_name):
-    if (node_name[0] == '/'):
-        node_name = node_name[1:]
-    tokens = node_name.split('/')
-    node_basename = tokens[-1]
-    if len(tokens) > 1:
-        namespace = '/' + '/'.join(tokens[:-1])
-        full_node_name = namespace + '/' + node_basename
+    if node_name[0] != '/':
+        full_node_name = '/' + node_name
     else:
+        full_node_name = node_name
+    tokens = full_node_name.rsplit('/', 1)
+    node_basename = tokens[1]
+    namespace = tokens[0]
+    if namespace == '':
         namespace = '/'
-        full_node_name = '/' + node_basename
     return NodeName(node_basename, namespace, full_node_name)
 
 

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -37,8 +37,8 @@ def parse_node_name(full_node_name):
     namespace = '/'
     if len(tokens) > 1:
         node_name = tokens[-1]
-        namespace = '/'.join(tokens[:-1])
-    return NodeName(node_name, namespace, full_node_name)
+        namespace = '/' + '/'.join(tokens[:-1])
+    return NodeName(node_name, namespace, '/' + full_node_name)
 
 
 def get_node_names(*, node, include_hidden_nodes=False):

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -30,13 +30,10 @@ def get_absolute_node_name(node_name):
 
 
 def parse_node_name(node_name):
-    if node_name[0] != '/':
-        full_node_name = '/' + node_name
-    else:
-        full_node_name = node_name
-    tokens = full_node_name.rsplit('/', 1)
-    node_basename = tokens[1]
-    namespace = tokens[0]
+    full_node_name = node_name
+    if not full_node_name.startswith('/'):
+        full_node_name = '/' + full_node_name
+    namespace, node_basename = full_node_name.rsplit('/', 1)
     if namespace == '':
         namespace = '/'
     return NodeName(node_basename, namespace, full_node_name)

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -43,13 +43,13 @@ class InfoVerb(VerbExtension):
         if args.node_name in [n.full_name for n in node_names]:
             with DirectNode(args) as node:
                 print(args.node_name)
-                subscribers = get_subscriber_info(node=node, remote_node_name=args.node_name[1:])
+                subscribers = get_subscriber_info(node=node, remote_node_name=args.node_name)
                 print('  Subscribers:')
                 print_names_and_types(subscribers)
-                publishers = get_publisher_info(node=node, remote_node_name=args.node_name[1:])
+                publishers = get_publisher_info(node=node, remote_node_name=args.node_name)
                 print('  Publishers:')
                 print_names_and_types(publishers)
-                services = get_service_info(node=node, remote_node_name=args.node_name[1:])
+                services = get_service_info(node=node, remote_node_name=args.node_name)
                 print('  Services:')
                 print_names_and_types(services)
         else:

--- a/ros2node/test/test_node.py
+++ b/ros2node/test/test_node.py
@@ -18,6 +18,14 @@ from ros2node.api import parse_node_name
 def test_parse_node_name():
     """Test parse_node_name api function."""
     # The input of parse_node_name is the full_name without the initial '/'
+    name = parse_node_name('/talker')
+    assert name.full_name == '/talker'
+    assert name.namespace == '/'
+    assert name.name == 'talker'
+    name = parse_node_name('/ns/talker')
+    assert name.full_name == '/ns/talker'
+    assert name.namespace == '/ns'
+    assert name.name == 'talker'
     name = parse_node_name('talker')
     assert name.full_name == '/talker'
     assert name.namespace == '/'

--- a/ros2node/test/test_node.py
+++ b/ros2node/test/test_node.py
@@ -1,0 +1,28 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2node.api import parse_node_name
+
+
+def test_parse_node_name():
+    """Test parse_node_name api function."""
+    # The input of parse_node_name is the full_name without the initial '/'
+    name = parse_node_name('talker')
+    assert name.full_name == '/talker'
+    assert name.namespace == '/'
+    assert name.name == 'talker'
+    name = parse_node_name('ns/talker')
+    assert name.full_name == '/ns/talker'
+    assert name.namespace == '/ns'
+    assert name.name == 'talker'


### PR DESCRIPTION
Fixes #201 
Fixes #181 
Initial '/' was missing when the node was inside a namespace.
Now, non fully qualified names are also accepted.
Added unit test.