### PR TITLE
Better error message for ros2 action show

### DIFF
--- a/ros2action/ros2action/verb/show.py
+++ b/ros2action/ros2action/verb/show.py
@@ -27,8 +27,12 @@ class ShowVerb(VerbExtension):
         arg.completer = action_type_completer
 
     def main(self, *, args):
-        package_name, action_name = args.action_type.split('/', 2)
-        if not package_name or not action_name:
+        # TODO(jacobperron) this logic should come from a rosidl related package
+        try:
+            package_name, action_name = args.action_type.split('/', 2)
+            if not package_name or not action_name:
+                raise ValueError()
+        except ValueError:
             raise RuntimeError('The passed action type is invalid')
         try:
             path = get_action_path(package_name, action_name)


### PR DESCRIPTION
Catch a potential error when splitting the input string.
This is how it is done for 'ros2 msg show' and 'ros2 srv show'.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7208)](http://ci.ros2.org/job/ci_linux/7208/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3409)](http://ci.ros2.org/job/ci_linux-aarch64/3409/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5905)](http://ci.ros2.org/job/ci_osx/5905/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7035)](http://ci.ros2.org/job/ci_windows/7035/)