### PR TITLE
fix name of standalone verb

### DIFF
--- a/ros2component/ros2component/verb/standalone.py
+++ b/ros2component/ros2component/verb/standalone.py
@@ -23,7 +23,7 @@ from ros2component.api import run_standalone_container
 from ros2component.verb import VerbExtension
 
 
-class RunVerb(VerbExtension):
+class StandaloneVerb(VerbExtension):
     """Run a component into its own standalone container node."""
 
     def add_arguments(self, parser, cli_name):


### PR DESCRIPTION
Before this PR:

```
$ ros2 component -h
Failed to load entry point 'standalone': module 'ros2component.verb.standalone' has no attribute 'StandaloneVerb'
usage: ros2 component [-h]
                      Call `ros2 component <command> -h` for more detailed
                      usage. ...

Various component related sub-commands

optional arguments:
  -h, --help            show this help message and exit

Commands:
  list    Output a list of running containers and components
  load    Load a component into a container node
  types   Output a list of components registered in the ament index
  unload  Unload a component from a container node
```

With this PR:
```
$ ros2 component -h
usage: ros2 component [-h]
                      Call `ros2 component <command> -h` for more detailed
                      usage. ...

Various component related sub-commands

optional arguments:
  -h, --help            show this help message and exit

Commands:
  list        Output a list of running containers and components
  load        Load a component into a container node
  standalone  Run a component into its own standalone container node
  types       Output a list of components registered in the ament index
  unload      Unload a component from a container node

  Call `ros2 component <command> -h` for more detailed usage.
```
