### PR TITLE
Update report feature with new argument, add temp fix for ifcfg module 

### DIFF
--- a/ros2doctor/README.md
+++ b/ros2doctor/README.md
@@ -1,0 +1,30 @@
+# ros2doctor
+
+This folder contains the source code for ros2doctor.
+It is one of the ROS 2 command line interface tools included with a standard install of any ROS 2 distro.
+`ros2doctor` is similar to `roswtf` from ROS 1.
+It will examine your ROS 2 setup, such as distribution, platform, network interface, etc., and look for potential issues in a running ROS 2 system.
+
+## Usage
+
+Run `ros2 doctor` or `ros2 wtf`(alias) to conduct checks.
+
+Run `ros2 doctor -h/--help` to print all available command extensions.
+
+Run `ros2 doctor -r/--report` to see details of checks.
+
+## Add New Checks
+
+To add your own checks or information to report, use [Python entry points](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points) to add modules to `setup.py`. See example below:
+
+```python
+    entry_points={
+        'ros2doctor.checks': [
+            'check_platform = ros2doctor.api.platform:check_platform',
+        ],
+        'ros2doctor.report': [
+            'report_platform = ros2doctor.api.platform:print_platform_info',
+            'report_ros_distro = ros2doctor.api.platform:print_ros2_info',
+        ],
+    }
+```

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -9,7 +9,6 @@
 
   <depend>ros2cli</depend>
 
-  <exec_depend>ifcfg_vendor</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
   
   <test_depend>ament_copyright</test_depend>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -9,7 +9,7 @@
 
   <depend>ros2cli</depend>
 
-  <exec_depend>python3-ifcfg</exec_depend>
+  <exec_depend>ifcfg-pip</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
   
   <test_depend>ament_copyright</test_depend>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -9,7 +9,7 @@
 
   <depend>ros2cli</depend>
 
-  <exec_depend>ifcfg-pip</exec_depend>
+  <exec_depend>ifcfg_vendor</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
   
   <test_depend>ament_copyright</test_depend>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -9,7 +9,7 @@
 
   <depend>ros2cli</depend>
 
-  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-ifcfg</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
   
   <test_depend>ament_copyright</test_depend>

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -77,7 +77,6 @@ def run_checks() -> Tuple[Set[str], int, int]:
             result = check_class.check()
         except ValueError:
             doctor_warn('Check class from %s failed to load.' % check_entry_pt.name)
-            pass
         if result is False:
             fail += 1
             failed_cats.add(cat)
@@ -99,7 +98,6 @@ def generate_reports(*, categories=None) -> List[Report]:
             report = report_class.report()
         except ValueError:
             doctor_warn('Report class from %s failed to load.' % report_entry_pt.name)
-            pass
         if categories:
             if report_category in categories:
                 reports.append(report)

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -94,13 +94,13 @@ def generate_reports(*, categories=None) -> List[Report]:
     reports = []
     for report_entry_pt in iter_entry_points('ros2doctor.report'):
         report_class = report_entry_pt.load()()
+        try:
+            report_category = report_class.category()
+            report = report_class.report()
+        except ValueError:
+            doctor_warn('Report class failed to load.')
+            pass
         if categories:
-            try:
-                report_category = report_class.category()
-                report = report_class.report()
-            except ValueError:
-                doctor_warn('Report class failed to load.')
-                pass
             if report_category in categories:
                 reports.append(report)
         else:

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pkg_resources import iter_entry_points
 from typing import List
 from typing import Set
 from typing import Tuple
-import warnings
+
+from pkg_resources import iter_entry_points
 
 from ros2doctor.api.format import doctor_warn
 
@@ -25,15 +25,11 @@ class DoctorCheck:
     """Abstract base class of ros2doctor check."""
 
     def category(self) -> str:
-        """
-        :return: string linking checks and reports
-        """
+        """:return: string linking checks and reports."""
         raise NotImplementedError
 
     def check(self) -> bool:
-        """
-        :return: boolean indicating result of checks
-        """
+        """:return: boolean indicating result of checks."""
         raise NotImplementedError
 
 
@@ -41,15 +37,11 @@ class DoctorReport:
     """Abstract base class of ros2doctor report."""
 
     def category(self) -> str:
-        """
-        :return: string linking checks and reports
-        """
+        """:return: string linking checks and reports."""
         raise NotImplementedError
 
     def report(self) -> 'Report':  # using str as wrapper for custom class Report
-        """
-        :return: Report object storing report content
-        """
+        """:return: Report object storing report content."""
         raise NotImplementedError
 
 
@@ -71,6 +63,7 @@ class Report:
 def run_checks() -> Tuple[Set[str], int, int]:
     """
     Run all checks and return check results.
+
     :return: 3-tuple (categories of failed checks, number of failed checks,
              total number of checks)
     """
@@ -95,6 +88,7 @@ def run_checks() -> Tuple[Set[str], int, int]:
 def generate_reports(*, categories=None) -> List[Report]:
     """
     Print all reports or reports of failed checks to terminal.
+
     :return: list of Report objects
     """
     reports = []

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -41,7 +41,9 @@ class DoctorReport:
 
 class Report:
     """Contains report name and content."""
+
     __slots__ = ['name', 'items']
+
     def __init__(self, name):
         self.name = name
         self.items = []

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -18,14 +18,15 @@ from pkg_resources import iter_entry_points
 def run_checks():
     """Run all checks when `ros2 doctor/wtf` is called."""
     all_results = []
-    failed_names = []
+    failed_checks = []
+    failed_modules = []
     for check in iter_entry_points('ros2doctor.checks'):
         result = check.load()()  # load() returns method
         all_results.append(result)
-        print(check.module_name)
         if result is False:
-            failed_names.append(check.module_name)
-    return all_results, failed_names
+            failed_checks.append(check.name)
+            failed_modules.append(check.module_name)
+    return all_results, failed_checks, failed_modules
 
 
 def generate_report():

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -16,8 +16,13 @@ from pkg_resources import iter_entry_points
 
 
 class DoctorCheck:
+    """
+        Abstract based class of ros2doctor check modules.
+        category method returns a string that includes the module name.
+        check method returns a boolean value based on check result.
+    """
 
-    def target(self):
+    def category(self):
         raise NotImplementedError
 
     def check(self):
@@ -25,8 +30,13 @@ class DoctorCheck:
 
 
 class DoctorReport:
+    """
+        Abstract based class of ros2doctor report modules.
+        category method returns a string that includes the module name.
+        report method returns a Report instance that contains report content. 
+    """
 
-    def target(self):
+    def category(self):
         raise NotImplementedError
 
     def report(self):
@@ -34,6 +44,7 @@ class DoctorReport:
 
 
 class Report:
+    """Contains report name and content."""
 
     def __init__(self):
         self.name = None
@@ -44,26 +55,25 @@ class Report:
 
 
 def run_checks():
-    """Run all checks when `ros2 doctor/wtf` is called."""
-    all_results = []
-    failed_checks = []
-    failed_modules = []
-    for check in iter_entry_points('ros2doctor.checks'):
-        result = check.load()()  # load() returns method
-        all_results.append(result)
-        if result is False:
-            failed_checks.append(check.name)
-            failed_modules.append(check.module_name)
-    return all_results, failed_checks, failed_modules
+    """
+        Run all checks and return check results.
+        Return: list of tuple (string, boolean) => (category, check result)
+    """
+    results = []
+    for check_entry_pt in iter_entry_points('ros2doctor.checks'):
+        check_class = check_entry_pt.load()
+        results.append((check_class.category(), check_class.check()))
+    return results
 
 
 def generate_report():
-    """Print report to terminal when `-r/--report` is attached."""
-    report = {}
-    for r in iter_entry_points('ros2doctor.report'):
-        if r.module_name in report:
-            report[r.module_name].extend(r.load()())
-        else:
-            report[r.module_name] = r.load()()  # load() returns method
-    return report
+    """
+        Print report to terminal.
+        Return:list of tuple (string, list of tuple) => (category, report items)
+    """
+    reports = []
+    for report_entry_pt in iter_entry_points('ros2doctor.report'):
+        report_class = report_entry_pt.load()
+        reports.append((report_class.category(), report_class.report()))
+    return reports
 

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -17,9 +17,10 @@ from pkg_resources import iter_entry_points
 
 class DoctorCheck:
     """
-        Abstract based class of ros2doctor check modules.
-        category method returns a string that includes the module name.
-        check method returns a boolean value based on check result.
+    Abstract based class of ros2doctor check modules.
+
+    category method returns a string that includes the module name.
+    check method returns a boolean value based on check result.
     """
 
     def category(self):
@@ -31,9 +32,10 @@ class DoctorCheck:
 
 class DoctorReport:
     """
-        Abstract based class of ros2doctor report modules.
-        category method returns a string that includes the module name.
-        report method returns a Report instance that contains report content. 
+    Abstract based class of ros2doctor report modules.
+
+    category method returns a string that includes the module name.
+    report method returns a Report instance that contains report content.
     """
 
     def category(self):
@@ -46,34 +48,35 @@ class DoctorReport:
 class Report:
     """Contains report name and content."""
 
-    def __init__(self):
-        self.name = None
+    def __init__(self, name):
+        self.name = name
         self.items = []
 
-    def add_to_report(item_name, item_info):
+    def add_to_report(self, item_name, item_info):
         self.items.append((item_name, item_info))
 
 
 def run_checks():
     """
-        Run all checks and return check results.
-        Return: list of tuple (string, boolean) => (category, check result)
+    Run all checks and return check results.
+
+    Return: list of tuple (string, boolean) => (category, check result)
     """
     results = []
     for check_entry_pt in iter_entry_points('ros2doctor.checks'):
-        check_class = check_entry_pt.load()
+        check_class = check_entry_pt.load()()
         results.append((check_class.category(), check_class.check()))
     return results
 
 
 def generate_report():
     """
-        Print report to terminal.
-        Return:list of tuple (string, list of tuple) => (category, report items)
+    Print report to terminal.
+
+    Return:list of tuple (string, list of tuple) => (category, report items)
     """
     reports = []
     for report_entry_pt in iter_entry_points('ros2doctor.report'):
-        report_class = report_entry_pt.load()
+        report_class = report_entry_pt.load()()
         reports.append((report_class.category(), report_class.report()))
     return reports
-

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -16,38 +16,32 @@ from pkg_resources import iter_entry_points
 
 
 class DoctorCheck:
-    """
-    Abstract based class of ros2doctor check modules.
-
-    category method returns a string that includes the module name.
-    check method returns a boolean value based on check result.
-    """
+    """Abstract base class of ros2doctor check."""
 
     def category(self):
+        """Return: string linking checks and reports."""
         raise NotImplementedError
 
     def check(self):
+        """Return: boolean indicating result of checks."""
         raise NotImplementedError
 
 
 class DoctorReport:
