### PR TITLE
parse middle_module from message type in ros2topic

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -58,7 +58,9 @@ def import_message_type(topic_name, message_type):
     # TODO(dirk-thomas) this logic should come from a rosidl related package
     try:
         package_name, middle_module, message_name = message_type.split('/')
-        if not package_name or not middle_module or not message_name:
+        if not middle_module:
+            middle_module = 'msg'
+        if not package_name  or not message_name:
             raise ValueError()
     except ValueError:
         raise RuntimeError('The passed message type is invalid')

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -57,19 +57,18 @@ class TopicNameCompleter:
 def import_message_type(topic_name, message_type):
     # TODO(dirk-thomas) this logic should come from a rosidl related package
     try:
-        package_name, *message_name = message_type.split('/')
-        if not package_name or not message_name or not all(message_name):
+        package_name, middle_module, message_name = message_type.split('/')
+        if not package_name or not middle_module or not message_name:
             raise ValueError()
     except ValueError:
         raise RuntimeError('The passed message type is invalid')
 
     # TODO(sloretz) node API to get topic types should indicate if action or msg
-    middle_module = 'msg'
     if topic_name.endswith('/_action/feedback'):
         middle_module = 'action'
 
     module = importlib.import_module(package_name + '.' + middle_module)
-    return getattr(module, message_name[-1])
+    return getattr(module, message_name)
 
 
 class TopicTypeCompleter:


### PR DESCRIPTION
Attempts to solve issue #277.  The middle module name is parsed from the message type rather than being hardcoded as .msg.  I have tested it with a few message types generated from .msg and from .idl but not exhaustively.  Is there a case where the message_type split could result in more than 3 strings?