### PR TITLE
add section about DCO to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,8 @@ be under the Apache 2 License, as dictated by that
    the terms of any separate license agreement you may have executed
    with Licensor regarding such Contributions.
 ~~~
+
+Contributors must sign-off each commit by adding a `Signed-off-by: ...`
+line to commit messages to certify that they have the right to submit
+the code they are contributing to the project according to the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).


### PR DESCRIPTION
The patch proposes an addition to the `CONTRIBUTING.md` file mentioning the requirement to sign-off commits as a way to certify the origin.

Please provide feedback in the form of proposed changes if you think the wording should be changed.

Once this PR has been accepted I will apply the same change to all other repositories which will be subject to the DCO.