### PR TITLE
Add 'topic find' verb

### DIFF
--- a/ros2topic/ros2topic/verb/find.py
+++ b/ros2topic/ros2topic/verb/find.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from ros2cli.node.strategy import NodeStrategy
-from ros2topic.api import TopicTypeCompleter
+from ros2msg.api import message_type_completer
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.verb import VerbExtension
 
@@ -25,7 +25,7 @@ class FindVerb(VerbExtension):
         arg = parser.add_argument(
             'topic_type',
             help="Name of the ROS topic type to filter for (e.g. 'std_msg/msg/String')")
-        arg.completer = TopicTypeCompleter()
+        arg.completer = message_type_completer
         parser.add_argument(
             '-c', '--count-topics', action='store_true',
             help='Only display the number of topics discovered')

--- a/ros2topic/ros2topic/verb/find.py
+++ b/ros2topic/ros2topic/verb/find.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ros2cli.node.strategy import NodeStrategy
+from ros2topic.api import TopicTypeCompleter
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.verb import VerbExtension
 
@@ -21,9 +22,10 @@ class FindVerb(VerbExtension):
     """Output a list of available topics of a given type."""
 
     def add_arguments(self, parser, cli_name):
-        parser.add_argument(
+        arg = parser.add_argument(
             'topic_type',
             help="Name of the ROS topic type to filter for (e.g. 'std_msg/msg/String')")
+        arg.completer = TopicTypeCompleter()
         parser.add_argument(
             '-c', '--count-topics', action='store_true',
             help='Only display the number of topics discovered')

--- a/ros2topic/ros2topic/verb/find.py
+++ b/ros2topic/ros2topic/verb/find.py
@@ -1,0 +1,50 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2cli.node.strategy import NodeStrategy
+from ros2topic.api import get_topic_names_and_types
+from ros2topic.verb import VerbExtension
+
+
+class FindVerb(VerbExtension):
+    """Output a list of available topics of a given type."""
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            'topic_type',
+            help="Name of the ROS topic type to filter for (e.g. 'std_msg/msg/String')")
+        parser.add_argument(
+            '-c', '--count-topics', action='store_true',
+            help='Only display the number of topics discovered')
+        # duplicate the following argument from the command for visibility
+        parser.add_argument(
+            '--include-hidden-topics', action='store_true',
+            help='Consider hidden topics as well')
+
+    def main(self, *, args):
+        with NodeStrategy(args) as node:
+            topic_names_and_types = get_topic_names_and_types(
+                node=node,
+                include_hidden_topics=args.include_hidden_topics)
+
+        filtered_topics = []
+        for (topic_name, topic_type) in topic_names_and_types:
+            if args.topic_type in topic_type:
+                filtered_topics.append(topic_name)
+
+        if args.count_topics:
+            print(len(filtered_topics))
+        else:
+            for filtered_topic in filtered_topics:
+                print(filtered_topic)

--- a/ros2topic/setup.py
+++ b/ros2topic/setup.py
@@ -36,11 +36,11 @@ The package provides the topic command for the ROS 2 command line tools.""",
             'bw = ros2topic.verb.bw:BwVerb',
             'delay = ros2topic.verb.delay:DelayVerb',
             'echo = ros2topic.verb.echo:EchoVerb',
+            'find = ros2topic.verb.find:FindVerb',
             'hz = ros2topic.verb.hz:HzVerb',
             'info = ros2topic.verb.info:InfoVerb',
             'list = ros2topic.verb.list:ListVerb',
             'pub = ros2topic.verb.pub:PubVerb',
-            'find = ros2topic.verb.find:FindVerb',
         ],
     }
 )

--- a/ros2topic/setup.py
+++ b/ros2topic/setup.py
@@ -40,6 +40,7 @@ The package provides the topic command for the ROS 2 command line tools.""",
             'info = ros2topic.verb.info:InfoVerb',
             'list = ros2topic.verb.list:ListVerb',
             'pub = ros2topic.verb.pub:PubVerb',
+            'find = ros2topic.verb.find:FindVerb',
         ],
     }
 )


### PR DESCRIPTION
Add the `find` verb which lists all topics of a given type.
E.g.  
```terminal
$ ros2 topic find rcl_interfaces/msg/Log
/rosout
```
or with `count-topics` option,  
```terminal
$ ros2 topic find rcl_interfaces/msg/Log -c
1
```