### PR TITLE
Improve ros2 component CLI

### DIFF
--- a/ros2component/package.xml
+++ b/ros2component/package.xml
@@ -9,11 +9,15 @@
   <maintainer email="michel@ekumenlabs.com">Michel Hidalgo</maintainer>
   <license>Apache License 2.0</license>
 
-  <depend>composition_interfaces</depend>
-  <depend>ros2cli</depend>
-  <depend>ros2node</depend>
-  <depend>ros2param</depend>
-  <depend>ros2pkg</depend>
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>composition_interfaces</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
+  <exec_depend>ros2node</exec_depend>
+  <exec_depend>ros2param</exec_depend>
+  <exec_depend>ros2pkg</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -256,19 +256,19 @@ def add_component_arguments(parser):
         'plugin_name', help='Type name of the component to be loaded'
     )
     argument.completer = ComponentTypeNameCompleter(package_name_key='package_name')
-    parser.add_argument('-n', '--node-name', default=None, help='Component node name')
-    parser.add_argument('--node-namespace', default=None, help='Component node namespace')
-    parser.add_argument('--log-level', default=None, help='Component node log level')
+    parser.add_argument('-n', '--node-name', help='Component node name')
+    parser.add_argument('--node-namespace', help='Component node namespace')
+    parser.add_argument('--log-level', help='Component node log level')
     parser.add_argument(
-        '-r', '--remap-rule', action='append', default=None, dest='remap_rules',
+        '-r', '--remap-rule', action='append', dest='remap_rules',
         help="Component node remapping rules, in the 'from:=to' form"
     )
     parser.add_argument(
-        '-p', '--parameter', action='append', default=None, dest='parameters',
+        '-p', '--parameter', action='append', dest='parameters',
         help="Component node parameters, in the 'name:=value' form"
     )
     parser.add_argument(
-        '-e', '--extra-argument', action='append', default=None, dest='extra_arguments',
+        '-e', '--extra-argument', action='append', dest='extra_arguments',
         help="Extra arguments for the container, in the 'name:=value' form"
     )
 

--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -271,3 +271,17 @@ def add_component_arguments(parser):
         '-e', '--extra-argument', action='append', default=None, dest='extra_arguments',
         help="Extra arguments for the container, in the 'name:=value' form"
     )
+
+
+def run_standalone_container(*, container_node_name):
+    """Run a standalone component container."""
+    try:
+        paths = get_executable_paths(package_name='rclcpp_components')
+    except PackageNotFound:
+        raise RuntimeError("Package 'rclcpp_components' not found")
+
+    executable_path = next((p for p in paths if 'component_container' in p), None)
+    if executable_path is None:
+        raise RuntimeError('No component container node found!')
+
+    return subprocess.Popen([executable_path, '__node:=' + container_node_name])

--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import namedtuple
+import subprocess
 
 from ament_index_python import get_resource
 from ament_index_python import get_resources
@@ -28,7 +29,8 @@ from ros2cli.node.strategy import NodeStrategy
 from ros2node.api import get_node_names
 from ros2node.api import get_service_info
 from ros2param.api import get_parameter_value
-
+from ros2pkg.api import get_executable_paths
+from ros2pkg.api import PackageNotFound
 
 COMPONENTS_RESOURCE_TYPE = 'rclcpp_components'
 
