### PR TITLE
Fix component arguments to be inline with service.

### DIFF
--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -101,7 +101,7 @@ def load_component_into_container(
     package_name,
     plugin_name,
     node_name=None,
-    namespace_name=None,
+    node_namespace=None,
     log_level=None,
     remap_rules=None,
     parameters=None,
@@ -115,7 +115,7 @@ def load_component_into_container(
     :param package_name: where the component node plugin is to be found
     :param plugin_name: of the component plugin to load
     :param node_name: name for the component node
-    :param namespace_name: namespace for the component node
+    :param node_namespace: namespace for the component node
     :param log_level: log level for the component node
     :param remap_rules: remapping rules for the component node, in the 'from:=to' form
     :param parameters: optional parameters for the component node, in the 'name:=value' form
@@ -132,8 +132,8 @@ def load_component_into_container(
         request.plugin_name = plugin_name
         if node_name is not None:
             request.node_name = node_name
-        if namespace_name is not None:
-            request.namespace_name = namespace_name
+        if node_namespace is not None:
+            request.node_namespace = node_namespace
         if log_level is not None:
             request.log_level = log_level
         if remap_rules is not None:

--- a/ros2component/ros2component/verb/load.py
+++ b/ros2component/ros2component/verb/load.py
@@ -47,7 +47,7 @@ class LoadVerb(VerbExtension):
         )
         argument.completer = ComponentTypeNameCompleter(package_name_key='package_name')
         parser.add_argument('-n', '--node-name', default=None, help='Component node name')
-        parser.add_argument('--namespace-name', default=None, help='Component node namespace')
+        parser.add_argument('--node-namespace', default=None, help='Component node namespace')
         parser.add_argument('--log-level', default=None, help='Component node log level')
         parser.add_argument(
             '-r', '--remap-rule', action='append', default=None, dest='remap_rules',
@@ -74,7 +74,7 @@ class LoadVerb(VerbExtension):
                 return load_component_into_container(
                     node=node, remote_container_node_name=args.container_node_name,
                     package_name=args.package_name, plugin_name=args.plugin_name,
-                    node_name=args.node_name, namespace_name=args.namespace_name,
+                    node_name=args.node_name, node_namespace=args.node_namespace,
                     log_level=args.log_level, remap_rules=args.remap_rules,
                     parameters=args.parameters, extra_arguments=args.extra_arguments
                 )


### PR DESCRIPTION
`namespace_name` should be `node_namespace` as it is in the service call (https://github.com/ros2/rcl_interfaces/blob/1189517a0217a2cb9f78e71c2959542429ad9fc0/composition_interfaces/srv/LoadNode.srv#L9)