-    """
-    Abstract based class of ros2doctor report modules.
-
-    category method returns a string that includes the module name.
-    report method returns a Report instance that contains report content.
-    """
+    """Abstract base class of ros2doctor report."""
 
     def category(self):
+        """Return: a string linking checks and reports."""
         raise NotImplementedError
 
     def report(self):
+        """Return: a Report object containing report content."""
         raise NotImplementedError
 
 
 class Report:
     """Contains report name and content."""
-
+    __slots__ = ['name', 'items']
     def __init__(self, name):
         self.name = name
         self.items = []
@@ -73,7 +67,7 @@ def generate_report():
     """
     Print report to terminal.
 
-    Return:list of tuple (string, list of tuple) => (category, report items)
+    Return: list of tuple (string, list of tuple) => (category, report items)
     """
     reports = []
     for report_entry_pt in iter_entry_points('ros2doctor.report'):

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -28,9 +28,12 @@ def run_checks():
     return all_results, failed_names
 
 
-def generate_report(names, report):
+def generate_report():
     """Print report to terminal when `-r/--report` is attached."""
     report = {}
     for r in iter_entry_points('ros2doctor.report'):
-        report[r.module_name] = r.load()()  # load() returns method
+        if r.module_name in report:
+            report[r.module_name].extend(r.load()())
+        else:
+            report[r.module_name] = r.load()()  # load() returns method
     return report

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -72,28 +72,18 @@ def run_checks():
     return failed_cats, fail, total
 
 
-def generate_all_reports():
+def generate_reports(*, cats=None):
     """
-    Print all reports to terminal.
+    Print all reports or reports of failed checks to terminal.
 
     Return: list of Report objects
     """
     reports = []
     for report_entry_pt in iter_entry_points('ros2doctor.report'):
         report_class = report_entry_pt.load()()
-        reports.append(report_class.report())
-    return reports
-
-
-def generate_fail_reports(failed_cats):
-    """
-    Print reports of failed checks to terminal.
-
-    Return: list of Report objects
-    """
-    reports = []
-    for report_entry_pt in iter_entry_points('ros2doctor.report'):
-        report_class = report_entry_pt.load()()
-        if report_class.category() in failed_cats:
+        if cats:
+            if report_class.category() in cats:
+                reports.append(report_class.report())
+        else:
             reports.append(report_class.report())
     return reports

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -76,7 +76,7 @@ def run_checks() -> Tuple[Set[str], int, int]:
             cat = check_class.category()
             result = check_class.check()
         except ValueError:
-            doctor_warn('Check class failed to load.')
+            doctor_warn('Check class from %s failed to load.' % check_entry_pt.name)
             pass
         if result is False:
             fail += 1
@@ -98,7 +98,7 @@ def generate_reports(*, categories=None) -> List[Report]:
             report_category = report_class.category()
             report = report_class.report()
         except ValueError:
-            doctor_warn('Report class failed to load.')
+            doctor_warn('Report class from %s failed to load.' % report_entry_pt.name)
             pass
         if categories:
             if report_category in categories:

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -18,6 +18,8 @@ from typing import Set
 from typing import Tuple
 import warnings
 
+from ros2doctor.api.format import doctor_warn
+
 
 class DoctorCheck:
     """Abstract base class of ros2doctor check."""
@@ -44,7 +46,7 @@ class DoctorReport:
         """
         raise NotImplementedError
 
-    def report(self) -> 'Report':  # can't refer to class not defined, using str as wrapper
+    def report(self) -> 'Report':  # using str as wrapper for custom class Report
         """
         :return: Report object storing report content
         """
@@ -79,7 +81,7 @@ def run_checks() -> Tuple[Set[str], int, int]:
         try:
             check_class = check_entry_pt.load()()
         except ValueError:
-            warnings.warn('Entry point load error.')
+            doctor_warn('Failed to load entry point %s \n' % check_entry_pt.name)
             pass
         cat = check_class.category()
         result = check_class.check()
@@ -100,9 +102,9 @@ def generate_reports(*, categories=None) -> List[Report]:
         try:
             report_class = report_entry_pt.load()()
         except ValueError:
-            warnings.warn('Entry point load error.')
+            doctor_warn('Failed to load entry point %s \n' % report_entry_pt.name)
             pass
-        if cats:
+        if categories:
             if report_class.category() in categories:
                 reports.append(report_class.report())
         else:

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -58,7 +58,7 @@ def run_checks():
 
     Return: list of String, Int, Int
     """
-    failed_cats = []
+    failed_cats = set()  # remove repeating elements
     fail = 0
     total = 0
     for check_entry_pt in iter_entry_points('ros2doctor.checks'):
@@ -67,8 +67,7 @@ def run_checks():
         result = check_class.check()
         if result is False:
             fail += 1
-            if cat not in failed_cats:
-                failed_cats.append(cat)
+            failed_cats.add(cat)
         total += 1
     return failed_cats, fail, total
 

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -28,9 +28,9 @@ def run_checks():
     return all_results, failed_names
 
 
-def generate_report():
+def generate_report(names, report):
     """Print report to terminal when `-r/--report` is attached."""
-    modules = {}
-    for report in iter_entry_points('ros2doctor.report'):
-        modules[report.module_name] = report.load()()  # load() returns method
-    return modules
+    report = {}
+    for r in iter_entry_points('ros2doctor.report'):
+        report[r.module_name] = r.load()()  # load() returns method
+    return report

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -22,12 +22,15 @@ def run_checks():
     for check in iter_entry_points('ros2doctor.checks'):
         result = check.load()()  # load() returns method
         all_results.append(result)
+        print(check.module_name)
         if result is False:
-            failed_names.append(check.name)
+            failed_names.append(check.module_name)
     return all_results, failed_names
 
 
 def generate_report():
     """Print report to terminal when `-r/--report` is attached."""
+    modules = {}
     for report in iter_entry_points('ros2doctor.report'):
-        report.load()()  # load() returns method
+        modules[report.module_name] = report.load()()  # load() returns method
+    return modules

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -17,6 +17,7 @@ from typing import Set
 from typing import Tuple
 
 from pkg_resources import iter_entry_points
+from pkg_resources import UnknownExtra
 
 from ros2doctor.api.format import doctor_warn
 
@@ -73,16 +74,16 @@ def run_checks() -> Tuple[Set[str], int, int]:
     for check_entry_pt in iter_entry_points('ros2doctor.checks'):
         try:
             check_class = check_entry_pt.load()
-        except ValueError:
+        except (ImportError, UnknownExtra):
             doctor_warn('Check entry point %s fails to load.' % check_entry_pt.name)
         try:
             check_instance = check_class()
-        except ValueError:
+        except Exception:
             doctor_warn('Unable to instantiate check object from %s.' % check_entry_pt.name)
         try:
             check_category = check_instance.category()
             result = check_instance.check()
-        except ValueError:
+        except Exception:
             doctor_warn('Fail to call %s class functions.' % check_entry_pt.name)
         if result is False:
             fail += 1
@@ -101,16 +102,16 @@ def generate_reports(*, categories=None) -> List[Report]:
     for report_entry_pt in iter_entry_points('ros2doctor.report'):
         try:
             report_class = report_entry_pt.load()
-        except ValueError:
+        except (ImportError, UnknownExtra):
             doctor_warn('Report entry point %s fails to load.' % report_entry_pt.name)
         try:
             report_instance = report_class()
-        except ValueError:
+        except Exception:
             doctor_warn('Unable to instantiate report object from %s.' % report_entry_pt.name)
         try:
             report_category = report_instance.category()
             report = report_instance.report()
-        except ValueError:
+        except Exception:
             doctor_warn('Fail to call %s class functions.' % report_entry_pt.name)
         if categories:
             if report_category in categories:

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -15,6 +15,34 @@
 from pkg_resources import iter_entry_points
 
 
+class DoctorCheck:
+
+    def target(self):
+        raise NotImplementedError
+
+    def check(self):
+        raise NotImplementedError
+
+
+class DoctorReport:
+
+    def target(self):
+        raise NotImplementedError
+
+    def report(self):
+        raise NotImplementedError
+
+
+class Report:
+
+    def __init__(self):
+        self.name = None
+        self.items = []
+
+    def add_to_report(item_name, item_info):
+        self.items.append((item_name, item_info))
+
+
 def run_checks():
     """Run all checks when `ros2 doctor/wtf` is called."""
     all_results = []
@@ -38,3 +66,4 @@ def generate_report():
         else:
             report[r.module_name] = r.load()()  # load() returns method
     return report
+

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from typing import List
 from typing import Tuple
-import sys
 import warnings
 
 
-def format_print(report: 'Report') -> None:  # using str as wrapper for custom class Report
+def format_print(report):
     """
     Format print report content.
+
     :param report: Report object with name and items list
     """
     # temp fix for missing ifcfg
@@ -28,7 +29,7 @@ def format_print(report: 'Report') -> None:  # using str as wrapper for custom c
         sys.stderr.write('No report found. Skip print...\n')
         return
 
-    print('\n', report.name)
+    print('\n ', report.name)
     padding_num = compute_padding(report.items)
     for item_name, item_content in report.items:
         print('{:{padding}}: {}'.format(item_name, item_content, padding=padding_num))
@@ -37,6 +38,7 @@ def format_print(report: 'Report') -> None:  # using str as wrapper for custom c
 def compute_padding(report_items: List[Tuple[str, str]]) -> int:
     """
     Compute padding based on report content.
+
     :param report_items: list of item name and item content tuple
     :return: padding number
     """
@@ -59,13 +61,21 @@ class CustomWarningFormat:
         self._default_format = warnings.formatwarning
         warnings.formatwarning = custom_warning_format
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, t, v, trb):
+        """
+        Define exit action for context manager.
+
+        :param t: type
+        :param v: value
+        :param trb: traceback
+        """
         warnings.formatwarning = self._default_format
 
 
 def doctor_warn(msg: str) -> None:
     """
     Use CustomWarningFormat to print customized warning message.
+
     :param msg: warning message to be printed
     """
     with CustomWarningFormat():

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -15,12 +15,12 @@
 import sys
 
 
-def format_print(names, report):
+def format_print(modules, report):
     """Format print report according to module names."""
-    padding_num = compute_padding(names, report)
-    for n in names:
-        if n in report:
-            module_report = report.get(n)
+    padding_num = compute_padding(modules, report)
+    for m in modules:
+        if m in report:
+            module_report = report.get(m)
             for k, v in module_report:
                 if k == 'NAME':
                     print(v)
@@ -31,14 +31,14 @@ def format_print(names, report):
             sys.stderr.write('WARNING: No report available for this check.')
 
 
-def compute_padding(names, report):
+def compute_padding(modules, report):
     """Compute padding based on report content."""
     padding = 8
-    for n in names:
-        if n in report:
-            module_report = report.get(n)
-            item_names = list(zip(*module_report))[0]
-            max_len = len(max(item_names, key=len))
+    for m in modules:
+        if m in report:
+            module_report = report.get(m)
+            check_items = list(zip(*module_report))[0]  # get first elements of tuples
+            max_len = len(max(check_items, key=len))  # find the longest string
             if max_len >= padding:
