### PR TITLE
set ttl for ros2cli multicast to 10 instead of 1

### DIFF
--- a/ros2multicast/ros2multicast/api/__init__.py
+++ b/ros2multicast/ros2multicast/api/__init__.py
@@ -17,10 +17,13 @@ import struct
 
 DEFAULT_GROUP = '225.0.0.1'
 DEFAULT_PORT = 49150
+DEFAULT_TTL = 10
 
 
 def send(data, *, group=DEFAULT_GROUP, port=DEFAULT_PORT):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    ttl = struct.pack('b', DEFAULT_TTL)
+    s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
     try:
         s.sendto(data, (group, port))
     finally:


### PR DESCRIPTION
When debugging multicast on non-trivial networks, TTL > 1 is required. I'm not sure of the exact value, but we just had a situation where it needed to be 2, which made debugging challenging :man_facepalming: . Network ops folks suggested we set to 10 to avoid confusion in the future.

Ideally TTL could be a command line option, but for now at least, anything greater than 1 would allow this tool to work for our use case. Just submitting the PR to start the conversation. Cheers