### PR TITLE
Add warning and error handling for `ifcfg` import on Windows and OSX

### DIFF
--- a/ros2doctor/README.md
+++ b/ros2doctor/README.md
@@ -15,16 +15,19 @@ Run `ros2 doctor -r/--report` to see details of checks.
 
 ## Add New Checks
 
-To add your own checks or information to report, use [Python entry points](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points) to add modules to `setup.py`. See example below:
+To add your own checks or information to report, use [Python entry points](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points) to add modules to `setup.py`.
+See example below:
 
 ```python
     entry_points={
         'ros2doctor.checks': [
-            'check_platform = ros2doctor.api.platform:check_platform',
+            'PlatformCheck = ros2doctor.api.platform:PlatformCheck',
+            'NetworkCheck = ros2doctor.api.network:NetworkCheck',
         ],
         'ros2doctor.report': [
-            'report_platform = ros2doctor.api.platform:print_platform_info',
-            'report_ros_distro = ros2doctor.api.platform:print_ros2_info',
+            'PlatformReport = ros2doctor.api.platform:PlatformReport',
+            'RosdistroReport = ros2doctor.api.platform:RosdistroReport',
+            'NetworkReport = ros2doctor.api.network:NetworkReport',
         ],
     }
 ```

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -9,8 +9,8 @@
 
   <depend>ros2cli</depend>
 
-  <exec_depend>python3-rosdistro-modules</exec_depend>
   <exec_depend>python3-ifcfg</exec_depend>
+  <exec_depend>python3-rosdistro-modules</exec_depend>
   
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -10,6 +10,7 @@
   <depend>ros2cli</depend>
 
   <exec_depend>python3-rosdistro-modules</exec_depend>
+  <exec_depend>python3-ifcfg</exec_depend>
   
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -72,6 +72,7 @@ def run_checks() -> Tuple[Set[str], int, int]:
     fail = 0
     total = 0
     for check_entry_pt in iter_entry_points('ros2doctor.checks'):
+        result = ''  # default to invalid
         try:
             check_class = check_entry_pt.load()
         except (ImportError, UnknownExtra):
@@ -103,6 +104,8 @@ def generate_reports(*, categories=None) -> List[Report]:
     """
     reports = []
     for report_entry_pt in iter_entry_points('ros2doctor.report'):
+        report = ''  # default to invalid
+        report_category = ''  # init val
         try:
             report_class = report_entry_pt.load()
         except (ImportError, UnknownExtra):

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -114,11 +114,11 @@ def generate_reports(*, categories=None) -> List[Report]:
         try:
             report_category = report_instance.category()
             report = report_instance.report()
+            if categories:
+                if report_category in categories:
+                    reports.append(report)
+            else:
+                reports.append(report)
         except Exception:
             doctor_warn('Fail to call %s class functions.' % report_entry_pt.name)
-        if categories:
-            if report_category in categories:
-                reports.append(report)
-        else:
-            reports.append(report)
     return reports

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -101,8 +101,6 @@ def generate_reports(*, categories=None) -> List[Report]:
     """
     reports = []
     for report_entry_pt in iter_entry_points('ros2doctor.report'):
-        report = Report('')  # default to invalid
-        report_category = ''
         try:
             report_class = report_entry_pt.load()
         except (ImportError, UnknownExtra):

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -91,7 +91,7 @@ def run_checks() -> Tuple[Set[str], int, int]:
                 failed_cats.add(check_category)
             total += 1
         else:
-            doctor_warn('Check result is invalid in %s.' % check_entry_pt.name)
+            doctor_warn('Check result from %s is invalid.' % check_entry_pt.name)
     return failed_cats, fail, total
 
 
@@ -123,5 +123,5 @@ def generate_reports(*, categories=None) -> List[Report]:
             else:
                 reports.append(report)
         else:
-            doctor_warn('Report is invalid for %s.' % report_entry_pt.name)
+            doctor_warn('Report from %s is invalid.' % report_entry_pt.name)
     return reports

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -91,7 +91,7 @@ def run_checks() -> Tuple[Set[str], int, int]:
                 failed_cats.add(check_category)
             total += 1
         else:
-            doctor_warn('No check result found in %s.' % check_entry_pt.name)
+            doctor_warn('Check result is invalid in %s.' % check_entry_pt.name)
     return failed_cats, fail, total
 
 