-                padding = max_len + 4
+                padding = max_len + 4  # padding number is longest string length + 4
     return padding

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
+from typing import Tuple
 import sys
 
 
-def format_print(report):
-    """Format print report content."""
+def format_print(report: Report) -> None:
+    """
+    Format print report content.
+    :param report: Report object with name and items list
+    """
     # temp fix for missing ifcfg
     if report is None:
-        sys.stderr.write('No report found. Skip print...')
+        sys.stderr.write('No report found. Skip print...\n')
         return
 
     print('\n', report.name)
@@ -28,8 +33,12 @@ def format_print(report):
         print('{:{padding}}: {}'.format(item_name, item_content, padding=padding_num))
 
 
-def compute_padding(report_items):
-    """Compute padding based on report content."""
+def compute_padding(report_items: List[Tuple[str, str]]) -> int:
+    """
+    Compute padding based on report content.
+    :param report_items: list of item name and item content tuple
+    :return: padding number
+    """
     padding = 8
     check_items = list(zip(*report_items))[0]  # get first elements of tuples
     max_len = len(max(check_items, key=len))  # find the longest string length

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -34,7 +34,7 @@ def compute_padding(report_items):
     check_items = list(zip(*report_items))[0]  # get first elements of tuples
     max_len = len(max(check_items, key=len))  # find the longest string length
     if max_len >= padding:
-        padding = max_len + 4  # padding number is longest string length + 4
+        padding = max_len + 4  # padding number is longest string length + 4 spaces
     return padding
 
 

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-def print_term(k, v):
+def format_print(name, report):
     """Print term only if it exists."""
     if v:
         # TODO(clairewang): 20 padding needs to be dynamically set

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -38,7 +38,7 @@ def compute_padding(modules, report):
         if m in report:
             module_report = report.get(m)
             check_items = list(zip(*module_report))[0]  # get first elements of tuples
-            max_len = len(max(check_items, key=len))  # find the longest string
+            max_len = len(max(check_items, key=len))  # find the longest string length
             if max_len >= padding:
                 padding = max_len + 4  # padding number is longest string length + 4
     return padding

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -1,0 +1,20 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def print_term(k, v):
+    """Print term only if it exists."""
+    if v:
+        # TODO: 20 padding needs to be dynamically set
+        print('{:20}: {}'.format(k,v))

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -17,10 +17,12 @@ import sys
 
 def format_print(report):
     """Format print report content."""
+    # temp fix for missing ifcfg 
     if report is None:
-        sys.stderr.write('WARNING: No report found. Skip print...\n')
+        sys.stderr.write('No report found. Skip print...')
         return
-    print(report.name)
+
+    print('\n', report.name)
     padding_num = compute_padding(report.items)
     for item_name, item_content in report.items:
         print('{:{padding}}: {}'.format(item_name, item_content, padding=padding_num))
@@ -34,3 +36,7 @@ def compute_padding(report_items):
     if max_len >= padding:
         padding = max_len + 4  # padding number is longest string length + 4
     return padding
+
+
+def warning_format(msg, cat, filename, linenum, file=None, line=None):
+    return '%s: %s: %s: %s\n' % (filename, linenum, cat.__name__, msg)

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -16,5 +16,5 @@
 def print_term(k, v):
     """Print term only if it exists."""
     if v:
-        # TODO: 20 padding needs to be dynamically set
+        # TODO(clairewang): 20 padding needs to be dynamically set
         print('{:20}: {}'.format(k, v))

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -15,9 +15,10 @@
 from typing import List
 from typing import Tuple
 import sys
+import warnings
 
 
-def format_print(report: Report) -> None:
+def format_print(report: 'Report') -> None:  # using str as wrapper for custom class Report
     """
     Format print report content.
     :param report: Report object with name and items list
@@ -47,5 +48,25 @@ def compute_padding(report_items: List[Tuple[str, str]]) -> int:
     return padding
 
 
-def warning_format(msg, cat, filename, linenum, file=None, line=None):
+def custom_warning_format(msg, cat, filename, linenum, file=None, line=None):
     return '%s: %s: %s: %s\n' % (filename, linenum, cat.__name__, msg)
+
+
+class CustomWarningFormat:
+    """Support custom warning format without modifying default format."""
+
+    def __enter__(self):
+        self._default_format = warnings.formatwarning
+        warnings.formatwarning = custom_warning_format
+
+    def __exit__(self, type, value, traceback):
+        warnings.formatwarning = self._default_format
+
+
+def doctor_warn(msg: str) -> None:
+    """
+    Use CustomWarningFormat to print customized warning message.
+    :param msg: warning message to be printed
+    """
+    with CustomWarningFormat():
+        warnings.warn(msg)

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -17,22 +17,20 @@ import sys
 
 def format_print(report):
     """Format print report content."""
-    # padding_num = compute_padding(report)
     if report is None:
-        sys.stderr.write('ERROR: No report available for this check.', file=sys.stderr)
+        sys.stderr.write('WARNING: No report found. Skip print...\n')
+        return
     print(report.name)
+    padding_num = compute_padding(report.items)
     for item_name, item_content in report.items:
-        print('{}: {}'.format(item_name, item_content))
+        print('{:{padding}}: {}'.format(item_name, item_content, padding=padding_num))
 
 
-# def compute_padding(report):
-#     """Compute padding based on report content."""
-#     padding = 8
-#     for m in modules:
-#         if m in report:
-#             module_report = report.get(m)
-#             check_items = list(zip(*module_report))[0]  # get first elements of tuples
-#             max_len = len(max(check_items, key=len))  # find the longest string length
-#             if max_len >= padding:
-#                 padding = max_len + 4  # padding number is longest string length + 4
-#     return padding
+def compute_padding(report_items):
+    """Compute padding based on report content."""
+    padding = 8
+    check_items = list(zip(*report_items))[0]  # get first elements of tuples
+    max_len = len(max(check_items, key=len))  # find the longest string length
+    if max_len >= padding:
+        padding = max_len + 4  # padding number is longest string length + 4
+    return padding

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-def format_print(name, report):
+def format_print(names, report):
     """Print term only if it exists."""
-    if v:
-        # TODO(clairewang): 20 padding needs to be dynamically set
-        print('{:20}: {}'.format(k, v))
+	

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -25,7 +25,7 @@ def format_print(modules, report):
                 if k == 'NAME':
                     print(v)
                 else:
-                    print('{:{padding}}: {}'.format(k, v, padding = padding_num))
+                    print('{:{padding}}: {}'.format(k, v, padding=padding_num))
         else:
             # print warning if no report available for a particular check
             sys.stderr.write('WARNING: No report available for this check.')

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -14,5 +14,29 @@
 
 
 def format_print(names, report):
-    """Print term only if it exists."""
-	
+    """Format print report according to module names."""
+    padding_num = compute_padding(names, report)
+    for n in names:
+        if n in report:
+            module_report = report.get(n)
+            for k, v in module_report:
+                if k == 'NAME':
+                    print(v)
+                else:
+                    print('{:{padding}}: {}'.format(k, v, padding = padding_num))
+        else:
+            # print warning if no report available for a particular check
+            sys.stderr.write('WARNING: No report available for this check.')
+
+
+def compute_padding(names, report):
+    """Compute padding based on report content."""
+    padding = 8
+    for n in names:
+        if n in report:
+            module_report = report.get(n)
+            item_names = list(zip(*module_report))[0]
+            max_len = len(max(item_names, key=len))
+            if max_len >= padding:
+                padding = max_len + 4
+    return padding

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -17,7 +17,7 @@ import sys
 
 def format_print(report):
     """Format print report content."""
-    # temp fix for missing ifcfg 
+    # temp fix for missing ifcfg
     if report is None:
         sys.stderr.write('No report found. Skip print...')
         return

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 
 def format_print(names, report):
     """Format print report according to module names."""

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -28,7 +28,7 @@ def format_print(modules, report):
                     print('{:{padding}}: {}'.format(k, v, padding=padding_num))
         else:
             # print warning if no report available for a particular check
-            sys.stderr.write('WARNING: No report available for this check.')
+            sys.stderr.write('WARNING: No report available for this check.', file=sys.stderr)
 
 
 def compute_padding(modules, report):

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -17,4 +17,4 @@ def print_term(k, v):
     """Print term only if it exists."""
     if v:
         # TODO: 20 padding needs to be dynamically set
-        print('{:20}: {}'.format(k,v))
+        print('{:20}: {}'.format(k, v))

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -15,30 +15,24 @@
 import sys
 
 
-def format_print(modules, report):
-    """Format print report according to module names."""
-    padding_num = compute_padding(modules, report)
-    for m in modules:
-        if m in report:
-            module_report = report.get(m)
-            for k, v in module_report:
-                if k == 'NAME':
-                    print(v)
-                else:
-                    print('{:{padding}}: {}'.format(k, v, padding=padding_num))
-        else:
-            # print warning if no report available for a particular check
-            sys.stderr.write('WARNING: No report available for this check.', file=sys.stderr)
+def format_print(report):
+    """Format print report content."""
+    # padding_num = compute_padding(report)
+    if report is None:
+        sys.stderr.write('ERROR: No report available for this check.', file=sys.stderr)
+    print(report.name)
+    for item_name, item_content in report.items:
+        print('{}: {}'.format(item_name, item_content))
 
 
-def compute_padding(modules, report):
-    """Compute padding based on report content."""
-    padding = 8
-    for m in modules:
-        if m in report:
-            module_report = report.get(m)
-            check_items = list(zip(*module_report))[0]  # get first elements of tuples
-            max_len = len(max(check_items, key=len))  # find the longest string length
-            if max_len >= padding:
-                padding = max_len + 4  # padding number is longest string length + 4
-    return padding
+# def compute_padding(report):
+#     """Compute padding based on report content."""
+#     padding = 8
+#     for m in modules:
+#         if m in report:
+#             module_report = report.get(m)
+#             check_items = list(zip(*module_report))[0]  # get first elements of tuples
+#             max_len = len(max(check_items, key=len))  # find the longest string length
+#             if max_len >= padding:
+#                 padding = max_len + 4  # padding number is longest string length + 4
+#     return padding

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -90,4 +90,6 @@ def check_network():
 
 def print_network():
     """Print all system and ROS network information."""
+    local_addrs = get_local_addresses()
+    print('Local addresses: ', *local_addrs)
     pass

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+from typing import Tuple
 import warnings
 
 from ros2doctor.api import DoctorCheck
@@ -27,15 +28,16 @@ try:
     import ifcfg
 except ImportError:
     warnings.warn('Failed to import ifcfg. '
-                  'Use `python -m pip install ifcfg` to install needed package.')
+                  'Use `python -m pip install ifcfg` to install needed package.',\
+                   ImportWarning)  # suppressed by default
 
 
-def _is_unix_like_platform():
+def _is_unix_like_platform() -> bool:
     """Return True if conforms to UNIX/POSIX-style APIs."""
     return os.name == 'posix'
 
 
-def _check_network_config_helper():
+def _check_network_config_helper() -> Tuple[bool, bool, bool]:
     """Check if loopback and multicast IP addresses are found."""
     has_loopback, has_non_loopback, has_multicast = False, False, False
     # temp fix for ifcfg package, maunually pass network check

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -1,0 +1,91 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import netifaces
+import platform
+import socket
+import sys
+
+
+def _is_unix_like_platform():
+    """Return True is conforms to UNIX/POSIX-style APIs."""
+    return platform.system() in ['Linux', 'FreeBSD', 'Darwin']
+
+
+def _use_ipv6():
+    """Check if ROS uses IPV6"""
+    ipv6 = os.environ.get('ROS_IPV6')
+    return ipv6 and ipv6 == 'on'
+
+
+def get_local_addresses():
+    """Fetch a list of local IP addresses."""
+    local_addrs = []
+    if _is_unix_like_platform():
+        ipv4_addrs = []
+        ipv6_addrs = []
+        for i in netifaces.interfaces():
+            addrs = netifaces.ifaddresses(i)
+            if socket.AF_INET in addrs:
+                v4addrs.extend([addr['addr'] for addr in addrs[socket.AF_INET]])
+            if socket.AF_INET6 in addrs:
+                v6addrs.extend([addr['addr'] for addr in addrs[socket.AF_INET6]])
+        if _use_ipv6():
+            local_addrs = ipv4_addrs + ipv6_addrs
+        else:
+            local_addrs = ipv4_addrs
+    else:
+        # can only resolve one address on other platforms?
+        if _use_ipv6():
+            local_addrs = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(),\
+                                0, 0, 0, socket.SOL_TCP)]
+        else:
+            local_addrs = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(),\
+                                0, socket.AF_INET, 0, socket.SOL_TCP)]
+    return local_addrs
+
+
+def check_sys_ips():
+    """Compare roslib's routine against socket resolution to see if they agree."""
+    #TODO figure out the significance of this check
+    pass
+
+# def check_ros_hostname():
+#     """Check if ROS_HOSTNAME resolves to a local IP address."""
+#     hostname = 
+#     pass
+
+def check_ros_ip():
+    """Check if ROS_IP is a local IP address."""
+
+    pass
+
+
+# Error / Warning Rules
+
+warnings = {}
+
+errors = {}
+
+
+def check_network():
+    """Conduct network checks and output error/warning messages."""
+
+    pass
+
+
+def print_network():
+    """Print all system and ROS network information."""
+
+    pass

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -51,10 +51,10 @@ def check_network_config():
     return has_loopback and has_non_loopback and has_multicast
 
 
