### PR TITLE
separate the yaml of messages with three dashes

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -115,7 +115,7 @@ def subscriber(node, topic_name, message_type, callback):
 def subscriber_cb(truncate_length):
     def cb(msg):
         nonlocal truncate_length
-        print(message_to_yaml(msg, truncate_length))
+        print(message_to_yaml(msg, truncate_length), end='---\n')
     return cb
 
 


### PR DESCRIPTION
Related to ros2/ros2cli#154.

Instead of an empty line use `---` to separate the yaml output of messages.

It allows to copy-n-paste multiple messages and load them via `yaml.load_all()`.