### PR TITLE
Add service call prototype completer

### DIFF
--- a/ros2service/ros2service/api/__init__.py
+++ b/ros2service/ros2service/api/__init__.py
@@ -15,6 +15,8 @@
 from rclpy.topic_or_service_is_hidden import topic_or_service_is_hidden
 from ros2cli.node.strategy import NodeStrategy
 from ros2srv.api import service_type_completer
+from rosidl_runtime_py.convert import message_to_yaml
+from rosidl_runtime_py.utilities import get_service
 
 
 def get_service_names_and_types(*, node, include_hidden_services=False):
@@ -62,3 +64,14 @@ class ServiceTypeCompleter:
                     if n == service_name:
                         return t
         return service_type_completer()
+
+
+class ServicePrototypeCompleter:
+    """Callable returning a service prototype."""
+
+    def __init__(self, *, service_type_key=None):
+        self.service_type_key = service_type_key
+
+    def __call__(self, prefix, parsed_args, **kwargs):
+        service = get_service(getattr(parsed_args, self.service_type_key))
+        return [message_to_yaml(service.Request())]

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -18,6 +18,7 @@ import time
 import rclpy
 from ros2cli.node import NODE_NAME_PREFIX
 from ros2service.api import ServiceNameCompleter
+from ros2service.api import ServicePrototypeCompleter
 from ros2service.api import ServiceTypeCompleter
 from ros2service.verb import VerbExtension
 from rosidl_runtime_py import set_message_fields
@@ -38,11 +39,13 @@ class CallVerb(VerbExtension):
             help="Type of the ROS service (e.g. 'std_srvs/srv/Empty')")
         arg.completer = ServiceTypeCompleter(
             service_name_key='service_name')
-        parser.add_argument(
+        arg = parser.add_argument(
             'values', nargs='?', default='{}',
             help='Values to fill the service request with in YAML format ' +
                  '(e.g. "{a: 1, b: 2}"), ' +
                  'otherwise the service request will be published with default values')
+        arg.completer = ServicePrototypeCompleter(
+            service_type_key='service_type')
         parser.add_argument(
             '-r', '--rate', metavar='N', type=float,
             help='Repeat the call at a specific rate in Hz')


### PR DESCRIPTION
Add a service request prototype completer to `ros2 service call`.  
E.g.
```terminal
$ ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts [tab][tab]
a:\ 0\^Jb:\ 0\  -r              --rate
```
Not very pretty but one can at least figure out the first few characters of the request body.
Then,
```terminal
$ ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "a [tab]
```
resolves to,
```terminal
ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "a: 0
b: 0"
```

This follows the work initiated in https://github.com/ros2/ros2cli/pull/298.

Signed-off-by: artivis <jeremie.deray@canonical.com>