### PR TITLE
Convert list comprehension to generator

### DIFF
--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -40,7 +40,7 @@ class InfoVerb(VerbExtension):
     def main(self, *, args):
         with NodeStrategy(args) as node:
             node_names = get_node_names(node=node, include_hidden_nodes=True)
-        if args.node_name in [n.full_name for n in node_names]:
+        if args.node_name in (n.full_name for n in node_names):
             with DirectNode(args) as node:
                 print(args.node_name)
                 subscribers = get_subscriber_info(node=node, remote_node_name=args.node_name)


### PR DESCRIPTION
Addresses flake8 C412 errors introduced by flake8-comprehension 2.2.0

https://github.com/adamchainz/flake8-comprehensions/blob/master/README.rst#c412-unnecessary-list-comprehension---in-can-take-a-generator

See ros2/build_cop#228

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7867)](http://ci.ros2.org/job/ci_linux/7867/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3928)](http://ci.ros2.org/job/ci_linux-aarch64/3928/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6420)](http://ci.ros2.org/job/ci_osx/6420/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7727)](http://ci.ros2.org/job/ci_windows/7727/)