### PR TITLE
[ros2component] Stop the standalone container when load fails

### DIFF
--- a/ros2component/ros2component/verb/standalone.py
+++ b/ros2component/ros2component/verb/standalone.py
@@ -51,7 +51,7 @@ class StandaloneVerb(VerbExtension):
                 )
             except RuntimeError as ex:
                 # In case the component fails to load, kill the container.
-                print('{}, terminating container.'.format(ex))
+                print('{}, interrupting container node'.format(ex))
                 if platform.system() == 'Windows':
                     container.send_signal(signal.CTRL_C_EVENT)
                 else:

--- a/ros2component/ros2component/verb/standalone.py
+++ b/ros2component/ros2component/verb/standalone.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import platform
 import signal
 import uuid
 
@@ -49,8 +50,12 @@ class StandaloneVerb(VerbExtension):
                     parameters=args.parameters, extra_arguments=args.extra_arguments
                 )
             except RuntimeError as ex:
-                print("{}, terminating container.".format(ex))
-                container.send_signal(signal.SIGINT)
+                # In case the component fails to load, kill the container.
+                print('{}, terminating container.'.format(ex))
+                if platform.system() == 'Windows':
+                    container.send_signal(signal.CTRL_C_EVENT)
+                else:
+                    container.send_signal(signal.SIGINT)
 
         while container.returncode is None:
             try:


### PR DESCRIPTION
This prevents zombie container processes from hanging around when a
component fails to load.

Closes: #260