@@ -156,8 +158,8 @@ def load_component_into_container(
         rclpy.spin_until_future_complete(node, future)
         response = future.result()
         if not response.success:
-            return 'Failed to load component: ' + response.error_message.capitalize()
-        print('{} {}'.format(response.unique_id, response.full_node_name))
+            raise RuntimeError('Failed to load component: ' + response.error_message.capitalize())
+        return response.unique_id, response.full_node_name
     finally:
         node.destroy_client(load_node_client)
 
@@ -182,13 +184,7 @@ def unload_component_from_container(*, node, remote_container_node_name, compone
             future = unload_node_client.call_async(request)
             rclpy.spin_until_future_complete(node, future)
             response = future.result()
-            if not response.success:
-                return 'Failed to unload component {} from {} container\n  {}'.format(
-                    uid, remote_container_node_name, response.error_message
-                )
-            print('Unloaded component {} from {} container'.format(
-                uid, remote_container_node_name
-            ))
+            yield uid, not response.success, response.error_message
     finally:
         node.destroy_client(unload_node_client)
 
@@ -248,3 +244,30 @@ class ComponentTypeNameCompleter:
     def __call__(self, prefix, parsed_args, **kwargs):
         package_name = getattr(parsed_args, self.package_name_key)
         return get_package_component_types(package_name=package_name)
+
+
+def add_component_arguments(parser):
+    """Add component specific arguments to the CLI parser."""
+    argument = parser.add_argument(
+        'package_name', help='Name of the package where the component is to be found'
+    )
+    argument.completer = package_with_components_name_completer
+    argument = parser.add_argument(
+        'plugin_name', help='Type name of the component to be loaded'
+    )
+    argument.completer = ComponentTypeNameCompleter(package_name_key='package_name')
+    parser.add_argument('-n', '--node-name', default=None, help='Component node name')
+    parser.add_argument('--node-namespace', default=None, help='Component node namespace')
+    parser.add_argument('--log-level', default=None, help='Component node log level')
+    parser.add_argument(
+        '-r', '--remap-rule', action='append', default=None, dest='remap_rules',
+        help="Component node remapping rules, in the 'from:=to' form"
+    )
+    parser.add_argument(
+        '-p', '--parameter', action='append', default=None, dest='parameters',
+        help="Component node parameters, in the 'name:=value' form"
+    )
+    parser.add_argument(
+        '-e', '--extra-argument', action='append', default=None, dest='extra_arguments',
+        help="Extra arguments for the container, in the 'name:=value' form"
+    )

--- a/ros2component/ros2component/verb/list.py
+++ b/ros2component/ros2component/verb/list.py
@@ -52,7 +52,7 @@ class ListVerb(VerbExtension):
                         node=node, remote_container_node_name=args.container_node_name
                     )
                     if any(components):
-                        print(*['{}    {}'.format(c.uid, c.name) for c in components], sep='\n')
+                        print(*['{}  {}'.format(c.uid, c.name) for c in components], sep='\n')
             else:
                 for n in container_node_names:
                     print(n.full_name)
@@ -62,5 +62,5 @@ class ListVerb(VerbExtension):
                         )
                         if any(components):
                             print(*[
-                                4 * ' ' + '{}    {}'.format(c.uid, c.name) for c in components
+                                '  ' + '{}  {}'.format(c.uid, c.name) for c in components
                             ], sep='\n')

--- a/ros2component/ros2component/verb/list.py
+++ b/ros2component/ros2component/verb/list.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import rclpy
-
-from ros2cli.node import NODE_NAME_PREFIX
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
@@ -47,10 +44,6 @@ class ListVerb(VerbExtension):
             container_node_names = find_container_node_names(
                 node=node, node_names=node_names
             )
-
-        rclpy.init()
-        node = rclpy.create_node(NODE_NAME_PREFIX + '_component_list_requester')
-        try:
             if args.container_node_name is not None:
                 if args.container_node_name not in [n.full_name for n in container_node_names]:
                     return "Unable to find container node '" + args.container_node_name + "'"
@@ -71,6 +64,3 @@ class ListVerb(VerbExtension):
                             print(*[
                                 2 * '  ' + '{}  {}'.format(c.uid, c.name) for c in components
                             ], sep='\n')
-        finally:
-            node.destroy_node()
-            rclpy.shutdown()

--- a/ros2component/ros2component/verb/list.py
+++ b/ros2component/ros2component/verb/list.py
@@ -52,7 +52,7 @@ class ListVerb(VerbExtension):
                         node=node, remote_container_node_name=args.container_node_name
                     )
                     if any(components):
-                        print(*['{}  {}'.format(c.uid, c.name) for c in components], sep='\n')
+                        print(*['{}    {}'.format(c.uid, c.name) for c in components], sep='\n')
             else:
                 for n in container_node_names:
                     print(n.full_name)
@@ -62,5 +62,5 @@ class ListVerb(VerbExtension):
                         )
                         if any(components):
                             print(*[
-                                2 * '  ' + '{}  {}'.format(c.uid, c.name) for c in components
+                                4 * ' ' + '{}    {}'.format(c.uid, c.name) for c in components
                             ], sep='\n')

--- a/ros2component/ros2component/verb/load.py
+++ b/ros2component/ros2component/verb/load.py
@@ -12,18 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import rclpy
-
-from ros2cli.node import NODE_NAME_PREFIX
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
 