-def print_network():
+def report_network():
     """Print all system and ROS network information."""
-    print('NETWORK CONFIGURATION')
+    network_info = {'NAME': 'NETWORK CONFIGURATION'}
     for name, iface in ifcfg.interfaces().items():
         for k, v in iface.items():
-            print_term(k, v)
-    print('\n')
+            network_info[k] = v
+    return network_info

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -15,7 +15,11 @@
 import os
 import sys
 
-import ifcfg
+try:
+    import ifcfg
+except ImportError:
+    sys.stderr.write('ERROR: No ifcfg module found. '
+                     'Install with `python -m pip install ifcfg`.')
 
 
 def _is_unix_like_platform():

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -21,15 +21,13 @@ from ros2doctor.api.format import print_term
 
 
 def _is_unix_like_platform():
-    """Return True is conforms to UNIX/POSIX-style APIs."""
+    """Return True if conforms to UNIX/POSIX-style APIs."""
     return platform.system() in ['Linux', 'FreeBSD', 'Darwin']
 
 
 def check_sys_ips():
-    """Check if loopback and multicast IP addresses are present."""
-    has_loopback = False
-    has_others = False
-    has_multicast = False
+    """Check if loopback and multicast IP addresses are found."""
+    has_loopback, has_others, has_multicast = False, False, False
     for name, iface in ifcfg.interfaces().items():
         flags = iface.get('flags')
         if 'LOOPBACK' in flags:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -17,8 +17,6 @@ import sys
 
 import ifcfg
 
-from ros2doctor.api.format import print_term
-
 
 def _is_unix_like_platform():
     """Return True if conforms to UNIX/POSIX-style APIs."""
@@ -56,5 +54,6 @@ def report_network():
     network_info = [('NAME', 'NETWORK CONFIGURATION')]
     for name, iface in ifcfg.interfaces().items():
         for k, v in iface.items():
-            network_info.append((k, v))
+            if v:
+                network_info.append((k, v))
     return network_info

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -25,12 +25,6 @@ def _is_unix_like_platform():
     return platform.system() in ['Linux', 'FreeBSD', 'Darwin']
 
 
-# def _use_ipv6():
-#     """Check if ROS uses IPV6"""
-#     ipv6 = os.environ.get('ROS_IPV6')
-#     return ipv6 and ipv6 == 'on'
-
-
 def get_local_addresses():
     """Fetch a list of local IP addresses."""
     local_addrs = []
@@ -40,8 +34,10 @@ def get_local_addresses():
         for i in netifaces.interfaces():
             addrs = netifaces.ifaddresses(i)
             if socket.AF_INET in addrs:
+                # get ipv4 addresses from all interfaces
                 ipv4_addrs.extend([addr['addr'] for addr in addrs[socket.AF_INET]])
             if socket.AF_INET6 in addrs:
+                # get ipv6 addresses from all interfaces
                 ipv6_addrs.extend([addr['addr'] for addr in addrs[socket.AF_INET6]])
         if socket.has_ipv6:
             local_addrs = ipv4_addrs + ipv6_addrs
@@ -62,7 +58,6 @@ def check_sys_ips(local_addrs):
     """Check if loopback and multicast IP addresses are present."""
     has_loopback = False
     has_others = False
-    has_multicast = False
     for addr in local_addrs:
         try:
             addr_obj = ipaddress.ip_address(addr)
@@ -72,9 +67,7 @@ def check_sys_ips(local_addrs):
             has_loopback = True
         else:
             has_others = True
-        # if addr_obj.is_multicast:
-        #     has_multicast = True
-    return has_loopback, has_others, has_multicast
+    return has_loopback, has_others
 
 
 def check_network():
@@ -85,13 +78,11 @@ def check_network():
         sys.stderr.write('ERROR: No local IP addresses found.\n')
         return result
     else:
-        has_loopback, has_others, has_multicast = check_sys_ips(local_addrs)
+        has_loopback, has_others = check_sys_ips(local_addrs)
         if not has_loopback:
             sys.stderr.write('ERROR: No loopback IP address is found.\n')
         if not has_others:
             sys.stderr.write('WARNING: Only loopback IP address is found.\n')
-        # if not has_multicast:
-        #     sys.stderr.write('WARNING: No multicast IP address found.\n')
         if has_loopback and has_others:
             result = True
     return result

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -73,13 +73,13 @@ class NetworkCheck(DoctorCheck):
 
 
 class NetworkReport(DoctorReport):
-    """Report network interface configuration."""
+    """Report network configuration."""
 
     def category(self):
         return 'network'
 
     def report(self):
-        """Print all system and ROS network information."""
+        """Print system and ROS network information."""
         network_report = Report('NETWORK CONFIGURATION')
         # temp fix for ifcfg package, return none for report
         if 'ifcfg' not in sys.modules:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -53,8 +53,8 @@ def check_network_config():
 
 def report_network():
     """Print all system and ROS network information."""
-    network_info = {'NAME': 'NETWORK CONFIGURATION'}
+    network_info = [('NAME', 'NETWORK CONFIGURATION')]
     for name, iface in ifcfg.interfaces().items():
         for k, v in iface.items():
-            network_info[k] = v
+            network_info.append((k, v))
     return network_info

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -22,42 +22,43 @@ except ImportError:
                      'Install with `python -m pip install ifcfg`.')
 
 
-def _is_unix_like_platform():
-    """Return True if conforms to UNIX/POSIX-style APIs."""
-    return os.name == 'posix'
+class NetworkCheck():
+    def _is_unix_like_platform():
+        """Return True if conforms to UNIX/POSIX-style APIs."""
+        return os.name == 'posix'
 
 
-def check_network_config_helper():
-    """Check if loopback and multicast IP addresses are found."""
-    has_loopback, has_non_loopback, has_multicast = False, False, False
-    for name, iface in ifcfg.interfaces().items():
-        flags = iface.get('flags')
-        if 'LOOPBACK' in flags:
-            has_loopback = True
-        else:
-            has_non_loopback = True
-        if 'MULTICAST' in flags:
-            has_multicast = True
-    return has_loopback, has_non_loopback, has_multicast
+    def check_network_config_helper():
+        """Check if loopback and multicast IP addresses are found."""
+        has_loopback, has_non_loopback, has_multicast = False, False, False
+        for name, iface in ifcfg.interfaces().items():
+            flags = iface.get('flags')
+            if 'LOOPBACK' in flags:
+                has_loopback = True
+            else:
+                has_non_loopback = True
+            if 'MULTICAST' in flags:
+                has_multicast = True
+        return has_loopback, has_non_loopback, has_multicast
 
 
-def check_network_config():
-    """Conduct network checks and output error/warning messages."""
-    has_loopback, has_non_loopback, has_multicast = check_network_config_helper()
-    if not has_loopback:
-        sys.stderr.write('ERROR: No loopback IP address is found.\n')
-    if not has_non_loopback:
-        sys.stderr.write('WARNING: Only loopback IP address is found.\n')
-    if not has_multicast:
-        sys.stderr.write('WARNING: No multicast IP address is found.\n')
-    return has_loopback and has_non_loopback and has_multicast
+    def check_network_config():
+        """Conduct network checks and output error/warning messages."""
+        has_loopback, has_non_loopback, has_multicast = check_network_config_helper()
+        if not has_loopback:
+            sys.stderr.write('ERROR: No loopback IP address is found.\n')
+        if not has_non_loopback:
+            sys.stderr.write('WARNING: Only loopback IP address is found.\n')
+        if not has_multicast:
+            sys.stderr.write('WARNING: No multicast IP address is found.\n')
+        return has_loopback and has_non_loopback and has_multicast
 
 
-def report_network():
-    """Print all system and ROS network information."""
-    network_info = [('NAME', 'NETWORK CONFIGURATION')]
-    for name, iface in ifcfg.interfaces().items():
-        for k, v in iface.items():
-            if v:
-                network_info.append((k, v))
-    return network_info
+    def report_network():
+        """Print all system and ROS network information."""
+        network_info = [('NAME', 'NETWORK CONFIGURATION')]
+        for name, iface in ifcfg.interfaces().items():
+            for k, v in iface.items():
+                if v:
+                    network_info.append((k, v))
+        return network_info

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -20,16 +20,14 @@ import warnings
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
-from ros2doctor.api.format import warning_format
-
-warnings.formatwarning = warning_format
+from ros2doctor.api.format import doctor_warn
 
 try:
     import ifcfg
 except ImportError:
     warnings.warn('Failed to import ifcfg. '
                   'Use `python -m pip install ifcfg` to install needed package.',\
-                   ImportWarning)  # suppressed by default
+                   ImportWarning)  # ImportWarning is suppressed by default
 
 
 def _is_unix_like_platform() -> bool:
