### PR TITLE
Add action send_goal prototype completer

### DIFF
--- a/ros2action/ros2action/api/__init__.py
+++ b/ros2action/ros2action/api/__init__.py
@@ -22,6 +22,8 @@ import rclpy.action
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.validate_full_topic_name import validate_full_topic_name
 from ros2cli.node.direct import DirectNode
+from rosidl_runtime_py.convert import message_to_yaml
+from rosidl_runtime_py.utilities import get_action
 
 
 def _is_action_status_topic(topic_name, action_name):
@@ -139,3 +141,14 @@ class ActionTypeCompleter:
                 if n == action_name:
                     return t
         return []
+
+
+class ActionGoalPrototypeCompleter:
+    """Callable returning an action goal prototype."""
+
+    def __init__(self, *, action_type_key=None):
+        self.action_type_key = action_type_key
+
+    def __call__(self, prefix, parsed_args, **kwargs):
+        action = get_action(getattr(parsed_args, self.action_type_key))
+        return [message_to_yaml(action.Goal())]

--- a/ros2action/ros2action/verb/send_goal.py
+++ b/ros2action/ros2action/verb/send_goal.py
@@ -18,6 +18,7 @@ from action_msgs.msg import GoalStatus
 import rclpy
 from rclpy.action import ActionClient
 from ros2action.api import action_name_completer
+from ros2action.api import ActionGoalPrototypeCompleter
 from ros2action.api import ActionTypeCompleter
 from ros2action.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
@@ -39,9 +40,10 @@ class SendGoalVerb(VerbExtension):
             'action_type',
             help="Type of the ROS action (e.g. 'example_interfaces/action/Fibonacci')")
         arg.completer = ActionTypeCompleter(action_name_key='action_name')
-        parser.add_argument(
+        arg = parser.add_argument(
             'goal',
             help="Goal request values in YAML format (e.g. '{order: 10}')")
+        arg.completer = ActionGoalPrototypeCompleter(action_type_key='action_type')
         parser.add_argument(
             '-f', '--feedback', action='store_true',
             help='Echo feedback messages for the goal')


### PR DESCRIPTION
Add an action goal prototype completer to `ros2 action send_goal`.  
E.g.
```terminal
$ ros2 action send_goal /fibonacci action_tutorials/action/Fibonacci [tab][tab]
-f          --feedback  order:\ 0\ 
```
Not very pretty but one can at least figure out the first few characters of the goal body.
Then,
```terminal
$ ros2 action send_goal /fibonacci action_tutorials/action/Fibonacci "o [tab]
```
resolves to,
```terminal
$ ros2 action send_goal /fibonacci action_tutorials/action/Fibonacci "order: 0"
```

This follows the work initiated in https://github.com/ros2/ros2cli/pull/298.

Signed-off-by: artivis <jeremie.deray@canonical.com>