### PR TITLE
use new type identification for lifecycle nodes

### DIFF
--- a/ros2lifecycle/ros2lifecycle/api/__init__.py
+++ b/ros2lifecycle/ros2lifecycle/api/__init__.py
@@ -37,7 +37,7 @@ def _has_lifecycle(node_name, service_names_and_types):
     for (service_name, service_types) in service_names_and_types:
         if (
             service_name == '{node_name}/get_state'.format_map(locals()) and
-            'lifecycle_msgs/GetState' in service_types
+            'lifecycle_msgs/srv/GetState' in service_types
         ):
             return True
     return False


### PR DESCRIPTION
The current ros2lifecycle command line tools are broken, because the type identification for the service to lifecycle nodes are inaccurate. 

The new type for the service has to be specified with `lifecycle_msgs/srv/GetState`.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>