### PR TITLE
Handle find_container_node_names error

### DIFF
--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -201,7 +201,10 @@ def find_container_node_names(*, node, node_names):
     """
     container_node_names = []
     for n in node_names:
-        services = get_service_info(node=node, remote_node_name=n.full_name)
+        try:
+            services = get_service_info(node=node, remote_node_name=n.full_name)
+        except RuntimeError:
+            continue
         if not any(s.name.endswith('_container/load_node') and
                    'composition_interfaces/srv/LoadNode' in s.types
                    for s in services):

--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -203,7 +203,7 @@ def find_container_node_names(*, node, node_names):
     for n in node_names:
         try:
             services = get_service_info(node=node, remote_node_name=n.full_name)
-        except rclpy.NodeNameNonExistentError:
+        except rclpy.node.NodeNameNonExistentError:
             continue
         if not any(s.name.endswith('_container/load_node') and
                    'composition_interfaces/srv/LoadNode' in s.types

--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -203,7 +203,7 @@ def find_container_node_names(*, node, node_names):
     for n in node_names:
         try:
             services = get_service_info(node=node, remote_node_name=n.full_name)
-        except RuntimeError:
+        except rclpy.NodeNameNonExistentError:
             continue
         if not any(s.name.endswith('_container/load_node') and
                    'composition_interfaces/srv/LoadNode' in s.types


### PR DESCRIPTION
Fix #321.

There is a raise condition, as I described [here](https://github.com/ros2/ros2cli/issues/321#issuecomment-524834399).

The error I'm catching comes from here:
https://github.com/ros2/rclpy/blob/8da91cee54b68f1108ca017da885496ffb5ae16c/rclpy/src/rclpy/_rclpy.c#L3137-L3146

The problem is that I can be also hiding some other errors by doing this.
`rcl_get_service_names_and_types_by_node` is a wrapper of `rmw_get_service_names_and_types_by_node`.
`rmw_get_service_names_and_types_by_node` can fail not only because the node name wan't found, but also because allocation problems, etc (it depends on the rmw implementation); and I don't have a way to identify the error above from `rclpy` or above layers.

Ideally, the best way of solving this would be to list the services of all nodes, using:
https://github.com/ros2/ros2cli/blob/9f2854465ee704ee9b6c58c91c286fef5939f411/ros2service/ros2service/api/__init__.py#L22-L28

And then recognize the node that was hosting the service from the fully qualified service name.
This won't be possible until we go ahead with https://github.com/ros2/design/pull/241.
There is currently ambiguity:
`/asd/bsd/_container/load_node`
Can be a node with `ns=/asd` `name=bsd` and the service name is `_container/load_node`.
Or it can be: `ns=/` `name=asd` and service name is `bsd/_container/load_name` (an unusual choice).

Seeing the four places than `find_container_node_names` is used ([1](https://github.com/ros2/ros2cli/blob/9f2854465ee704ee9b6c58c91c286fef5939f411/ros2component/ros2component/verb/list.py#L40-L46), [2](https://github.com/ros2/ros2cli/blob/9f2854465ee704ee9b6c58c91c286fef5939f411/ros2component/ros2component/verb/load.py#L44-L49), [3](https://github.com/ros2/ros2cli/blob/9f2854465ee704ee9b6c58c91c286fef5939f411/ros2component/ros2component/verb/unload.py#L44-L49), [4](https://github.com/ros2/ros2cli/blob/9f2854465ee704ee9b6c58c91c286fef5939f411/ros2component/ros2component/api/__init__.py#L226-L235)), I prefer hiding some unusual errors (bad allocations, etc) to avoid the race condition (which is a frequent error). The only result is that a node container is not found and skipped (when any error occurs).