### PR TITLE
Change action_tutorials_py for action_tutorials_cpp

### DIFF
--- a/test_ros2cli/package.xml
+++ b/test_ros2cli/package.xml
@@ -10,7 +10,7 @@
   <license>Apache License 2.0</license>
 
   <test_depend>action_tutorials_interfaces</test_depend>
-  <test_depend>action_tutorials_py</test_depend>
+  <test_depend>action_tutorials_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ros_testing</test_depend>

--- a/test_ros2cli/test/config_ros2action_test.py
+++ b/test_ros2cli/test/config_ros2action_test.py
@@ -26,7 +26,7 @@ from test_config import TestConfig  # noqa
 
 def get_action_server_node_action():
     return Node(
-        package='action_tutorials_py',
+        package='action_tutorials_cpp',
         node_executable='fibonacci_action_server',
         sigterm_timeout=LaunchConfiguration('sigterm_timeout', default=30)
     )


### PR DESCRIPTION
Fixes https://github.com/ros2/ros2cli/issues/313.

For a reason I don't understand, after we split `action_tutorials` in `action_tutorials_py` and `action_tutorials_interfaces`, launch_testing can't kill `fibonacci_action_server` and the test fails (before we were installing a script and running it with `python ...`. Now we are installing it using console scripts entry points, that already installs an executable).
I switched to `action_tutorials_cpp` executable and it works well now.

I will dig in the real problem later, this is just for having green CI.