### PR TITLE
Add pkg xml verb

### DIFF
--- a/ros2pkg/ros2pkg/verb/xml.py
+++ b/ros2pkg/ros2pkg/verb/xml.py
@@ -35,9 +35,8 @@ class XmlVerb(VerbExtension):
             'package_name',
             help='The package name')
         arg.completer = package_name_completer
-        arg = parser.add_argument(
+        parser.add_argument(
             '-t', '--tag',
-            default='None',
             help="The package's xml's tag to print")
 
     def main(self, *, args):
@@ -47,17 +46,16 @@ class XmlVerb(VerbExtension):
             return PACKAGE_NOT_FOUND
 
         package_xml = os.path.join(package_share_dir, 'package.xml')
-        if os.path.isfile(package_xml):
-            tree = ET.parse(package_xml)
-            if args.tag == 'None':
-                ET.dump(tree)
-                return 0
-            else:
-                elements = tree.getroot().findall(args.tag)
-                if len(elements) > 0:
-                    for element in elements:
-                        print(element.text)
-                else:
-                    return PACKAGE_XML_TAG_NOT_FOUND
-        else:
+        if not os.path.isfile(package_xml):
             return PACKAGE_XML_NOT_FOUND
+
+        tree = ET.parse(package_xml)
+        if args.tag is None:
+            ET.dump(tree)
+            return 0
+        else:
+            elements = tree.getroot().findall(args.tag)
+            if len(elements) == 0:
+                return PACKAGE_XML_TAG_NOT_FOUND
+            for element in elements:
+                    print(element.text)

--- a/ros2pkg/ros2pkg/verb/xml.py
+++ b/ros2pkg/ros2pkg/verb/xml.py
@@ -1,0 +1,57 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import xml.etree.ElementTree as ET
+
+from ament_index_python import get_package_share_directory
+from ament_index_python import PackageNotFoundError
+from ros2pkg.api import package_name_completer
+from ros2pkg.verb import VerbExtension
+
+
+PACKAGE_NOT_FOUND = 'Package not found'
+PACKAGE_XML_TAG_NOT_FOUND = 'XML tag not found'
+
+
+class XmlVerb(VerbExtension):
+    """Output the package xml manifest or an optional tag."""
+
+    def add_arguments(self, parser, cli_name):
+        arg = parser.add_argument(
+            'package_name',
+            help='The package name')
+        arg = parser.add_argument(
+            '-t', '--tag',
+            default='root',
+            help="The package's xml's tag to print")
+        arg.completer = package_name_completer
+
+    def main(self, *, args):
+        try:
+            package_share_dir = get_package_share_directory(args.package_name)
+            package_xml = os.path.join(package_share_dir, 'package.xml')
+            if os.path.isfile(package_xml):
+                tree = ET.parse(package_xml)
+                if args.tag == 'root':
+                    ET.dump(tree)
+                    return 0
+                else:
+                    for elements in tree.getroot().findall(args.tag):
+                        print(elements.text)
+                    return 0
+                return PACKAGE_XML_TAG_NOT_FOUND
+        except PackageNotFoundError:
+            return PACKAGE_NOT_FOUND

--- a/ros2pkg/ros2pkg/verb/xml.py
+++ b/ros2pkg/ros2pkg/verb/xml.py
@@ -27,7 +27,7 @@ PACKAGE_XML_TAG_NOT_FOUND = 'XML tag not found'
 
 
 class XmlVerb(VerbExtension):
-    """Output the package xml manifest or an optional tag."""
+    """Output the package xml manifest or an specific tag."""
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(

--- a/ros2pkg/ros2pkg/verb/xml.py
+++ b/ros2pkg/ros2pkg/verb/xml.py
@@ -34,11 +34,11 @@ class XmlVerb(VerbExtension):
         arg = parser.add_argument(
             'package_name',
             help='The package name')
+        arg.completer = package_name_completer
         arg = parser.add_argument(
             '-t', '--tag',
             default='None',
             help="The package's xml's tag to print")
-        arg.completer = package_name_completer
 
     def main(self, *, args):
         try:

--- a/ros2pkg/ros2pkg/verb/xml.py
+++ b/ros2pkg/ros2pkg/verb/xml.py
@@ -23,12 +23,12 @@ from ros2pkg.verb import VerbExtension
 
 
 PACKAGE_NOT_FOUND = 'Package not found'
-PACKAGE_XML_NOT_FOUND = 'Package xml manifest not found'
+PACKAGE_XML_NOT_FOUND = 'Package XML manifest not found'
 PACKAGE_XML_TAG_NOT_FOUND = 'XML tag not found'
 
 
 class XmlVerb(VerbExtension):
-    """Output the package xml manifest or a specific tag."""
+    """Output the XML of the package manifest or a specific tag."""
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
@@ -37,7 +37,7 @@ class XmlVerb(VerbExtension):
         arg.completer = package_name_completer
         parser.add_argument(
             '-t', '--tag',
-            help="The package's xml's tag to print")
+            help="The XML tag to output (e.g. 'version')")
 
     def main(self, *, args):
         try:
@@ -53,9 +53,10 @@ class XmlVerb(VerbExtension):
         if args.tag is None:
             ET.dump(tree)
             return 0
-        else:
-            elements = tree.getroot().findall(args.tag)
-            if len(elements) == 0:
-                return PACKAGE_XML_TAG_NOT_FOUND
-            for element in elements:
-                    print(element.text)
+
+        elements = tree.getroot().findall(args.tag)
+        if not elements:
+            return PACKAGE_XML_TAG_NOT_FOUND
+
+        for element in elements:
+            print(element.text)

--- a/ros2pkg/ros2pkg/verb/xml.py
+++ b/ros2pkg/ros2pkg/verb/xml.py
@@ -23,6 +23,7 @@ from ros2pkg.verb import VerbExtension
 
 
 PACKAGE_NOT_FOUND = 'Package not found'
+PACKAGE_XML_NOT_FOUND = 'Package xml manifest not found'
 PACKAGE_XML_TAG_NOT_FOUND = 'XML tag not found'
 
 
@@ -35,23 +36,28 @@ class XmlVerb(VerbExtension):
             help='The package name')
         arg = parser.add_argument(
             '-t', '--tag',
-            default='root',
+            default='None',
             help="The package's xml's tag to print")
         arg.completer = package_name_completer
 
     def main(self, *, args):
         try:
             package_share_dir = get_package_share_directory(args.package_name)