-from ros2component.api import ComponentTypeNameCompleter
+from ros2component.api import add_component_arguments
 from ros2component.api import container_node_name_completer
 from ros2component.api import find_container_node_names
 from ros2component.api import load_component_into_container
-from ros2component.api import package_with_components_name_completer
 from ros2component.verb import VerbExtension
 
 from ros2node.api import get_node_names
@@ -35,51 +31,23 @@ class LoadVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         add_arguments(parser)
         argument = parser.add_argument(
-            'container_node_name', help='Container node name to load component into'
+            'container_node_name', help='Container node name to unload component from'
         )
         argument.completer = container_node_name_completer
-        argument = parser.add_argument(
-            'package_name', help='Name of the package where the component is to be found'
-        )
-        argument.completer = package_with_components_name_completer
-        argument = parser.add_argument(
-            'plugin_name', help='Type name of the component to be loaded'
-        )
-        argument.completer = ComponentTypeNameCompleter(package_name_key='package_name')
-        parser.add_argument('-n', '--node-name', default=None, help='Component node name')
-        parser.add_argument('--node-namespace', default=None, help='Component node namespace')
-        parser.add_argument('--log-level', default=None, help='Component node log level')
-        parser.add_argument(
-            '-r', '--remap-rule', action='append', default=None, dest='remap_rules',
-            help="Component node remapping rules, in the 'from:=to' form"
-        )
-        parser.add_argument(
-            '-p', '--parameter', action='append', default=None, dest='parameters',
-            help="Component node parameters, in the 'name:=value' form"
-        )
-        parser.add_argument(
-            '-e', '--extra-argument', action='append', default=None, dest='extra_arguments',
-            help="Extra arguments for the container, in the 'name:=value' form"
-        )
+        add_component_arguments(parser)
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
             node_names = get_node_names(node=node)
         with DirectNode(args) as node:
             container_node_names = find_container_node_names(node=node, node_names=node_names)
-        rclpy.init()
-        node = rclpy.create_node(NODE_NAME_PREFIX + '_component_load_requester')
-        try:
-            if args.container_node_name in [n.full_name for n in container_node_names]:
-                return load_component_into_container(
-                    node=node, remote_container_node_name=args.container_node_name,
-                    package_name=args.package_name, plugin_name=args.plugin_name,
-                    node_name=args.node_name, node_namespace=args.node_namespace,
-                    log_level=args.log_level, remap_rules=args.remap_rules,
-                    parameters=args.parameters, extra_arguments=args.extra_arguments
-                )
-            else:
+            if args.container_node_name not in [n.full_name for n in container_node_names]:
                 return "Unable to find container node '" + args.container_node_name + "'"
-        finally:
-            node.destroy_node()
-            rclpy.shutdown()
+            component_uid, component_name = load_component_into_container(
+                node=node, remote_container_node_name=args.container_node_name,
+                package_name=args.package_name, plugin_name=args.plugin_name,
+                node_name=args.node_name, node_namespace=args.node_namespace,
+                log_level=args.log_level, remap_rules=args.remap_rules,
+                parameters=args.parameters, extra_arguments=args.extra_arguments
+            )
+            print('{}  {}'.format(component_uid, component_name))

--- a/ros2component/ros2component/verb/load.py
+++ b/ros2component/ros2component/verb/load.py
@@ -37,7 +37,7 @@ class LoadVerb(VerbExtension):
         add_component_arguments(parser)
         parser.add_argument(
             '-q', '--quiet', action='store_true', default=False,
-            help='Print bare minimum output: component unique IDs and names only'
+            help='Only print component unique IDs and names'
         )
 
     def main(self, *, args):
@@ -59,4 +59,4 @@ class LoadVerb(VerbExtension):
                     component_uid, args.container_node_name, component_name
                 ))
             else:
-                print('{}    {}'.format(component_uid, component_name))
+                print('{}  {}'.format(component_uid, component_name))

--- a/ros2component/ros2component/verb/load.py
+++ b/ros2component/ros2component/verb/load.py
@@ -35,6 +35,10 @@ class LoadVerb(VerbExtension):
         )
         argument.completer = container_node_name_completer
         add_component_arguments(parser)
