### PR TITLE
use new type identification for service calls

### DIFF
--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -59,7 +59,7 @@ class CallVerb(VerbExtension):
 def requester(service_type, service_name, values, period):
     # TODO(wjwwood) this logic should come from a rosidl related package
     try:
-        package_name, srv_name = service_type.split('/', 2)
+        package_name, _, srv_name = service_type.split('/', 3)
         if not package_name or not srv_name:
             raise ValueError()
     except ValueError:

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -58,17 +58,15 @@ class CallVerb(VerbExtension):
 
 def requester(service_type, service_name, values, period):
     # TODO(wjwwood) this logic should come from a rosidl related package
+    # TODO(karsten1987) as of dashing, types are split in three parts indicating
+    # package_Name, middle_module (e.g. srv, msg, action), srv_name
+    # This might change in the future and has to be re-addressed if so.
     try:
-        package_name, _, srv_name = service_type.split('/', 3)
+        package_name, middle_module, srv_name = service_type.split('/', 3)
         if not package_name or not srv_name:
             raise ValueError()
     except ValueError:
         raise RuntimeError('The passed service type is invalid')
-
-    # TODO(sloretz) node API to get topic types should indicate if action or srv
-    middle_module = 'srv'
-    if service_name.endswith('/_action/get_result') or service_name.endswith('/_action/send_goal'):
-        middle_module = 'action'
 
     module = importlib.import_module(package_name + '.' + middle_module)
     srv_module = getattr(module, srv_name)

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -59,7 +59,7 @@ class CallVerb(VerbExtension):
 def requester(service_type, service_name, values, period):
     # TODO(wjwwood) this logic should come from a rosidl related package
     # TODO(karsten1987) as of dashing, types are split in three parts indicating
-    # package_Name, middle_module (e.g. srv, msg, action), srv_name
+    # package_name, middle_module (e.g. srv, msg, action), srv_name
     # This might change in the future and has to be re-addressed if so.
     try:
         package_name, middle_module, srv_name = service_type.split('/', 3)

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -58,18 +58,17 @@ class CallVerb(VerbExtension):
 
 def requester(service_type, service_name, values, period):
     # TODO(wjwwood) this logic should come from a rosidl related package
-    # TODO(karsten1987) as of dashing, types are split in three parts indicating
-    # package_name, middle_module (e.g. srv, msg, action), srv_name
-    # This might change in the future and has to be re-addressed if so.
     try:
-        package_name, middle_module, srv_name = service_type.split('/', 3)
-        if not package_name or not srv_name:
+        parts = service_type.split('/')
+        package_name = parts[0]
+        module = importlib.import_module('.'.join(parts[:-1]))
+        srv_name = parts[-1]
+        srv_module = getattr(module, srv_name)
+        if not package_name or not srv_module:
             raise ValueError()
     except ValueError:
         raise RuntimeError('The passed service type is invalid')
 
-    module = importlib.import_module(package_name + '.' + middle_module)
-    srv_module = getattr(module, srv_name)
     values_dictionary = yaml.safe_load(values)
 
     rclpy.init()


### PR DESCRIPTION
Similar problem as described here: https://github.com/ros2/ros2cli/pull/241
`ros2 service call ...` fails because the new service types are parsed incorrectly.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>