### PR TITLE
Add interface proto 

### DIFF
--- a/ros2interface/package.xml
+++ b/ros2interface/package.xml
@@ -12,6 +12,7 @@
   <depend>ros2cli</depend>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2interface/ros2interface/api/__init__.py
+++ b/ros2interface/ros2interface/api/__init__.py
@@ -17,6 +17,10 @@ from ament_index_python import get_resource
 from ament_index_python import get_resources
 from ament_index_python import has_resource
 
+from rosidl_parser.definition import NamespacedType
+from rosidl_runtime_py.convert import message_to_yaml
+from rosidl_runtime_py.import_message import import_message_from_namespaced_type
+
 
 def get_all_interface_packages():
     return get_resources('rosidl_interfaces')
@@ -151,3 +155,28 @@ def get_message_path(package_name, message_name):
     # TODO(dirk-thomas) this logic should come from a rosidl related package
     return os.path.join(
         prefix_path, 'share', package_name, 'msg', message_name + '.msg')
+
+
+def get_interface_instance(package_name, interface_type, interface_name):
+    MODE_MSG = 'msg'
+    MODE_SRV = 'srv'
+    MODE_ACT = 'action'
+
+    interface = import_message_from_namespaced_type(
+        NamespacedType([package_name, interface_type], interface_name))
+
+    if (interface_type == MODE_SRV):
+        instance = interface.Request()
+    elif (interface_type == MODE_ACT):
+        instance = interface.Goal()
+    elif (interface_type == MODE_MSG):
+        instance = interface()
+    else:
+        raise RuntimeError('Unknown interface type')
+
+    return instance
+
+
+def interface_to_yaml(package_name, interface_type, interface_name):
+    instance = get_interface_instance(package_name, interface_type, interface_name)
+    return message_to_yaml(instance)

--- a/ros2interface/ros2interface/api/__init__.py
+++ b/ros2interface/ros2interface/api/__init__.py
@@ -17,9 +17,8 @@ from ament_index_python import get_resource
 from ament_index_python import get_resources
 from ament_index_python import has_resource
 
-from rosidl_parser.definition import NamespacedType
+from rosidl_runtime_py import utilities
 from rosidl_runtime_py.convert import message_to_yaml
-from rosidl_runtime_py.import_message import import_message_from_namespaced_type
 
 
 def get_all_interface_packages():
@@ -157,26 +156,13 @@ def get_message_path(package_name, message_name):
         prefix_path, 'share', package_name, 'msg', message_name + '.msg')
 
 
-def get_interface_instance(package_name, interface_type, interface_name):
-    MODE_MSG = 'msg'
-    MODE_SRV = 'srv'
-    MODE_ACT = 'action'
-
-    interface = import_message_from_namespaced_type(
-        NamespacedType([package_name, interface_type], interface_name))
-
-    if (interface_type == MODE_SRV):
-        instance = interface.Request()
-    elif (interface_type == MODE_ACT):
+def interface_to_yaml(identifier):
+    interface = utilities.get_interface(identifier)
+    if utilities.is_action(interface):
         instance = interface.Goal()
-    elif (interface_type == MODE_MSG):
-        instance = interface()
+    elif utilities.is_service(interface):
+        instance = interface.Request()
     else:
-        raise RuntimeError('Unknown interface type')
+        instance = interface()
 
-    return instance
-
-
-def interface_to_yaml(package_name, interface_type, interface_name):
-    instance = get_interface_instance(package_name, interface_type, interface_name)
     return message_to_yaml(instance)

--- a/ros2interface/ros2interface/verb/proto.py
+++ b/ros2interface/ros2interface/verb/proto.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
-
-from ros2cli.node.strategy import add_arguments
-from ros2interface.api import type_completer
 from ros2interface.api import interface_to_yaml
+from ros2interface.api import type_completer
 from ros2interface.verb import VerbExtension
 
 
@@ -33,15 +30,7 @@ class ProtoVerb(VerbExtension):
             help='if true output has no outer hyphens.')
 
     def main(self, *, args):
-        try:
-            parts = args.type.split('/')
-            package_name = parts[0]
-            interface_type = parts[1]
-            interface_name = parts[-1]
-        except LookupError as e:
-            return str(e)
-
-        yaml = interface_to_yaml(package_name, interface_type, interface_name)
+        yaml = interface_to_yaml(args.type)
 
         if args.no_hyphens is True:
             print(yaml)

--- a/ros2interface/ros2interface/verb/proto.py
+++ b/ros2interface/ros2interface/verb/proto.py
@@ -26,13 +26,13 @@ class ProtoVerb(VerbExtension):
                 help='Show an interface definition (e.g. "std_msgs/msg/String")')
         arg.completer = type_completer
         parser.add_argument(
-            '--no-hyphens', action='store_true',
-            help='if true output has no outer hyphens.')
+            '--no-quotes', action='store_true',
+            help='if true output has no outer quotes.')
 
     def main(self, *, args):
         yaml = interface_to_yaml(args.type)
 
-        if args.no_hyphens is True:
+        if args.no_quotes is True:
             print(yaml)
         else:
             print('"' + yaml + '"')

--- a/ros2interface/ros2interface/verb/proto.py
+++ b/ros2interface/ros2interface/verb/proto.py
@@ -1,0 +1,49 @@
+# Copyright 2019 Canonical Ldt.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+from ros2cli.node.strategy import add_arguments
+from ros2interface.api import type_completer
+from ros2interface.api import interface_to_yaml
+from ros2interface.verb import VerbExtension
+
+
+class ProtoVerb(VerbExtension):
+    """Output an interface prototype."""
+
+    def add_arguments(self, parser, cli_name):
+        arg = parser.add_argument(
+                'type',
+                help='Show an interface definition (e.g. "std_msgs/msg/String")')
+        arg.completer = type_completer
+        parser.add_argument(
+            '--no-hyphens', action='store_true',
+            help='if true output has no outer hyphens.')
+
+    def main(self, *, args):
+        try:
+            parts = args.type.split('/')
+            package_name = parts[0]
+            interface_type = parts[1]
+            interface_name = parts[-1]
+        except LookupError as e:
+            return str(e)
+
+        yaml = interface_to_yaml(package_name, interface_type, interface_name)
+
+        if args.no_hyphens is True:
+            print(yaml)
+        else:
+            print('"' + yaml + '"')

--- a/ros2interface/setup.py
+++ b/ros2interface/setup.py
@@ -36,6 +36,7 @@ The package provides the interface command for the ROS 2 command line tools.""",
             'list = ros2interface.verb.list:ListVerb',
             'packages = ros2interface.verb.packages:PackagesVerb',
             'package = ros2interface.verb.package:PackageVerb',
+            'proto = ros2interface.verb.proto:ProtoVerb',
             'show = ros2interface.verb.show:ShowVerb',
         ],
     }


### PR DESCRIPTION
Add `ros2 interface proto` verb.
This new verb prints a given interface prototype, e.g.

Topic : 
```terminal
$ ros2 interface proto geometry_msgs/msg/Pose
"position:
  x: 0.0
  y: 0.0
  z: 0.0
orientation:
  x: 0.0
  y: 0.0
  z: 0.0
  w: 0.0
"
```
Service : 
```terminal
$ ros2 interface proto example_interfaces/srv/AddTwoInts 
"a: 0
b: 0
"
```
Action : 
```terminal
$ ros2 interface proto example_interfaces/action/Fibonacci
"order: 0
"
```

This new verb comes handy while scripting, but the main point was to figure out the pieces to get an interface prototype completer to be used in other cli tools.

Signed-off-by: artivis <jeremie.deray@canonical.com>