### PR TITLE
Expose qos durability and reliability to ros2topic echo

### DIFF
--- a/ros2topic/package.xml
+++ b/ros2topic/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -13,20 +13,28 @@
 # limitations under the License.
 
 from argparse import ArgumentTypeError
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import TypeVar
 
 import rclpy
 from rclpy.expand_topic_name import expand_topic_name
-from rclpy.qos import qos_profile_sensor_data
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
 from rclpy.validate_full_topic_name import validate_full_topic_name
 from ros2cli.node.direct import DirectNode
+from ros2topic.api import add_qos_arguments_to_argument_parser
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import import_message_type
+from ros2topic.api import qos_profile_from_short_keys
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
+MsgType = TypeVar('MsgType')
 
 
 def unsigned_int(string):
@@ -51,6 +59,8 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             'message_type', nargs='?',
             help="Type of the ROS message (e.g. 'std_msgs/String')")
+        add_qos_arguments_to_argument_parser(
+            parser, is_publisher=False, default_preset='sensor_data')
         parser.add_argument(
             '--csv', action='store_true',
             help='Output all recursive fields separated by commas (e.g. for '
@@ -80,12 +90,21 @@ def main(args):
     else:
         truncate_length = args.truncate_length if not args.full_length else None
         callback = subscriber_cb_csv(truncate_length, args.no_arr, args.no_str)
+    qos_profile = qos_profile_from_short_keys(
+        args.qos_profile, reliability=args.qos_reliability, durability=args.qos_durability)
     with DirectNode(args) as node:
         subscriber(
-            node.node, args.topic_name, args.message_type, callback)
+            node.node, args.topic_name, args.message_type, callback, qos_profile)
 
 
-def subscriber(node, topic_name, message_type, callback):
+def subscriber(
+    node: Node,
+    topic_name: str,
+    message_type: MsgType,
+    callback: Callable[[MsgType], Any],
+    qos_profile: QoSProfile
+) -> Optional[str]:
+    """Initialize a node with a single subscription and spin."""
     if message_type is None:
         topic_names_and_types = get_topic_names_and_types(node=node, include_hidden_topics=True)
         try:
@@ -112,10 +131,9 @@ def subscriber(node, topic_name, message_type, callback):
     msg_module = import_message_type(topic_name, message_type)
 
     node.create_subscription(
-        msg_module, topic_name, callback, qos_profile_sensor_data)
+        msg_module, topic_name, callback, qos_profile)
 
-    while rclpy.ok():
-        rclpy.spin_once(node)
+    rclpy.spin(node)
 
 
 def subscriber_cb(truncate_length, noarr, nostr):

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import signal
 import subprocess
 
@@ -41,6 +42,7 @@ def echo_pub_node():
     rclpy.shutdown(context=context)
 
 