@@ -42,7 +40,7 @@ def _check_network_config_helper() -> Tuple[bool, bool, bool]:
     has_loopback, has_non_loopback, has_multicast = False, False, False
     # temp fix for ifcfg package, maunually pass network check
     if 'ifcfg' not in sys.modules:
-        warnings.warn('ifcfg not imported. Skip network check...')
+        doctor_warn('ifcfg not imported. Skip network check...')
         return True, True, True
 
     for name, iface in ifcfg.interfaces().items():
@@ -66,11 +64,11 @@ class NetworkCheck(DoctorCheck):
         """Check network configuration."""
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper()
         if not has_loopback:
-            warnings.warn('ERROR: No loopback IP address is found.')
+            doctor_warn('ERROR: No loopback IP address is found.')
         if not has_non_loopback:
-            warnings.warn('Only loopback IP address is found.')
+            doctor_warn('Only loopback IP address is found.')
         if not has_multicast:
-            warnings.warn('No multicast IP address is found.')
+            doctor_warn('No multicast IP address is found.')
         return has_loopback and has_non_loopback and has_multicast
 
 
@@ -85,7 +83,7 @@ class NetworkReport(DoctorReport):
         network_report = Report('NETWORK CONFIGURATION')
         # temp fix for ifcfg package, return none for report
         if 'ifcfg' not in sys.modules:
-            warnings.warn('ERROR: ifcfg package not imported. Skipping network report...')
+            doctor_warn('ERROR: ifcfg package not imported. Skipping network report...')
             return None
 
         for name, iface in ifcfg.interfaces().items():

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -61,4 +61,3 @@ def report_network():
             if v:
                 network_info.append((k, v))
     return network_info
-

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -26,8 +26,8 @@ try:
     import ifcfg
 except ImportError:
     warnings.warn('Failed to import ifcfg. '
-                  'Use `python -m pip install ifcfg` to install needed package.',\
-                   ImportWarning)  # ImportWarning is suppressed by default
+                  'Use `python -m pip install ifcfg` to install needed package.',
+                  ImportWarning)  # ImportWarning is suppressed by default
 
 
 def _is_unix_like_platform() -> bool:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ipaddress
-import netifaces
-import os
 import platform
-import socket
 import sys
+
+import ifcfg
+
+from ros2doctor.api.format import print_term
 
 
 def _is_unix_like_platform():
@@ -25,71 +25,41 @@ def _is_unix_like_platform():
     return platform.system() in ['Linux', 'FreeBSD', 'Darwin']
 
 
-def get_local_addresses():
-    """Fetch a list of local IP addresses."""
-    local_addrs = []
-    if _is_unix_like_platform():
-        ipv4_addrs = []
-        ipv6_addrs = []
-        for i in netifaces.interfaces():
-            addrs = netifaces.ifaddresses(i)
-            if socket.AF_INET in addrs:
-                # get ipv4 addresses from all interfaces
-                ipv4_addrs.extend([addr['addr'] for addr in addrs[socket.AF_INET]])
-            if socket.AF_INET6 in addrs:
-                # get ipv6 addresses from all interfaces
-                ipv6_addrs.extend([addr['addr'] for addr in addrs[socket.AF_INET6]])
-        if socket.has_ipv6:
-            local_addrs = ipv4_addrs + ipv6_addrs
-        else:
-            local_addrs = ipv4_addrs
-    else:
-        # can only resolve one address on other platforms?
-        if socket.has_ipv6:
-            local_addrs = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(),\
-                                0, 0, 0, socket.SOL_TCP)]
-        else:
-            local_addrs = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(),\
-                                0, socket.AF_INET, 0, socket.SOL_TCP)]
-    return local_addrs
-
-
-def check_sys_ips(local_addrs):
+def check_sys_ips():
     """Check if loopback and multicast IP addresses are present."""
     has_loopback = False
     has_others = False
-    for addr in local_addrs:
-        try:
-            addr_obj = ipaddress.ip_address(addr)
-        except ValueError:
-            continue
-        if addr_obj.is_loopback:
+    has_multicast = False
+    for name, iface in ifcfg.interfaces().items():
+        flags = iface.get('flags')
+        if 'LOOPBACK' in flags:
             has_loopback = True
         else:
             has_others = True
-    return has_loopback, has_others
+        if 'MULTICAST' in flags:
+            has_multicast = True
+    return has_loopback, has_others, has_multicast
 
 
-def check_network():
+def check_network_config():
     """Conduct network checks and output error/warning messages."""
     result = False
-    local_addrs = get_local_addresses()
-    if not local_addrs:
-        sys.stderr.write('ERROR: No local IP addresses found.\n')
-        return result
-    else:
-        has_loopback, has_others = check_sys_ips(local_addrs)
-        if not has_loopback:
-            sys.stderr.write('ERROR: No loopback IP address is found.\n')
-        if not has_others:
-            sys.stderr.write('WARNING: Only loopback IP address is found.\n')
-        if has_loopback and has_others:
-            result = True
+    has_loopback, has_others, has_multicast = check_sys_ips()
+    if not has_loopback:
+        sys.stderr.write('ERROR: No loopback IP address is found.\n')
+    if not has_others:
+        sys.stderr.write('WARNING: Only loopback IP address is found.\n')
+    if not has_multicast:
+        sys.stderr.write('WARNING: No multicast IP address is found.\n')
+    if has_loopback and has_others and has_multicast:
+        result = True
     return result
 
 
 def print_network():
     """Print all system and ROS network information."""
-    local_addrs = get_local_addresses()
-    print('Local addresses: ', *local_addrs)
-    pass
+    print('NETWORK CONFIGURATION')
+    for name, iface in ifcfg.interfaces().items():
+        for k, v in iface.items():
+            print_term(k, v)
+    print('\n')

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -66,7 +66,7 @@ class PlatformCheck(DoctorCheck):
         elif distro_info.get('distribution_status') == 'end-of-life':
             sys.stderr.write('WARNING: Distribution %s is no longer supported or deprecated. '
                              'To get the latest features, download the new versions at '
-                             'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+                             'https://index.ros.org/doc/ros2/Installation/\n' % distro_name)
         else:
             result = True
         return result

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -16,8 +16,6 @@ import os
 import platform
 import sys
 
-from ros2doctor.api.format import print_term
-
 import rosdistro
 
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -42,19 +42,19 @@ def check_platform_helper():
     """Check ROS_DISTRO related environment variables and distribution name."""
     distro_name = os.environ.get('ROS_DISTRO')
     if not distro_name:
-        sys.stderr.write('WARNING: ROS_DISTRO is not set.')
+        sys.stderr.write('WARNING: ROS_DISTRO is not set.\n')
         return
     else:
         distro_name = distro_name.lower()
     u = rosdistro.get_index_url()
     if not u:
-        sys.stderr.write('WARNING: Unable to access ROSDISTRO_INDEX_URL\
-            or DEFAULT_INDEX_URL.')
+        sys.stderr.write('WARNING: Unable to access ROSDISTRO_INDEX_URL '
+                         'or DEFAULT_INDEX_URL.\n')
         return
     i = rosdistro.get_index(u)
     distro_info = i.distributions.get(distro_name)
     if not distro_info:
-        sys.stderr.write("WARNING: Distribution name '%s' is not found" % distro_name)
+        sys.stderr.write("WARNING: Distribution name '%s' is not found\n" % distro_name)
         return
     distro_data = rosdistro.get_distribution(i, distro_name).get_data()
     return distro_name, distro_info, distro_data
@@ -84,15 +84,13 @@ def check_platform():
 
     # check distro status
     if distro_info.get('distribution_status') == 'prerelease':
-        sys.stderr.write('WARNING: Distribution is not fully supported or tested.\
-            To get more stable features,\
-                Download a stable version at\
-                    https://index.ros.org/doc/ros2/Installation/')
+        sys.stderr.write('WARNING: Distribution is not fully supported or tested. '
+                         'To get more stable features, download a stable version at '
+                         'https://index.ros.org/doc/ros2/Installation/\n')
     elif distro_info.get('distribution_status') == 'end-of-life':
-        sys.stderr.write('WARNING: Distribution is no longer supported or deprecated.\
-            To get the latest features,\
-                Download the latest version at\
-                    https://index.ros.org/doc/ros2/Installation/')
+        sys.stderr.write('WARNING: Distribution is no longer supported or deprecated. '
+                         'To get the latest features, download the latest version at '
+                         'https://index.ros.org/doc/ros2/Installation/')
     else:
         passed = True
     return passed

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -21,24 +21,25 @@ from ros2doctor.api.format import print_term
 import rosdistro
 
 
-def print_platform_info():
+def report_platform_info():
     """Print out platform information."""
     platform_name = platform.system()
     # platform info
-    print('PLATFORM INFORMATION')
-    print_term('system', platform_name)
-    print_term('platform info', platform.platform())
-    if platform_name == 'Darwin':
-        print_term('mac OS version', platform.mac_ver())
-    print_term('release', platform.release())
-    print_term('processor', platform.processor())
 
-    # python info
-    print('PYTHON INFORMATION')
-    print_term('version', platform.python_version())
-    print_term('compiler', platform.python_compiler())
-    print_term('build', platform.python_build())
-    print('\n')
+    platform_info = {'NAME': 'PLATFORM INFORMATION'}
+    platform_info['system'] = platform_name
+    platform_info['platform info'] = platform.platform()
+    if platform_name == 'Darwin':
+        platform_info['mac OS version'] = platform.mac_ver()
+    platform_info['release'] = platform.release()
+    platform_info['processor'] = platform.processor()
+
+    # # python info
+    # print('PYTHON INFORMATION')
+    # print_term('version', platform.python_version())
+    # print_term('compiler', platform.python_compiler())
+    # print_term('build', platform.python_build())
+    return platform_info
 
 
 def check_platform_helper():
@@ -63,19 +64,19 @@ def check_platform_helper():
     return distro_name, distro_info, distro_data
 
 
-def print_ros2_info():
+def report_ros2_info():
     """Print out ROS2 distribution info using `rosdistro`."""
     distros = check_platform_helper()
     if not distros:
         return
     distro_name, distro_info, distro_data = distros
 
-    print('ROS INFORMATION')
-    print_term('distribution name', distro_name)
-    print_term('distribution type', distro_info.get('distribution_type'))
-    print_term('distribution status', distro_info.get('distribution_status'))
-    print_term('release platforms', distro_data.get('release_platforms'))
-    print('\n')
+    ros_info = {'NAME': 'ROS 2 INFORMATION'}
+    ros_info['distribution name'] = distro_name
+    ros_info['distribution type'] = distro_info.get('distribution_type')
+    ros_info['distribution status'] = distro_info.get('distribution_status')
+    ros_info['release platforms'] = distro_data.get('release_platforms')
+    return ros_info
 
 
 def check_platform():

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -33,12 +33,6 @@ def report_platform_info():
         platform_info['mac OS version'] = platform.mac_ver()
     platform_info['release'] = platform.release()
     platform_info['processor'] = platform.processor()
-
-    # # python info
-    # print('PYTHON INFORMATION')
-    # print_term('version', platform.python_version())
-    # print_term('compiler', platform.python_compiler())
-    # print_term('build', platform.python_build())
     return platform_info
 
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -14,7 +14,6 @@
 
 import os
 import platform
-import sys
 import warnings
 
 from ros2doctor.api import DoctorCheck
@@ -22,9 +21,10 @@ from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
 from ros2doctor.api.format import warning_format
 
-warnings.formatwarning = warning_format
-
 import rosdistro
+
+
+warnings.formatwarning = warning_format
 
 
 def _check_platform_helper():
@@ -65,12 +65,12 @@ class PlatformCheck(DoctorCheck):
         # check distro status
         if distro_info.get('distribution_status') == 'prerelease':
             warnings.warn('Distribution %s is not fully supported or tested. '
-                             'To get more consistent features, download a stable version at '
-                             'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+                          'To get more consistent features, download a stable version at '
+                          'https://index.ros.org/doc/ros2/Installation/' % distro_name)
         elif distro_info.get('distribution_status') == 'end-of-life':
             warnings.warn('Distribution %s is no longer supported or deprecated. '
-                             'To get the latest features, download the new versions at '
-                             'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+                          'To get the latest features, download the new versions at '
+                          'https://index.ros.org/doc/ros2/Installation/' % distro_name)
         else:
             result = True
         return result

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -16,11 +16,11 @@ import os
 import platform
 import sys
 
-import rosdistro
-
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
+
+import rosdistro
 
 
 def _check_platform_helper():
@@ -61,15 +61,15 @@ class PlatformCheck(DoctorCheck):
         # check distro status
         if distro_info.get('distribution_status') == 'prerelease':
             sys.stderr.write('WARNING: Distribution %s is not fully supported or tested. '
-                            'To get more consistent features, download a stable version at '
-                            'https://index.ros.org/doc/ros2/Installation/\n' % distro_name)
+                             'To get more consistent features, download a stable version at '
+                             'https://index.ros.org/doc/ros2/Installation/\n' % distro_name)
         elif distro_info.get('distribution_status') == 'end-of-life':
             sys.stderr.write('WARNING: Distribution %s is no longer supported or deprecated. '
-                            'To get the latest features, download the new versions at '
-                            'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+                             'To get the latest features, download the new versions at '
+                             'https://index.ros.org/doc/ros2/Installation/' % distro_name)
         else:
             result = True
