### PR TITLE
removing ifcfg_vendor

### DIFF
--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -8,8 +8,7 @@
   <license>Apache License 2.0</license>
 
   <depend>ros2cli</depend>
-
-  <exec_depend>ifcfg_vendor</exec_depend>
+  
   <exec_depend>python3-rosdistro-modules</exec_depend>
   
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Removing ifcfg_vendor from build dependency to prevent breaking master build. Will add it later for the `network` check after a `.deb` package is ready.