+        parser.add_argument(
+            '-q', '--quiet', action='store_true', default=False,
+            help='Print bare minimum output: component unique IDs and names only'
+        )
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
@@ -50,4 +54,9 @@ class LoadVerb(VerbExtension):
                 log_level=args.log_level, remap_rules=args.remap_rules,
                 parameters=args.parameters, extra_arguments=args.extra_arguments
             )
-            print('{}  {}'.format(component_uid, component_name))
+            if not args.quiet:
+                print("Loaded component {} into '{}' container node as '{}'".format(
+                    component_uid, args.container_node_name, component_name
+                ))
+            else:
+                print('{}    {}'.format(component_uid, component_name))

--- a/ros2component/ros2component/verb/standalone.py
+++ b/ros2component/ros2component/verb/standalone.py
@@ -1,0 +1,57 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+from ros2cli.node.direct import DirectNode
+from ros2cli.node.strategy import add_arguments
+
+from ros2component.api import add_component_arguments
+from ros2component.api import load_component_into_container
+from ros2component.api import run_standalone_container
+from ros2component.verb import VerbExtension
+
+
+class RunVerb(VerbExtension):
+    """Run a component into its own standalone container node."""
+
+    def add_arguments(self, parser, cli_name):
+        add_arguments(parser)
+        add_component_arguments(parser)
+        parser.add_argument(
+            '-c', '--container-node-name',
+            default='standalone_container_' + uuid.uuid4().hex[:12],
+            help='Name of the standalone container node to be run'
+        )
+
+    def main(self, *, args):
+        container = run_standalone_container(container_node_name=args.container_node_name)
+
+        with DirectNode(args) as node:
+            load_component_into_container(
+                node=node, remote_container_node_name=args.container_node_name,
+                package_name=args.package_name, plugin_name=args.plugin_name,
+                node_name=args.node_name, node_namespace=args.node_namespace,
+                log_level=args.log_level, remap_rules=args.remap_rules,
+                parameters=args.parameters, extra_arguments=args.extra_arguments
+            )
+
+        while container.returncode is None:
+            try:
+                container.communicate()
+            except KeyboardInterrupt:
+                # the subprocess will also receive the signal and should shut down
+                # therefore we continue here until the process has finished
+                pass
+        return container.returncode

--- a/ros2component/ros2component/verb/unload.py
+++ b/ros2component/ros2component/verb/unload.py
@@ -38,7 +38,7 @@ class UnloadVerb(VerbExtension):
         )
         parser.add_argument(
             '-q', '--quiet', action='store_true', default=False,
-            help='Print bare minimum output: component unique IDs only'
+            help='Only print component unique IDs'
         )
 
     def main(self, *, args):

--- a/ros2component/ros2component/verb/unload.py
+++ b/ros2component/ros2component/verb/unload.py
@@ -36,6 +36,10 @@ class UnloadVerb(VerbExtension):
         argument = parser.add_argument(
             'component_uid', type=int, nargs='+', help='Unique ID of the component to be unloaded'
         )
+        parser.add_argument(
+            '-q', '--quiet', action='store_true', default=False,
+            help='Print bare minimum output: component unique IDs only'
+        )
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
@@ -52,6 +56,9 @@ class UnloadVerb(VerbExtension):
                     return "Failed to unload component {} from '{}' container node\n    {}".format(
                         uid, args.container_node_name, reason.capitalize()
                     )
-                print("Unloaded component {} from '{}' container node".format(
-                    uid, args.container_node_name
-                ))
+                if not args.quiet:
+                    print("Unloaded component {} from '{}' container node".format(
+                        uid, args.container_node_name
+                    ))
+                else:
+                    print(uid)

--- a/ros2component/setup.py
+++ b/ros2component/setup.py
@@ -35,6 +35,7 @@ The package provides the component command for the ROS 2 command line tools.""",
         'ros2component.verb': [
             'list = ros2component.verb.list:ListVerb',
             'load = ros2component.verb.load:LoadVerb',
+            'standalone = ros2component.verb.standalone:StandaloneVerb',
             'types = ros2component.verb.types:TypesVerb',
             'unload = ros2component.verb.unload:UnloadVerb',
         ],


### PR DESCRIPTION
Fixes #225. This pull request adds a `run` verb to start a component on a standalone container, for instance:

```sh
ros2 component run composition composition::Talker -n my_talker
```

But it also:
- Adds `--quiet` flag to existing verbs to ease shell scripting.
- Adds missing dependencies to the `package.xml`
- Mildly refactors the internal package API