+@pytest.mark.skipif(os.name == 'nt', reason='Subprocess bug in Windows Python 3.7.4')
 @pytest.mark.parametrize(
     'topic,provide_qos,compatible_qos', [
         ('/clitest/topic/pub_basic', False, True),
@@ -120,6 +122,7 @@ def test_pub_basic(echo_pub_node, topic: str, provide_qos: bool, compatible_qos:
         )
 
 
+@pytest.mark.skipif(os.name == 'nt', reason='Subprocess bug in Windows Python 3.7.4')
 @pytest.mark.parametrize(
     'topic,provide_qos,compatible_qos', [
         ('/clitest/topic/echo_basic', False, True),

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -1,0 +1,195 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import signal
+import subprocess
+
+import pytest
+
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.qos import DurabilityPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import ReliabilityPolicy
+from std_msgs.msg import String
+
+TEST_NODE = 'cli_echo_pub_test_node'
+TEST_NAMESPACE = 'cli_echo_pub'
+
+
+@pytest.fixture
+def echo_pub_node():
+    """Set up the global rclpy context and node for this test module."""
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+    node = rclpy.create_node(TEST_NODE, namespace=TEST_NAMESPACE, context=context)
+    executor = SingleThreadedExecutor(context=context)
+    executor.add_node(node)
+    yield node, executor, context
+    node.destroy_node()
+    rclpy.shutdown(context=context)
+
+
+@pytest.mark.parametrize(
+    'topic,provide_qos,compatible_qos', [
+        ('/clitest/topic/pub_basic', False, True),
+        ('/clitest/topic/pub_compatible_qos', True, True),
+        ('/clitest/topic/pub_incompatible_qos', True, False)
+    ]
+)
+def test_pub(echo_pub_node, topic: str, provide_qos: bool, compatible_qos: bool):
+    # Check for inconsistent arguments
+    assert provide_qos if not compatible_qos else True
+    node, executor, context = echo_pub_node
+    received_message_count = 0
+    expected_minimum_message_count = 1
+    expected_maximum_message_count = 5
+    future = rclpy.task.Future()
+    pub_extra_options = []
+    subscription_qos_profile = 10
+    if provide_qos:
+        if compatible_qos:
+            # For compatible test, put publisher at very high quality and subscription at low
+            pub_extra_options = [
+                '--qos-reliability', 'reliable',
+                '--qos-durability', 'transient_local']
+            subscription_qos_profile = QoSProfile(
+                depth=10,
+                reliability=ReliabilityPolicy.BEST_EFFORT,
+                durability=DurabilityPolicy.VOLATILE)
+        else:
+            # For an incompatible example, reverse the quality extremes
+            # and expect no messages to arrive
+            pub_extra_options = [
+                '--qos-reliability', 'best_effort',
+                '--qos-durability', 'volatile']
+            subscription_qos_profile = QoSProfile(
+                depth=10,
+                reliability=ReliabilityPolicy.RELIABLE,
+                durability=DurabilityPolicy.TRANSIENT_LOCAL)
+            expected_maximum_message_count = 0
+            expected_minimum_message_count = 0
+
+    process = subprocess.Popen(
+        ['ros2', 'topic', 'pub'] +
+        pub_extra_options +
+        [topic, 'std_msgs/String', 'data: hello'])
+
+    def shutdown():
+        process.send_signal(signal.SIGINT)
+        timeout_timer.cancel()
+        future.set_result(True)
+
+    def message_callback(msg):
+        """If we receive one message, the test has succeeded."""
+        nonlocal received_message_count
+        received_message_count += 1
+        shutdown()
+
+    subscription = node.create_subscription(
+        String, topic, message_callback, subscription_qos_profile)
+    assert subscription
+
+    timeout_timer = node.create_timer(3, shutdown)
+    executor.spin_until_future_complete(future)
+    try:
+        process.wait(1)
+    except subprocess.TimeoutExpired:
+        assert False, "CLI subprocess didn't shut down correctly"
+
+    # Cleanup
+    node.destroy_timer(timeout_timer)
+    node.destroy_subscription(subscription)
+
+    # Check results
+    assert (
+        received_message_count >= expected_minimum_message_count and
+        received_message_count <= expected_maximum_message_count), \
+        'Received {} messages from pub, which is not in expected range {}-{}'.format(
+            received_message_count, expected_minimum_message_count, expected_maximum_message_count
+        )
+
+
+@pytest.mark.parametrize(
+    'topic,provide_qos,compatible_qos', [
+        ('/clitest/topic/echo_basic', False, True),
+        ('/clitest/topic/echo_compatible_qos', True, True),
+        ('/clitest/topic/echo_incompatible_qos', True, False)
+    ]
+)
+def test_echo(echo_pub_node, topic: str, provide_qos: bool, compatible_qos: bool):
+    """Run a local publisher, check that `ros2 topic echo` receives at least one message."""
+    # Check for inconsistent arguments
+    assert provide_qos if not compatible_qos else True
+    node, executor, context = echo_pub_node
+    future = rclpy.task.Future()
+    echo_extra_options = []
+    publisher_qos_profile = 10
+    if provide_qos:
+        if compatible_qos:
+            # For compatible test, put publisher at very high quality and subscription at low
+            echo_extra_options = [
+                '--qos-reliability', 'best_effort',
+                '--qos-durability', 'volatile']
+            publisher_qos_profile = QoSProfile(
+                depth=10,
+                reliability=ReliabilityPolicy.RELIABLE,
+                durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        else:
+            # For an incompatible example, reverse the quality extremes
+            # and expect no messages to arrive
+            echo_extra_options = [
+                '--qos-reliability', 'reliable',
+                '--qos-durability', 'transient_local']
+            publisher_qos_profile = QoSProfile(
+                depth=10,
+                reliability=ReliabilityPolicy.BEST_EFFORT,
+                durability=DurabilityPolicy.VOLATILE)
+
+    process = subprocess.Popen(
+        ['ros2', 'topic', 'echo'] +
+        echo_extra_options +
+        [topic], stdout=subprocess.PIPE)
+
+    def shutdown():
+        process.send_signal(signal.SIGINT)
+        timeout_timer.cancel()
+        future.set_result(True)
+
+    def publish_message():
+        publisher.publish(String(data='hello'))
+
+    publisher = node.create_publisher(String, topic, publisher_qos_profile)
+    assert publisher
+
+    timeout_timer = node.create_timer(2, shutdown)
+    publish_timer = node.create_timer(0.5, publish_message)
+    executor.spin_until_future_complete(future)
+    try:
+        out, errs = process.communicate(1)
+    except subprocess.TimeoutExpired:
+        assert False, "CLI subprocess didn't shut down correctly"
+
+    # Cleanup
+    node.destroy_timer(timeout_timer)
+    node.destroy_timer(publish_timer)
+    node.destroy_publisher(publisher)
+
+    # Check results
+    if compatible_qos:
+        assert out, 'Echo CLI printed no output'
+        lines = out.decode('utf-8').split('\n')
+        assert 'data: hello' in lines, 'Echo CLI did not print expected message'
+    else:
+        assert not out, 'Echo CLI should not have received anything with incompatible QoS'

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -82,9 +82,9 @@ def test_pub_basic(echo_pub_node, topic: str, provide_qos: bool, compatible_qos:
             expected_minimum_message_count = 0
 
     process = subprocess.Popen(
-        ['ros2', 'topic', 'pub'] +
-        pub_extra_options +
-        [topic, 'std_msgs/String', 'data: hello'], stdout=subprocess.PIPE)
+        ['ros2', 'topic', 'pub'] + pub_extra_options + [topic, 'std_msgs/String', 'data: hello'],
+        stdout=subprocess.PIPE,
+        stdin=subprocess.DEVNULL)
 
     def shutdown():
         process.send_signal(signal.SIGINT)
@@ -156,9 +156,9 @@ def test_echo_basic(echo_pub_node, topic: str, provide_qos: bool, compatible_qos
                 durability=DurabilityPolicy.VOLATILE)
 
     process = subprocess.Popen(
-        ['ros2', 'topic', 'echo'] +
-        echo_extra_options +
-        [topic], stdout=subprocess.PIPE)
+        ['ros2', 'topic', 'echo'] + echo_extra_options + [topic],
+        stdout=subprocess.PIPE,
+        stdin=subprocess.DEVNULL)
 
     publisher = node.create_publisher(String, topic, publisher_qos_profile)
     assert publisher
@@ -168,7 +168,7 @@ def test_echo_basic(echo_pub_node, topic: str, provide_qos: bool, compatible_qos
 
     publish_timer = node.create_timer(0.5, publish_message)
     # The future won't complete - we will hit the timeout
-    executor.spin_until_future_complete(rclpy.task.Future(), timeout_sec=2)
+    executor.spin_until_future_complete(rclpy.task.Future(), timeout_sec=4)
     # Note it is important to send SIGINT - terminate will make the stdout unavailable
     process.send_signal(signal.SIGINT)
     try:

--- a/ros2topic/test/test_qos_conversions.py
+++ b/ros2topic/test/test_qos_conversions.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+
+from ros2topic.api import qos_profile_from_short_keys
+
+
+def test_profile_conversion():
+    profile = qos_profile_from_short_keys(
+        'sensor_data', reliability='reliable', durability='transient_local')
+    assert profile.durability == rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL
+    assert profile.reliability == rclpy.qos.QoSReliabilityPolicy.RELIABLE


### PR DESCRIPTION
Expose the same QoS settings to `ros2 topic echo` as were exposed to `ros2 topic pub` in https://github.com/ros2/ros2cli/pull/238

Fixes https://github.com/ros2/ros2cli/issues/281
Closes https://github.com/ros-security/aws-roadmap/issues/57

Blocked by #304 