-        return result 
+        return result
 
 
 class PlatformReport(DoctorReport):
@@ -84,11 +84,11 @@ class PlatformReport(DoctorReport):
         # platform info
         platform_report = Report('PLATFORM INFORMATION')
         platform_report.add_to_report('system', platform_name)
-        platform_report.add_to_report(('platform info', platform.platform()))
+        platform_report.add_to_report('platform info', platform.platform())
         if platform_name == 'Darwin':
-            platform_report.add_to_report(('mac OS version', platform.mac_ver()))
-        platform_report.add_to_report(('release', platform.release()))
-        platform_report.add_to_report(('processor', platform.processor()))
+            platform_report.add_to_report('mac OS version', platform.mac_ver())
+        platform_report.add_to_report('release', platform.release())
+        platform_report.add_to_report('processor', platform.processor())
         return platform_report
 
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -18,23 +18,12 @@ import sys
 
 import rosdistro
 
-
-def report_platform_info():
-    """Print out platform information."""
-    platform_name = platform.system()
-    # platform info
-
-    platform_info = [('NAME', 'PLATFORM INFORMATION')]
-    platform_info.append(('system', platform_name))
-    platform_info.append(('platform info', platform.platform()))
-    if platform_name == 'Darwin':
-        platform_info.append(('mac OS version', platform.mac_ver()))
-    platform_info.append(('release', platform.release()))
-    platform_info.append(('processor', platform.processor()))
-    return platform_info
+from ros2doctor.api import DoctorCheck
+from ros2doctor.api import DoctorReport
+from ros2doctor.api import Report
 
 
-def check_platform_helper():
+def _check_platform_helper():
     """Check ROS_DISTRO related environment variables and distribution name."""
     distro_name = os.environ.get('ROS_DISTRO')
     if not distro_name:
@@ -56,38 +45,64 @@ def check_platform_helper():
     return distro_name, distro_info, distro_data
 
 
-def report_ros2_info():
-    """Print out ROS2 distribution info using `rosdistro`."""
-    distros = check_platform_helper()
-    if not distros:
-        return
-    distro_name, distro_info, distro_data = distros
+class PlatformCheck(DoctorCheck):
+    
+    def target(self):
+        return 'platform'
 
