### PR TITLE
Isolate the ROS_DOMAIN_ID when running ros2component tests

### DIFF
--- a/ros2component/package.xml
+++ b/ros2component/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>domain_coordinator</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/ros2component/test/test_api.py
+++ b/ros2component/test/test_api.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from domain_coordinator import get_coordinated_domain_id
+
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import NodeStrategy
 
@@ -19,6 +23,10 @@ from ros2component.api import find_container_node_names
 from ros2component.api import get_package_component_types
 
 from ros2node.api import get_node_names
+
+
+domain_id = get_coordinated_domain_id()  # Must keep this as a local to keep it alive
+os.environ['ROS_DOMAIN_ID'] = str(domain_id)
 
 
 def test_find_container_node_names():


### PR DESCRIPTION
This should address much of the flakiness we're seeing with this test on
the CI farm.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7995)](http://ci.ros2.org/job/ci_linux/7995/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4013)](http://ci.ros2.org/job/ci_linux-aarch64/4013/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6511)](http://ci.ros2.org/job/ci_osx/6511/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7844)](http://ci.ros2.org/job/ci_windows/7844/)