### PR TITLE
Make daemon “reset” itself when the IP address changes

### DIFF
--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -9,6 +9,7 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <exec_depend>python3-netifaces</exec_depend>
   <exec_depend>python3-pkg-resources</exec_depend>
   <exec_depend>rclpy</exec_depend>
 

--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -115,7 +115,7 @@ class _DirectNode:
 
         def wrapper():
             self.reset_if_addresses_changed()
-            return self.node.__getattr__(name)
+            return self.node.__getattr__(name)()
         wrapper.__name__ = attr.__name__
 
         if inspect.ismethod(attr):

--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -145,17 +145,8 @@ class _DirectNode:
         return addresses_by_interfaces
 
     def reset_if_addresses_changed(self):
-        def have_addresses_changed(new_addresses):
-            for (kind, addresses_by_interfaces) in self.addresses_at_start.items():
-                for (interface, addr) in addresses_by_interfaces.items():
-                    try:
-                        if new_addresses[kind][interface] != addr:
-                            return True
-                    except KeyError:
-                        return True
-            return False
         new_addresses = self.interfaces_ip_addresses()
-        if have_addresses_changed(new_addresses):
+        if new_addresses != self.addresses_at_start:
             self.addresses_at_start = new_addresses
             self.node.destroy_node()
             rclpy.shutdown()

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -72,11 +72,14 @@ def spawn_daemon(args, wait_until_spawned=None):
             'Unable to get rmw_implementation_identifier, '
             'try specifying the implementation to use via the '
             "'RMW_IMPLEMENTATION' environment variable")
-    subprocess.Popen(cmd + [
+    cmd.extend([
         # the arguments are only passed for visibility in e.g. the process list
         '--rmw-implementation', rmw_implementation_identifier,
-        '--ros-domain-id', str(ros_domain_id)],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **kwargs)
+        '--ros-domain-id', str(ros_domain_id)])
+    if not args.debug:
+        kwargs['stdout'] = subprocess.DEVNULL
+        kwargs['stderr'] = subprocess.DEVNULL
+    subprocess.Popen(cmd, **kwargs)
 
     if wait_until_spawned is None:
         return True

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -42,7 +42,7 @@ def is_daemon_running(args):
     return False
 
 
-def spawn_daemon(args, wait_until_spawned=None):
+def spawn_daemon(args, wait_until_spawned=None, debug=False):
     ros_domain_id = int(os.environ.get('ROS_DOMAIN_ID', 0))
     kwargs = {}
     if platform.system() != 'Windows':
@@ -76,7 +76,7 @@ def spawn_daemon(args, wait_until_spawned=None):
         # the arguments are only passed for visibility in e.g. the process list
         '--rmw-implementation', rmw_implementation_identifier,
         '--ros-domain-id', str(ros_domain_id)])
-    if not hasattr(args, 'debug') or not args.debug:
+    if not debug:
         kwargs['stdout'] = subprocess.DEVNULL
         kwargs['stderr'] = subprocess.DEVNULL
     subprocess.Popen(cmd, **kwargs)

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -76,7 +76,7 @@ def spawn_daemon(args, wait_until_spawned=None):
         # the arguments are only passed for visibility in e.g. the process list
         '--rmw-implementation', rmw_implementation_identifier,
         '--ros-domain-id', str(ros_domain_id)])
-    if not args.debug:
+    if not hasattr(args, 'debug') or not args.debug:
         kwargs['stdout'] = subprocess.DEVNULL
         kwargs['stderr'] = subprocess.DEVNULL
     subprocess.Popen(cmd, **kwargs)

--- a/ros2cli/ros2cli/verb/daemon/start.py
+++ b/ros2cli/ros2cli/verb/daemon/start.py
@@ -22,6 +22,11 @@ from ros2cli.verb.daemon import VerbExtension
 class StartVerb(VerbExtension):
     """Start the daemon if it isn't running."""
 
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '--debug', '-d', action='store_true',
+            help='Print debug messages')
+
     def main(self, *, args):
         running = is_daemon_running(args)
         if running:

--- a/ros2cli/ros2cli/verb/daemon/start.py
+++ b/ros2cli/ros2cli/verb/daemon/start.py
@@ -33,7 +33,7 @@ class StartVerb(VerbExtension):
             print('The daemon is already running')
             return
 
-        spawned = spawn_daemon(args, wait_until_spawned=10.0)
+        spawned = spawn_daemon(args, wait_until_spawned=10.0, debug=args.debug)
         if spawned:
             print('The daemon has been started')
         else:


### PR DESCRIPTION
The problem is that when the IP address changes (e.g.: by DHCP), discovery doesn't work all the time.

This is a first proposal for solving the problem. 
I'm doing the following:
  The methods registered in the `XMLRPC` server now check if one IP has changed, and in that case the `DirectNode` used by the Daemon is reset.

When the `DirectNode` is reset, the requested method is immediately call. Maybe an `spin_time` should be added (for ensuring enough discovery time).

With "checking that one IP has changed", I'm referring to the following -> If the IP address of any interface that has a gateway has changed, the `DirectNode` is reset.

As far as I understand, it's not possible to know what interface is the `rmw` implementation using.

Python doesn't have in the standard library a package for listing network interfaces, etc (in a platform independent way).
I'm using [netifaces](https://pypi.org/project/netifaces/) for that. I don't know if we want to add a new dependency or not.
In case that we don't want to add it, I can maybe add this as an optional plugin in another package.

For trying this, you have to install netifaces: `python3 -m pip install -U netifaces`