-    ros_info = [('NAME', 'ROS 2 INFORMATION')]
-    ros_info.append(('distribution name', distro_name))
-    ros_info.append(('distribution type', distro_info.get('distribution_type')))
-    ros_info.append(('distribution status', distro_info.get('distribution_status')))
-    ros_info.append(('release platforms', distro_data.get('release_platforms')))
-    return ros_info
+    def check(self):
+        result = False
+        distros = _check_platform_helper()
+        if not distros:
+            return result
+        distro_name, distro_info, _ = distros
+
+        # check distro status
+        if distro_info.get('distribution_status') == 'prerelease':
+            sys.stderr.write('WARNING: Distribution %s is not fully supported or tested. '
+                            'To get more consistent features, download a stable version at '
+                            'https://index.ros.org/doc/ros2/Installation/\n' % distro_name)
+        elif distro_info.get('distribution_status') == 'end-of-life':
+            sys.stderr.write('WARNING: Distribution %s is no longer supported or deprecated. '
+                            'To get the latest features, download the new versions at '
+                            'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+        else:
+            result = True
+        return result 
 
 
-def check_platform():
-    """Check platform information against ROS 2 requirements."""
-    passed = False
-    distros = check_platform_helper()
-    if not distros:
-        return passed
-    distro_name, distro_info, _ = distros
+class PlatformReport(DoctorReport):
 
-    # check distro status
-    if distro_info.get('distribution_status') == 'prerelease':
-        sys.stderr.write('WARNING: Distribution %s is not fully supported or tested. '
-                         'To get more consistent features, download a stable version at '
-                         'https://index.ros.org/doc/ros2/Installation/\n' % distro_name)
-    elif distro_info.get('distribution_status') == 'end-of-life':
-        sys.stderr.write('WARNING: Distribution %s is no longer supported or deprecated. '
-                         'To get the latest features, download the new versions at '
-                         'https://index.ros.org/doc/ros2/Installation/' % distro_name)
-    else:
-        passed = True
-    return passed
+    def target(self):
+        return 'platform'
+
+    def report(self):
+        platform_name = platform.system()
+
+        # platform info
+        platform_report = Report('PLATFORM INFORMATION')
+        platform_report.add_to_report('system', platform_name)
+        platform_report.add_to_report(('platform info', platform.platform()))
+        if platform_name == 'Darwin':
+            platform_report.add_to_report(('mac OS version', platform.mac_ver()))
+        platform_report.add_to_report(('release', platform.release()))
+        platform_report.add_to_report(('processor', platform.processor()))
+        return platform_report
+
+
+class RosdistroReport(DoctorReport):
+
+    def target(self):
+        return 'platform'
+
+    def report(self):
+        distros = _check_platform_helper()
+        if not distros:
+            return
+        distro_name, distro_info, distro_data = distros
+        ros_report = Report('ROS 2 INFORMATION')
+        ros_report.add_to_report('distribution name', distro_name)
+        ros_report.add_to_report('distribution type', distro_info.get('distribution_type'))
+        ros_report.add_to_report('distribution status', distro_info.get('distribution_status'))
+        ros_report.add_to_report('release platforms', distro_data.get('release_platforms'))
+        return ros_report

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -28,7 +28,7 @@ warnings.formatwarning = warning_format
 
 
 def _check_platform_helper():
-    """Check ROS_DISTRO related environment variables and distribution name."""
+    """Check ROS_DISTRO environment variables and distribution installed."""
     distro_name = os.environ.get('ROS_DISTRO')
     if not distro_name:
         warnings.warn('ROS_DISTRO is not set.')

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -46,8 +46,9 @@ def _check_platform_helper():
 
 
 class PlatformCheck(DoctorCheck):
-    
-    def target(self):
+    """Check system platform against ROSDistro."""
+
+    def category(self):
         return 'platform'
 
     def check(self):
@@ -72,8 +73,9 @@ class PlatformCheck(DoctorCheck):
 
 
 class PlatformReport(DoctorReport):
+    """Output platform report."""
 
-    def target(self):
+    def category(self):
         return 'platform'
 
     def report(self):
@@ -91,8 +93,9 @@ class PlatformReport(DoctorReport):
 
 
 class RosdistroReport(DoctorReport):
+    """Output ROSDistro report."""
 
-    def target(self):
+    def category(self):
         return 'platform'
 
     def report(self):

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -26,13 +26,13 @@ def report_platform_info():
     platform_name = platform.system()
     # platform info
 
-    platform_info = {'NAME': 'PLATFORM INFORMATION'}
-    platform_info['system'] = platform_name
-    platform_info['platform info'] = platform.platform()
+    platform_info = [('NAME', 'PLATFORM INFORMATION')]
+    platform_info.append(('system', platform_name))
+    platform_info.append(('platform info', platform.platform()))
     if platform_name == 'Darwin':
-        platform_info['mac OS version'] = platform.mac_ver()
-    platform_info['release'] = platform.release()
-    platform_info['processor'] = platform.processor()
+        platform_info.append(('mac OS version', platform.mac_ver()))
+    platform_info.append(('release', platform.release()))
+    platform_info.append(('processor', platform.processor()))
     return platform_info
 
 
@@ -65,11 +65,11 @@ def report_ros2_info():
         return
     distro_name, distro_info, distro_data = distros
 
-    ros_info = {'NAME': 'ROS 2 INFORMATION'}
-    ros_info['distribution name'] = distro_name
-    ros_info['distribution type'] = distro_info.get('distribution_type')
-    ros_info['distribution status'] = distro_info.get('distribution_status')
-    ros_info['release platforms'] = distro_data.get('release_platforms')
+    ros_info = [('NAME', 'ROS 2 INFORMATION')]
+    ros_info.append(('distribution name', distro_name))
+    ros_info.append(('distribution type', distro_info.get('distribution_type')))
+    ros_info.append(('distribution status', distro_info.get('distribution_status')))
+    ros_info.append(('release platforms', distro_data.get('release_platforms')))
     return ros_info
 
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -77,17 +77,17 @@ def check_platform():
     distros = check_platform_helper()
     if not distros:
         return passed
-    _, distro_info, _ = distros
+    distro_name, distro_info, _ = distros
 
     # check distro status
     if distro_info.get('distribution_status') == 'prerelease':
-        sys.stderr.write('WARNING: Distribution is not fully supported or tested. '
-                         'To get more stable features, download a stable version at '
-                         'https://index.ros.org/doc/ros2/Installation/\n')
+        sys.stderr.write('WARNING: Distribution %s is not fully supported or tested. '
+                         'To get more consistent features, download a stable version at '
+                         'https://index.ros.org/doc/ros2/Installation/\n' % distro_name)
     elif distro_info.get('distribution_status') == 'end-of-life':
-        sys.stderr.write('WARNING: Distribution is no longer supported or deprecated. '
-                         'To get the latest features, download the latest version at '
-                         'https://index.ros.org/doc/ros2/Installation/')
+        sys.stderr.write('WARNING: Distribution %s is no longer supported or deprecated. '
+                         'To get the latest features, download the new versions at '
+                         'https://index.ros.org/doc/ros2/Installation/' % distro_name)
     else:
         passed = True
     return passed

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -16,6 +16,8 @@ import os
 import platform
 import sys
 
+from ros2doctor.api.format import print_term
+
 import rosdistro
 
 
@@ -24,18 +26,19 @@ def print_platform_info():
     platform_name = platform.system()
     # platform info
     print('PLATFORM INFORMATION')
-    print('system               : ', platform_name)
-    print('Platform Info        : ', platform.platform())
+    print_term('system', platform_name)
+    print_term('platform info', platform.platform())
     if platform_name == 'Darwin':
-        print('Mac OS version       : ', platform.mac_ver())
-    print('release              : ', platform.release())
-    print('processor            : ', platform.processor())
+        print_term('mac OS version', platform.mac_ver())
+    print_term('release', platform.release())
+    print_term('processor', platform.processor())
 
     # python info
     print('PYTHON INFORMATION')
-    print('version              : ', platform.python_version())
-    print('compiler             : ', platform.python_compiler())
-    print('build                : ', platform.python_build())
+    print_term('version', platform.python_version())
+    print_term('compiler', platform.python_compiler())
+    print_term('build', platform.python_build())
+    print('\n')
 
 
 def check_platform_helper():
@@ -68,10 +71,11 @@ def print_ros2_info():
     distro_name, distro_info, distro_data = distros
 
     print('ROS INFORMATION')
-    print('distribution name    : ', distro_name)
-    print('distribution type    : ', distro_info.get('distribution_type'))
-    print('distribution status  : ', distro_info.get('distribution_status'))
-    print('release platforms    : ', distro_data.get('release_platforms'))
+    print_term('distribution name', distro_name)
+    print_term('distribution type', distro_info.get('distribution_type'))
+    print_term('distribution status', distro_info.get('distribution_status'))
+    print_term('release platforms', distro_data.get('release_platforms'))
+    print('\n')
 
 
 def check_platform():

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -15,18 +15,19 @@
 import os
 import platform
 from typing import Tuple
-import warnings
 
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
 from ros2doctor.api.format import doctor_warn
+
 import rosdistro
 
 
 def _check_platform_helper() -> Tuple[str, dict, dict]:
     """
     Check ROS_DISTRO environment variables and distribution installed.
+
     :return: string of distro name, dict of distribution info, dict of release platforms info
     """
     distro_name = os.environ.get('ROS_DISTRO')
@@ -112,4 +113,4 @@ class RosdistroReport(DoctorReport):
         ros_report.add_to_report('distribution type', distro_info.get('distribution_type'))
         ros_report.add_to_report('distribution status', distro_info.get('distribution_status'))
         ros_report.add_to_report('release platforms', distro_data.get('release_platforms'))
-        return ros_reports
+        return ros_report

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -20,12 +20,8 @@ import warnings
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
-from ros2doctor.api.format import warning_format
-
+from ros2doctor.api.format import doctor_warn
 import rosdistro
-
-
-warnings.formatwarning = warning_format
 
 
 def _check_platform_helper() -> Tuple[str, dict, dict]:
@@ -35,18 +31,18 @@ def _check_platform_helper() -> Tuple[str, dict, dict]:
     """
     distro_name = os.environ.get('ROS_DISTRO')
     if not distro_name:
-        warnings.warn('ROS_DISTRO is not set.')
+        doctor_warn('ROS_DISTRO is not set.')
         return
     else:
         distro_name = distro_name.lower()
     u = rosdistro.get_index_url()
     if not u:
-        warnings.warn('Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL.')
+        doctor_warn('Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL.')
         return
     i = rosdistro.get_index(u)
     distro_info = i.distributions.get(distro_name)
     if not distro_info:
-        warnings.warn("Distribution name '%s' is not found" % distro_name)
+        doctor_warn("Distribution name '%s' is not found" % distro_name)
         return
     distro_data = rosdistro.get_distribution(i, distro_name).get_data()
     return distro_name, distro_info, distro_data
@@ -68,13 +64,13 @@ class PlatformCheck(DoctorCheck):
 
         # check distro status
         if distro_info.get('distribution_status') == 'prerelease':
-            warnings.warn('Distribution %s is not fully supported or tested. '
-                          'To get more consistent features, download a stable version at '
-                          'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+            doctor_warn('Distribution %s is not fully supported or tested. '
+                        'To get more consistent features, download a stable version at '
+                        'https://index.ros.org/doc/ros2/Installation/' % distro_name)
         elif distro_info.get('distribution_status') == 'end-of-life':
-            warnings.warn('Distribution %s is no longer supported or deprecated. '
-                          'To get the latest features, download the new versions at '
-                          'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+            doctor_warn('Distribution %s is no longer supported or deprecated. '
+                        'To get the latest features, download the new versions at '
+                        'https://index.ros.org/doc/ros2/Installation/' % distro_name)
         else:
             result = True
         return result

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -14,6 +14,7 @@
 
 import os
 import platform
+from typing import Tuple
 import warnings
 
 from ros2doctor.api import DoctorCheck
@@ -27,8 +28,11 @@ import rosdistro
 warnings.formatwarning = warning_format
 
 
-def _check_platform_helper():
-    """Check ROS_DISTRO environment variables and distribution installed."""
+def _check_platform_helper() -> Tuple[str, dict, dict]:
+    """
+    Check ROS_DISTRO environment variables and distribution installed.
+    :return: string of distro name, dict of distribution info, dict of release platforms info
+    """
     distro_name = os.environ.get('ROS_DISTRO')
     if not distro_name:
         warnings.warn('ROS_DISTRO is not set.')
@@ -112,4 +116,4 @@ class RosdistroReport(DoctorReport):
         ros_report.add_to_report('distribution type', distro_info.get('distribution_type'))
         ros_report.add_to_report('distribution status', distro_info.get('distribution_status'))
         ros_report.add_to_report('release platforms', distro_data.get('release_platforms'))
-        return ros_report
+        return ros_reports

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -32,23 +32,31 @@ class DoctorCommand(CommandExtension):
         )
 
     def main(self, *, parser, args):
-        # print report only if no failed checks requested
+        """Run checks and print report to terminal based on user input args."""
         if args.report:
-            report = generate_report()
-            format_print(report.keys(), report)
+            cat_reports = generate_report()
+            for _, report in cat_reports:
+                format_print(report)
             return
-        check_results, failed_checks, failed_modules = run_checks()
-        failed = check_results.count(False)
-        passed = check_results.count(True)
+        cat_results = run_checks()
+        failed_cats = []
+        failed = 0
+        for cat, result in cat_results:
+            if result is False:
+                failed += 1
+                failed_cats.append(cat)
         if failed != 0:
-            print('%d/%d checks failed' % (failed, len(check_results)))
-            print('Failed checks:', *failed_checks)
+            print('%d/%d checks failed' % (failed, len(cat_results)))
+            print('Failed tests are ', *failed_cats)
         else:
-            print('%d/%d checks passed' % (passed, len(check_results)))
-        if args.reportfailed:
+            print('All %d checks passed' % len(cat_results))
+        if args.report_failed and failed != 0:
             # need to run checks to get failed modules
-            report = generate_report()
-            format_print(failed_modules, report)
+            cat_reports = generate_report()
+            for cat in failed_cats:
+                for rcat, report in cat_reports:
+                    if cat == rcat:
+                        format_print(report)
 
 
 class WtfCommand(DoctorCommand):

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 from ros2cli.command import CommandExtension
-from ros2doctor.api import generate_all_reports
-from ros2doctor.api import generate_fail_reports
+from ros2doctor.api import generate_reports
 from ros2doctor.api import run_checks
 from ros2doctor.api.format import format_print
 
@@ -37,7 +36,7 @@ class DoctorCommand(CommandExtension):
         """Run checks and print report to terminal based on user input args."""
         # `ros2 doctor -r`
         if args.report:
-            all_reports = generate_all_reports()
+            all_reports = generate_reports()
             for report_obj in all_reports:
                 format_print(report_obj)
             return
@@ -52,7 +51,7 @@ class DoctorCommand(CommandExtension):
 
         # `ros2 doctor -rf`
         if args.report_failed and fail != 0:
-            fail_reports = generate_fail_reports(failed_cats)
+            fail_reports = generate_reports(cats=failed_cats)
             for report_obj in fail_reports:
                 format_print(report_obj)
 

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -22,11 +22,12 @@ class DoctorCommand(CommandExtension):
     """Check ROS setup and other potential issues."""
 
     def add_arguments(self, parser, cli_name):
-        parser.add_argument(
+        group = parser.add_mutually_exclusive_group(required=False)
+        group.add_argument(
             '--report', '-r', action='store_true',
             help='Print out all report info.'
         )
-        parser.add_argument(
+        group.add_argument(
             '--report-failed', '-rf', action='store_true',
             help='Print out report info on failed checks.'
         )

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -47,7 +47,7 @@ class DoctorCommand(CommandExtension):
                 failed += 1
                 failed_cats.append(cat)
         if failed != 0:
-            print('%d/%d checks failed' % (failed, len(cat_results)))
+            print('%d/%d checks failed\n' % (failed, len(cat_results)))
             print('Failed tests are ', *failed_cats)
         else:
             print('All %d checks passed' % len(cat_results))

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -36,17 +36,17 @@ class DoctorCommand(CommandExtension):
             report = generate_report()
             format_print(report.keys(), report)
             return 
-        all_result, failed_names = run_checks()
-        failed = all_result.count(False)
-        passed = all_result.count(True)
+        check_results, failed_checks, failed_modules = run_checks()
+        failed = check_results.count(False)
+        passed = check_results.count(True)
         if failed != 0:
-            print('%d/%d checks failed' % (failed, len(all_result)))
-            print('Failed checks:', *failed_names)
+            print('%d/%d checks failed' % (failed, len(check_results)))
+            print('Failed checks:', *failed_checks)
         else:
-            print('%d/%d checks passed' % (passed, len(all_result)))
+            print('%d/%d checks passed' % (passed, len(check_results)))
         if args.report_failed:
             report = generate_report()
-            format_print(failed_names, report)
+            format_print(failed_modules, report)
 
 
 class WtfCommand(DoctorCommand):

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -47,10 +47,10 @@ class DoctorCommand(CommandExtension):
                 failed += 1
                 failed_cats.append(cat)
         if failed != 0:
-            print('%d/%d checks failed\n' % (failed, len(cat_results)))
+            print('\n%d/%d checks failed\n' % (failed, len(cat_results)))
             print('Failed tests are ', *failed_cats)
         else:
-            print('All %d checks passed' % len(cat_results))
+            print('\nAll %d checks passed\n' % len(cat_results))
         if args.report_failed and failed != 0:
             # need to run checks to get failed modules
             cat_reports = generate_report()

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -25,11 +25,11 @@ class DoctorCommand(CommandExtension):
         group = parser.add_mutually_exclusive_group(required=False)
         group.add_argument(
             '--report', '-r', action='store_true',
-            help='Print all report.'
+            help='Print all reports.'
         )
         group.add_argument(
             '--report-failed', '-rf', action='store_true',
-            help='Print report of failed checks only.'
+            help='Print reports of failed checks only.'
         )
 
     def main(self, *, parser, args):
@@ -43,7 +43,7 @@ class DoctorCommand(CommandExtension):
 
         # `ros2 doctor`
         failed_cats, fail, total = run_checks()
-        if fail != 0:
+        if fail:
             print('\n%d/%d checks failed\n' % (fail, total))
             print('Failed modules are ', *failed_cats)
         else:
@@ -51,7 +51,7 @@ class DoctorCommand(CommandExtension):
 
         # `ros2 doctor -rf`
         if args.report_failed and fail != 0:
-            fail_reports = generate_reports(cats=failed_cats)
+            fail_reports = generate_reports(categories=failed_cats)
             for report_obj in fail_reports:
                 format_print(report_obj)
 

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -27,7 +27,7 @@ class DoctorCommand(CommandExtension):
             help='Print out all report info.'
         )
         parser.add_argument(
-            '--report_failed', '-rf', action='store_true',
+            '--report-failed', '-rf', action='store_true',
             help='Print out report info on failed checks.'
         )
 
@@ -45,7 +45,7 @@ class DoctorCommand(CommandExtension):
             print('Failed checks:', *failed_checks)
         else:
             print('%d/%d checks passed' % (passed, len(check_results)))
-        if args.report_failed:
+        if args.reportfailed:
             # need to run checks to get failed modules
             report = generate_report()
             format_print(failed_modules, report)

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -41,6 +41,6 @@ class DoctorCommand(CommandExtension):
 
 
 class WtfCommand(DoctorCommand):
-    """Add `wtf` as alias to `doctor`."""
+    """Use `wtf` as alias to `doctor`."""
 
     pass

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -32,6 +32,10 @@ class DoctorCommand(CommandExtension):
         )
 
     def main(self, *, parser, args):
+        if args.report:
+            report = generate_report()
+            format_print(report.keys(), report)
+            return 
         all_result, failed_names = run_checks()
         failed = all_result.count(False)
         passed = all_result.count(True)
@@ -40,20 +44,9 @@ class DoctorCommand(CommandExtension):
             print('Failed checks:', *failed_names)
         else:
             print('%d/%d checks passed' % (passed, len(all_result)))
-
-        if args.report:
-            all_report = generate_report()
-            format_print(all_names, all_report)
-            # for name, module_report in all_report.items():
-            #     for k, v in module_report.items():
-            #         print_term(k, v)
         if args.report_failed:
-            format_print(failed_names, all_report)
-            # for module_name in failed_names:
-            #     module_report = all_report.get(module_name)
-            #     if module_report:
-            #         for k, v in module_report:
-            #             print_term(k, v)
+            report = generate_report()
+            format_print(failed_names, report)
 
 
 class WtfCommand(DoctorCommand):

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ros2cli.command import CommandExtension
+from ros2doctor.api.format import format_print
 from ros2doctor.api import generate_report
 from ros2doctor.api import run_checks
 
@@ -23,21 +24,36 @@ class DoctorCommand(CommandExtension):
     def add_arguments(self, parser, cli_name):
         parser.add_argument(
             '--report', '-r', action='store_true',
-            help='Print out doctor report.'
+            help='Print out all report info.'
+        )
+        parser.add_argument(
+            '--report_failed', '-rf', action='store_true',
+            help="Print out report info on failed checks."
         )
 
     def main(self, *, parser, args):
-        if args.report:
-            generate_report()
+        all_result, failed_names = run_checks()
+        failed = all_result.count(False)
+        passed = all_result.count(True)
+        if failed != 0:
+            print('%d/%d checks failed' % (failed, len(all_result)))
+            print('Failed checks:', *failed_names)
         else:
-            all_result, failed_names = run_checks()
-            failed = all_result.count(False)
-            passed = all_result.count(True)
-            if failed != 0:
-                print('%d/%d checks failed' % (failed, len(all_result)))
-                print('Failed checks:', *failed_names)
-            else:
-                print('%d/%d checks passed' % (passed, len(all_result)))
+            print('%d/%d checks passed' % (passed, len(all_result)))
+
+        if args.report:
+            all_report = generate_report()
+            format_print(all_names, all_report)
+            # for name, module_report in all_report.items():
+            #     for k, v in module_report.items():
+            #         print_term(k, v)
+        if args.report_failed:
+            format_print(failed_names, all_report)
+            # for module_name in failed_names:
+            #     module_report = all_report.get(module_name)
+            #     if module_report:
+            #         for k, v in module_report:
+            #             print_term(k, v)
 
 
 class WtfCommand(DoctorCommand):

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from ros2cli.command import CommandExtension
-from ros2doctor.api.format import format_print
 from ros2doctor.api import generate_report
 from ros2doctor.api import run_checks
+from ros2doctor.api.format import format_print
 
 
 class DoctorCommand(CommandExtension):
@@ -28,14 +28,15 @@ class DoctorCommand(CommandExtension):
         )
         parser.add_argument(
             '--report_failed', '-rf', action='store_true',
-            help="Print out report info on failed checks."
+            help='Print out report info on failed checks.'
         )
 
     def main(self, *, parser, args):
+        # print report only if no failed checks requested
         if args.report:
             report = generate_report()
             format_print(report.keys(), report)
-            return 
+            return
         check_results, failed_checks, failed_modules = run_checks()
         failed = check_results.count(False)
         passed = check_results.count(True)
@@ -45,6 +46,7 @@ class DoctorCommand(CommandExtension):
         else:
             print('%d/%d checks passed' % (passed, len(check_results)))
         if args.report_failed:
+            # need to run checks to get failed modules
             report = generate_report()
             format_print(failed_modules, report)
 

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -35,9 +35,9 @@ setup(
             'check_network_config = ros2doctor.api.network:check_network_config',
         ],
         'ros2doctor.report': [
-            'report_platform = ros2doctor.api.platform:print_platform_info',
-            'report_ros_distro = ros2doctor.api.platform:print_ros2_info',
-            'report_network_config = ros2doctor.api.network:print_network',
+            'report_platform = ros2doctor.api.platform:report_platform_info',
+            'report_ros_distro = ros2doctor.api.platform:report_ros2_info',
+            'report_network_config = ros2doctor.api.network:report_network',
         ],
     }
 )

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -31,13 +31,13 @@ setup(
             'wtf = ros2doctor.command.doctor:WtfCommand',
         ],
         'ros2doctor.checks': [
-            'check_platform = ros2doctor.api.platform:check_platform',
-            'check_network_config = ros2doctor.api.network:NetworkCheck',
+            'PlatformCheck = ros2doctor.api.platform:PlatformCheck',
+            'NetworkCheck = ros2doctor.api.network:NetworkCheck',
         ],
         'ros2doctor.report': [
-            'report_platform_info = ros2doctor.api.platform:report_platform_info',
-            'report_ros2_info = ros2doctor.api.platform:report_ros2_info',
-            'report_network = ros2doctor.api.network:NetworkCheck',
+            'PlatformReport = ros2doctor.api.platform:PlatformReport',
+            'RosdistroReport = ros2doctor.api.platform:RosdistroReport',
+            'NetworkReport = ros2doctor.api.network:NetworkReport',
         ],
     }
 )

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -32,12 +32,12 @@ setup(
         ],
         'ros2doctor.checks': [
             'check_platform = ros2doctor.api.platform:check_platform',
-            'check_network_config = ros2doctor.api.network:check_network_config',
+            'check_network_config = ros2doctor.api.network:NetworkCheck',
         ],
         'ros2doctor.report': [
-            'report_platform = ros2doctor.api.platform:report_platform_info',
-            'report_ros_distro = ros2doctor.api.platform:report_ros2_info',
-            'report_network_config = ros2doctor.api.network:report_network',
+            'report_platform_info = ros2doctor.api.platform:report_platform_info',
+            'report_ros2_info = ros2doctor.api.platform:report_ros2_info',
+            'report_network = ros2doctor.api.network:NetworkCheck',
         ],
     }
 )

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -32,6 +32,7 @@ setup(
         ],
         'ros2doctor.checks': [
             'check_platform = ros2doctor.api.platform:check_platform',
+            'check_network = ros2doctor.api.network:check_network',
         ],
         'ros2doctor.report': [
             'report_platform = ros2doctor.api.platform:print_platform_info',

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -32,11 +32,12 @@ setup(
         ],
         'ros2doctor.checks': [
             'check_platform = ros2doctor.api.platform:check_platform',
-            'check_network = ros2doctor.api.network:check_network',
+            'check_network_config = ros2doctor.api.network:check_network_config',
         ],
         'ros2doctor.report': [
             'report_platform = ros2doctor.api.platform:print_platform_info',
             'report_ros_distro = ros2doctor.api.platform:print_ros2_info',
+            'report_network_config = ros2doctor.api.network:print_network',
         ],
     }
 )


### PR DESCRIPTION
Import error added in `network.py` as a temporary fix for `ifcfg` module. Will remove and update with build dependency once a `deb` package is ready.

This is an enhancement to `report` feature based on previous discussion https://github.com/ros2/ros2cli/pull/319#discussion_r317217343 

This PR adds `--report_failed` argument, which allows user to only print report of failed checks. Major changes happen in `format.py` and `doctor.py` files. 

Report content is output from each check module and indexed by their module names in `generate_report()`. They are printed out by calling `format_print(modules, report)`. The function takes module names and print out their indexed report, with dynamically allocated space padding computed by `compute_padding`. 