### PR TITLE
Alphasort ros2 node list output.

### DIFF
--- a/ros2node/ros2node/verb/list.py
+++ b/ros2node/ros2node/verb/list.py
@@ -37,4 +37,4 @@ class ListVerb(VerbExtension):
         if args.count_nodes:
             print(len(node_names))
         elif node_names:
-            print(*[n.full_name for n in node_names], sep='\n')
+            print(*sorted(n.full_name for n in node_names), sep='\n')


### PR DESCRIPTION
For node name order to be deterministic. Connected to #304.