### PR TITLE
Add topic pub prototype completer

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -23,6 +23,8 @@ from rclpy.topic_or_service_is_hidden import topic_or_service_is_hidden
 from rclpy.validate_full_topic_name import validate_full_topic_name
 from ros2cli.node.strategy import NodeStrategy
 from ros2msg.api import message_type_completer
+from rosidl_runtime_py.convert import message_to_yaml
+from rosidl_runtime_py.utilities import get_message
 
 
 def get_topic_names_and_types(*, node, include_hidden_topics=False):
@@ -137,3 +139,14 @@ def _get_msg_class(node, topic, include_hidden_topics):
         return None
 
     return import_message_type(topic, message_type)
+
+
+class TopicMessagePrototypeCompleter:
+    """Callable returning a message prototype."""
+
+    def __init__(self, *, topic_type_key=None):
+        self.topic_type_key = topic_type_key
+
+    def __call__(self, prefix, parsed_args, **kwargs):
+        message = get_message(getattr(parsed_args, self.topic_type_key))
+        return [message_to_yaml(message())]

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -17,6 +17,7 @@ import time
 import rclpy
 from ros2cli.node import NODE_NAME_PREFIX
 from ros2topic.api import import_message_type
+from ros2topic.api import TopicMessagePrototypeCompleter
 from ros2topic.api import TopicNameCompleter
 from ros2topic.api import TopicTypeCompleter
 from ros2topic.verb import VerbExtension
@@ -38,11 +39,13 @@ class PubVerb(VerbExtension):
             help="Type of the ROS message (e.g. 'std_msgs/String')")
         arg.completer = TopicTypeCompleter(
             topic_name_key='topic_name')
-        parser.add_argument(
+        arg = parser.add_argument(
             'values', nargs='?', default='{}',
             help='Values to fill the message with in YAML format '
                  '(e.g. "data: Hello World"), '
                  'otherwise the message will be published with default values')
+        arg.completer = TopicMessagePrototypeCompleter(
+            topic_type_key='message_type')
         parser.add_argument(
             '-r', '--rate', metavar='N', type=float, default=1.0,
             help='Publishing rate in Hz (default: 1)')


### PR DESCRIPTION
Add a message prototype completer to `ros2 topic pub`.  
E.g.
```terminal
$ ros2 topic pub /chatter geometry_msgs/msg/Pose [tab][tab]
-1
-n
--node-name
--once
-p
position:^J  x: 0.0^J  y: 0.0^J  z: 0.0^Jorientation:^J  x: 0.0^J  y: 0.0^J  z: 0.0^J  w: 0.0
--print
--qos-durability
--qos-profile
--qos-reliability
-r
--rate
```
Not very pretty but one can at least figure out the first few characters of the message body.
Then,
```terminal
$ ros2 topic pub /chatter geometry_msgs/msg/Pose "p [tab]
```
resolves to,
```terminal
ros2 topic pub /chatter geometry_msgs/msg/Pose "position:
  x: 0.0
  y: 0.0
  z: 0.0
orientation:
  x: 0.0
  y: 0.0
  z: 0.0
  w: 0.0"
```

This follows the work initiated in https://github.com/ros2/ros2cli/pull/298.

Signed-off-by: artivis <jeremie.deray@canonical.com>