### PR TITLE
use system_default as qos for ros2 topic pub

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -58,6 +58,7 @@ class PubVerb(VerbExtension):
         parser.add_argument(
             '--qos-profile',
             choices=rclpy.qos.QoSPresetProfiles.short_keys(),
+            default='system_default',
             help='Quality of service profile to publish with')
         parser.add_argument(
             '--qos-reliability',


### PR DESCRIPTION
fixes https://github.com/ros2/ros2cli/issues/244

I am not sure whether this is the right default value, but given the name, it sounds sensible to me.
If the idea is to necessarily expose a QoS profile, I think we should change the command line to force a qos profile and not being optional.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>