### PR TITLE
add 'service find' verb

### DIFF
--- a/ros2service/ros2service/verb/find.py
+++ b/ros2service/ros2service/verb/find.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from ros2cli.node.strategy import NodeStrategy
-from ros2srv.api import service_type_completer
 from ros2service.api import get_service_names_and_types
 from ros2service.verb import VerbExtension
+from ros2srv.api import service_type_completer
 
 
 class FindVerb(VerbExtension):

--- a/ros2service/ros2service/verb/find.py
+++ b/ros2service/ros2service/verb/find.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ros2cli.node.strategy import NodeStrategy
+from ros2service.api import ServiceTypeCompleter
 from ros2service.api import get_service_names_and_types
 from ros2service.verb import VerbExtension
 
@@ -23,7 +24,9 @@ class FindVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
             'service_type',
-            help="Name of the ROS service type to filter for (e.g. 'rcl_interfaces/srv/ListParameters')")
+            help="Name of the ROS service type to filter for \
+                (e.g. 'rcl_interfaces/srv/ListParameters')")
+        arg.completer = ServiceTypeCompleter()
         parser.add_argument(
             '-c', '--count-services', action='store_true',
             help='Only display the number of services discovered')

--- a/ros2service/ros2service/verb/find.py
+++ b/ros2service/ros2service/verb/find.py
@@ -24,7 +24,7 @@ class FindVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
             'service_type',
-            help="Name of the ROS service type to filter for "
+            help='Name of the ROS service type to filter for '
                  "(e.g. 'rcl_interfaces/srv/ListParameters')")
         arg.completer = service_type_completer
         parser.add_argument(

--- a/ros2service/ros2service/verb/find.py
+++ b/ros2service/ros2service/verb/find.py
@@ -24,8 +24,8 @@ class FindVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
             'service_type',
-            help="Name of the ROS service type to filter for \
-                (e.g. 'rcl_interfaces/srv/ListParameters')")
+            help="Name of the ROS service type to filter for "
+                 "(e.g. 'rcl_interfaces/srv/ListParameters')")
         arg.completer = service_type_completer
         parser.add_argument(
             '-c', '--count-services', action='store_true',

--- a/ros2service/ros2service/verb/find.py
+++ b/ros2service/ros2service/verb/find.py
@@ -1,0 +1,50 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2cli.node.strategy import NodeStrategy
+from ros2service.api import get_service_names_and_types
+from ros2service.verb import VerbExtension
+
+
+class FindVerb(VerbExtension):
+    """Output a list of available services of a given type."""
+
+    def add_arguments(self, parser, cli_name):
+        arg = parser.add_argument(
+            'service_type',
+            help="Name of the ROS service type to filter for (e.g. 'rcl_interfaces/srv/ListParameters')")
+        parser.add_argument(
+            '-c', '--count-services', action='store_true',
+            help='Only display the number of services discovered')
+        # duplicate the following argument from the command for visibility
+        parser.add_argument(
+            '--include-hidden-services', action='store_true',
+            help='Consider hidden services as well')
+
+    def main(self, *, args):
+        with NodeStrategy(args) as node:
+            service_names_and_types = get_service_names_and_types(
+                node=node,
+                include_hidden_services=args.include_hidden_services)
+
+        filtered_services = []
+        for (service_name, service_type) in service_names_and_types:
+            if args.service_type in service_type:
+                filtered_services.append(service_name)
+
+        if args.count_services:
+            print(len(filtered_services))
+        else:
+            for filtered_service in filtered_services:
+                print(filtered_service)

--- a/ros2service/ros2service/verb/find.py
+++ b/ros2service/ros2service/verb/find.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from ros2cli.node.strategy import NodeStrategy
-from ros2service.api import ServiceTypeCompleter
+from ros2srv.api import service_type_completer
 from ros2service.api import get_service_names_and_types
 from ros2service.verb import VerbExtension
 
@@ -26,7 +26,7 @@ class FindVerb(VerbExtension):
             'service_type',
             help="Name of the ROS service type to filter for \
                 (e.g. 'rcl_interfaces/srv/ListParameters')")
-        arg.completer = ServiceTypeCompleter()
+        arg.completer = service_type_completer
         parser.add_argument(
             '-c', '--count-services', action='store_true',
             help='Only display the number of services discovered')

--- a/ros2service/setup.py
+++ b/ros2service/setup.py
@@ -34,6 +34,7 @@ The package provides the service command for the ROS 2 command line tools.""",
         ],
         'ros2service.verb': [
             'call = ros2service.verb.call:CallVerb',
+            'find = ros2service.verb.find:FindVerb',
             'list = ros2service.verb.list:ListVerb',
         ],
     }


### PR DESCRIPTION
Add the `find` verb to `service` which lists all services of a given type.
E.g.
given `ros2 run demo_nodes_cpp talker` & `ros2 run demo_nodes_cpp listener`
```terminal
$ ros2 service find rcl_interfaces/srv/ListParameters
/listener/list_parameters
/talker/list_parameters
```
or with count-topics option,
```
$ ros2 service find rcl_interfaces/srv/ListParameters -c
2
```