### PR TITLE
ros2param: consider automatic declaration for 'use_sim_time'

### DIFF
--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -39,6 +39,7 @@ test_node:
       str_param: foo
     int_param: 42
     str_param: Hello World
+    use_sim_time: false
 """
 
 


### PR DESCRIPTION
Connected to https://github.com/ros2/rclpy/pull/396; this fix is needed for CI to pass.

Signed-off-by: Juan Ignacio Ubeira <jubeira@ekumenlabs.com>