### PR TITLE
Add 'service type' verb

### DIFF
--- a/ros2service/ros2service/verb/type.py
+++ b/ros2service/ros2service/verb/type.py
@@ -36,7 +36,8 @@ class TypeVerb(VerbExtension):
 
         for (service_name, service_types) in service_names_and_types:
             if args.service_name == service_name:
-                print(service_types[0])
+                for service_type in service_types:
+                    print(service_type)
                 return 0
 
         return 1

--- a/ros2service/ros2service/verb/type.py
+++ b/ros2service/ros2service/verb/type.py
@@ -1,0 +1,42 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2cli.node.strategy import NodeStrategy
+from ros2service.api import get_service_names_and_types
+from ros2service.api import ServiceNameCompleter
+from ros2service.verb import VerbExtension
+
+
+class TypeVerb(VerbExtension):
+    """Output a service's type."""
+
+    def add_arguments(self, parser, cli_name):
+        arg = parser.add_argument(
+            'service_name',
+            help="Name of the ROS service to get type (e.g. '/talker/list_parameters')")
+        arg.completer = ServiceNameCompleter(
+            include_hidden_services_key='include_hidden_services')
+
+    def main(self, *, args):
+        with NodeStrategy(args) as node:
+            service_names_and_types = get_service_names_and_types(
+                node=node,
+                include_hidden_services=args.include_hidden_services)
+
+        for (service_name, service_types) in service_names_and_types:
+            if args.service_name == service_name:
+                print(service_types[0])
+                return 0
+
+        return 1

--- a/ros2service/setup.py
+++ b/ros2service/setup.py
@@ -35,6 +35,7 @@ The package provides the service command for the ROS 2 command line tools.""",
         'ros2service.verb': [
             'call = ros2service.verb.call:CallVerb',
             'list = ros2service.verb.list:ListVerb',
+            'type = ros2service.verb.type:TypeVerb',
         ],
     }
 )


### PR DESCRIPTION
Add the `type` verb to `service` which return the type of a given service.
E.g.
given `ros2 run demo_nodes_cpp talker`
```terminal
$ ros2 service type /talker/describe_parameters
rcl_interfaces/srv/DescribeParameters
```