-            package_xml = os.path.join(package_share_dir, 'package.xml')
-            if os.path.isfile(package_xml):
-                tree = ET.parse(package_xml)
-                if args.tag == 'root':
-                    ET.dump(tree)
-                    return 0
-                else:
-                    for elements in tree.getroot().findall(args.tag):
-                        print(elements.text)
-                    return 0
-                return PACKAGE_XML_TAG_NOT_FOUND
         except PackageNotFoundError:
             return PACKAGE_NOT_FOUND
+
+        package_xml = os.path.join(package_share_dir, 'package.xml')
+        if os.path.isfile(package_xml):
+            tree = ET.parse(package_xml)
+            if args.tag == 'None':
+                ET.dump(tree)
+                return 0
+            else:
+                elements = tree.getroot().findall(args.tag)
+                if len(elements) > 0:
+                    for element in elements:
+                        print(element.text)
+                else:
+                    return PACKAGE_XML_TAG_NOT_FOUND
+        else:
+            return PACKAGE_XML_NOT_FOUND

--- a/ros2pkg/ros2pkg/verb/xml.py
+++ b/ros2pkg/ros2pkg/verb/xml.py
@@ -28,7 +28,7 @@ PACKAGE_XML_TAG_NOT_FOUND = 'XML tag not found'
 
 
 class XmlVerb(VerbExtension):
-    """Output the package xml manifest or an specific tag."""
+    """Output the package xml manifest or a specific tag."""
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(

--- a/ros2pkg/setup.py
+++ b/ros2pkg/setup.py
@@ -37,6 +37,7 @@ The package provides the pkg command for the ROS 2 command line tools.""",
             'executables = ros2pkg.verb.executables:ExecutablesVerb',
             'list = ros2pkg.verb.list:ListVerb',
             'prefix = ros2pkg.verb.prefix:PrefixVerb',
+            'xml = ros2pkg.verb.xml:XmlVerb',
         ],
     },
     package_data={


### PR DESCRIPTION
Add the `xml` verb to `pkg`.  
By default it prints the whole xml manifest of a given package. User can request for a particular tag with the `--tag` option.

E.g.
```terminal
$ ros2 pkg xml demo_nodes_cpp -t version
0.7.6
$
$ ros2 pkg xml demo_nodes_cpp -t test_depend
ament_cmake_pytest
ament_lint_auto
ament_lint_common
launch
launch_testing
launch_testing_ament_cmake
launch_testing_ros
```