### PR TITLE
add 'topic type' verb

### DIFF
--- a/ros2topic/ros2topic/verb/type.py
+++ b/ros2topic/ros2topic/verb/type.py
@@ -1,0 +1,39 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2cli.node.direct import DirectNode
+from ros2topic.api import get_topic_names_and_types
+from ros2topic.api import TopicNameCompleter
+from ros2topic.verb import VerbExtension
+
+
+class TypeVerb(VerbExtension):
+    """Print a topic's type."""
+
+    def add_arguments(self, parser, cli_name):
+        arg = parser.add_argument(
+            'topic_name',
+            help="Name of the ROS topic to get info (e.g. '/chatter')")
+        arg.completer = TopicNameCompleter(
+            include_hidden_topics_key='include_hidden_topics')
+
+    def main(self, *, args):
+        with DirectNode(args) as node:
+            topic_names_and_types = get_topic_names_and_types(
+                node=node,
+                include_hidden_topics=args.include_hidden_topics)
+
+        for (topic_name, topic_types) in topic_names_and_types:
+            if args.topic_name == topic_name:
+                print(topic_types[0])

--- a/ros2topic/ros2topic/verb/type.py
+++ b/ros2topic/ros2topic/verb/type.py
@@ -37,3 +37,6 @@ class TypeVerb(VerbExtension):
         for (topic_name, topic_types) in topic_names_and_types:
             if args.topic_name == topic_name:
                 print(topic_types[0])
+                return 0
+
+        return 1

--- a/ros2topic/ros2topic/verb/type.py
+++ b/ros2topic/ros2topic/verb/type.py
@@ -24,7 +24,7 @@ class TypeVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
             'topic_name',
-            help="Name of the ROS topic to get info (e.g. '/chatter')")
+            help="Name of the ROS topic to get type (e.g. '/chatter')")
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')
 

--- a/ros2topic/setup.py
+++ b/ros2topic/setup.py
@@ -40,6 +40,7 @@ The package provides the topic command for the ROS 2 command line tools.""",
             'info = ros2topic.verb.info:InfoVerb',
             'list = ros2topic.verb.list:ListVerb',
             'pub = ros2topic.verb.pub:PubVerb',
+            'type = ros2topic.verb.type:TypeVerb',
         ],
     }
 )


### PR DESCRIPTION
Add the `type` verb which return the type of a given topic.
E.g.
```
$ ros2 topic type /rosout
rcl_interfaces/msg/Log
```