### PR TITLE
fix rename package-format to match other flags (#290)

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -40,6 +40,7 @@ class CreateVerb(VerbExtension):
             'package_name',
             help='The package name')
         parser.add_argument(
+            '--package-format',
             '--package_format',
             type=int,
             default=3,


### PR DESCRIPTION
Renames the `package_format` flag to `package-format`, matching other flags using hyphen delimiters
Resolves #290 