@@ -123,5 +123,5 @@ def generate_reports(*, categories=None) -> List[Report]:
             else:
                 reports.append(report)
         else:
-            doctor_warn('No report generated for %s.' % report_entry_pt.name)
+            doctor_warn('Report is invalid for %s.' % report_entry_pt.name)
     return reports

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -85,7 +85,7 @@ def run_checks() -> Tuple[Set[str], int, int]:
             result = check_instance.check()
         except Exception:
             doctor_warn('Fail to call %s class functions.' % check_entry_pt.name)
-        if type(result) == type(True):
+        if isinstance(result, bool):
             if result is False:
                 fail += 1
                 failed_cats.add(check_category)
@@ -116,7 +116,7 @@ def generate_reports(*, categories=None) -> List[Report]:
             report = report_instance.report()
         except Exception:
             doctor_warn('Fail to call %s class functions.' % report_entry_pt.name)
-        if type(report) == Report(''):
+        if isinstance(report, Report):
             if categories:
                 if report_category in categories:
                     reports.append(report)

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -85,10 +85,13 @@ def run_checks() -> Tuple[Set[str], int, int]:
             result = check_instance.check()
         except Exception:
             doctor_warn('Fail to call %s class functions.' % check_entry_pt.name)
-        if result is False:
-            fail += 1
-            failed_cats.add(check_category)
-        total += 1
+        if type(result) == type(True):
+            if result is False:
+                fail += 1
+                failed_cats.add(check_category)
+            total += 1
+        else:
+            doctor_warn('No check result found in %s.' % check_entry_pt.name)
     return failed_cats, fail, total
 
 
@@ -113,9 +116,12 @@ def generate_reports(*, categories=None) -> List[Report]:
             report = report_instance.report()
         except Exception:
             doctor_warn('Fail to call %s class functions.' % report_entry_pt.name)
-        if categories:
-            if report_category in categories:
+        if type(report) == Report(''):
+            if categories:
+                if report_category in categories:
+                    reports.append(report)
+            else:
                 reports.append(report)
         else:
-            reports.append(report)
+            doctor_warn('No report generated for %s.' % report_entry_pt.name)
     return reports

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 from typing import List
 from typing import Tuple
 import warnings

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -24,11 +24,6 @@ def format_print(report):
 
     :param report: Report object with name and items list
     """
-    # temp fix for missing ifcfg
-    if report is None:
-        sys.stderr.write('No report found. Skip print...\n')
-        return
-
     print('\n ', report.name)
     padding_num = compute_padding(report.items)
     for item_name, item_content in report.items:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
 from typing import Tuple
 
 from ros2doctor.api import DoctorCheck

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -59,7 +59,7 @@ class NetworkCheck(DoctorCheck):
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
             doctor_warn('ifcfg is not imported. Unable to run network check.')
-            return None
+            return False
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
         if not has_loopback:
@@ -84,7 +84,7 @@ class NetworkReport(DoctorReport):
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
             doctor_warn('ifcfg is not imported. Unable to generate network report.')
-            return None
+            return Report('')
 
         network_report = Report('NETWORK CONFIGURATION')
         for name, iface in ifcfg_ifaces.items():

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -25,7 +25,7 @@ try:
     import ifcfg
 except ImportError:  # check import error for windows and osx
     doctor_warn('Failed to import ifcfg. '
-                  'Use `python -m pip install ifcfg` to install needed package.')
+                'Use `python -m pip install ifcfg` to install needed package.')
 
 
 def _is_unix_like_platform() -> bool:
@@ -59,7 +59,7 @@ class NetworkCheck(DoctorCheck):
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
-            doctor_warn('ifcfg not imported. Unable to run network check.')
+            doctor_warn('ifcfg is not imported. Unable to run network check.')
             return None
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
@@ -84,7 +84,7 @@ class NetworkReport(DoctorReport):
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
-            doctor_warn('ifcfg not imported. Unable to generate network report.')
+            doctor_warn('ifcfg is not imported. Unable to generate network report.')
             return None
 
         network_report = Report('NETWORK CONFIGURATION')


### PR DESCRIPTION
This PR tells windows and osx users to install `ifcfg` with `pip`, handles the error cases when package fails to be imported and when network check/report is unable to run. It adds additional type check for check result and report, to make sure when custom plug-in is implemented incorrectly, the process does not break. 