### PR TITLE
ros2doctor: add `--include-warning` arg

### DIFF
--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -71,10 +71,12 @@ class Result:
         self.error = 0
         self.warning = 0
 
-    def increment_error(self) -> None:
+    def add_error(self, msg) -> None:
+        doctor_warn(msg)
         self.error += 1
 
-    def increment_warning(self) -> None:
+    def add_warning(self, msg) -> None:
+        doctor_warn(msg)
         self.warning += 1
 
 

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -70,7 +70,7 @@ class Result:
         """Initialize with no error or warning."""
         self.error = 0
         self.warning = 0
-    
+
     def increment_error(self) -> None:
         self.error += 1
 

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -18,6 +18,7 @@ from typing import Tuple
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
+from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_warn
 
 try:
@@ -54,21 +55,26 @@ class NetworkCheck(DoctorCheck):
 
     def check(self):
         """Check network configuration."""
+        result = Result()
         # check ifcfg import for windows and osx users
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
             doctor_warn('ifcfg is not imported. Unable to run network check.')
-            return False
+            result.increment_error()
+            return result
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
         if not has_loopback:
             doctor_warn('ERROR: No loopback IP address is found.')
+            result.increment_error()
         if not has_non_loopback:
             doctor_warn('Only loopback IP address is found.')
+            result.increment_warning()
         if not has_multicast:
             doctor_warn('No multicast IP address is found.')
-        return has_loopback and has_non_loopback and has_multicast
+            result.increment_warning()
+        return result
 
 
 class NetworkReport(DoctorReport):

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -60,20 +60,16 @@ class NetworkCheck(DoctorCheck):
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
-            doctor_warn('ifcfg is not imported. Unable to run network check.')
-            result.increment_error()
+            result.add_error('ERROR: ifcfg is not imported. Unable to run network check.')
             return result
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
         if not has_loopback:
-            doctor_warn('ERROR: No loopback IP address is found.')
-            result.increment_error()
+            result.add_error('ERROR: No loopback IP address is found.')
         if not has_non_loopback:
-            doctor_warn('Only loopback IP address is found.')
-            result.increment_warning()
+            result.add_warning('Only loopback IP address is found.')
         if not has_multicast:
-            doctor_warn('No multicast IP address is found.')
-            result.increment_warning()
+            result.add_warning('No multicast IP address is found.')
         return result
 
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -19,6 +19,7 @@ from typing import Tuple
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
+from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_warn
 
 import rosdistro
@@ -57,9 +58,10 @@ class PlatformCheck(DoctorCheck):
 
     def check(self):
         """Check system platform against ROS 2 Distro."""
-        result = False
+        result = Result()
         distros = _check_platform_helper()
         if not distros:
+            result.increment_error()
             return result
         distro_name, distro_info, _ = distros
 
@@ -68,12 +70,12 @@ class PlatformCheck(DoctorCheck):
             doctor_warn('Distribution %s is not fully supported or tested. '
                         'To get more consistent features, download a stable version at '
                         'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+            result.increment_warning()
         elif distro_info.get('distribution_status') == 'end-of-life':
             doctor_warn('Distribution %s is no longer supported or deprecated. '
                         'To get the latest features, download the new versions at '
                         'https://index.ros.org/doc/ros2/Installation/' % distro_name)
-        else:
-            result = True
+            result.increment_warning()
         return result
 
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -61,21 +61,19 @@ class PlatformCheck(DoctorCheck):
         result = Result()
         distros = _check_platform_helper()
         if not distros:
-            result.increment_error()
+            result.add_error('ERROR: Missing rosdistro info. Unable to check platform.')
             return result
         distro_name, distro_info, _ = distros
 
         # check distro status
         if distro_info.get('distribution_status') == 'prerelease':
-            doctor_warn('Distribution %s is not fully supported or tested. '
-                        'To get more consistent features, download a stable version at '
-                        'https://index.ros.org/doc/ros2/Installation/' % distro_name)
-            result.increment_warning()
+            result.add_warning('Distribution %s is not fully supported or tested. '
+                               'To get more consistent features, download a stable version at '
+                               'https://index.ros.org/doc/ros2/Installation/' % distro_name)
         elif distro_info.get('distribution_status') == 'end-of-life':
-            doctor_warn('Distribution %s is no longer supported or deprecated. '
-                        'To get the latest features, download the new versions at '
-                        'https://index.ros.org/doc/ros2/Installation/' % distro_name)
-            result.increment_warning()
+            result.add_warning('Distribution %s is no longer supported or deprecated. '
+                               'To get the latest features, download the new versions at '
+                               'https://index.ros.org/doc/ros2/Installation/' % distro_name)
         return result
 
 

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -31,6 +31,10 @@ class DoctorCommand(CommandExtension):
             '--report-failed', '-rf', action='store_true',
             help='Print reports of failed checks only.'
         )
+        parser.add_argument(
+            '--include-warnings', '-iw', action='store_true',
+            help='Include warnings as failed checks. Default sets warnings to be ignored.'
+        )
 
     def main(self, *, parser, args):
         """Run checks and print report to terminal based on user input args."""
@@ -41,8 +45,11 @@ class DoctorCommand(CommandExtension):
                 format_print(report_obj)
             return
 
-        # `ros2 doctor`
-        failed_cats, fail, total = run_checks()
+        # `ros2 doctor
+        if args.include_warnings:
+            failed_cats, fail, total = run_checks(include_warnings=True)
+        else:
+            failed_cats, fail, total = run_checks()
         if fail:
             print('\n%d/%d checks failed\n' % (fail, total))
             print('Failed modules are ', *failed_cats)

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -33,7 +33,7 @@ class DoctorCommand(CommandExtension):
         )
         parser.add_argument(
             '--include-warnings', '-iw', action='store_true',
-            help='Include warnings as failed checks. Default sets warnings to be ignored.'
+            help='Include warnings as failed checks. Warnings are ignored by default.'
         )
 
     def main(self, *, parser, args):

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -46,10 +46,7 @@ class DoctorCommand(CommandExtension):
             return
 
         # `ros2 doctor
-        if args.include_warnings:
-            failed_cats, fail, total = run_checks(include_warnings=True)
-        else:
-            failed_cats, fail, total = run_checks()
+        failed_cats, fail, total = run_checks(include_warnings=args.include_warnings)
         if fail:
             print('\n%d/%d checks failed\n' % (fail, total))
             print('Failed modules are ', *failed_cats)


### PR DESCRIPTION
Adds arg `--include-warning/-iw` to ros2doctor CLI. It reports both warnings and errors as failed checks, while the default only includes errors. It can be used in combination with `--report-failed/-rf` or by itself when running `ros2 doctor` checks. It lets users choose how extensive the checks and reports cover.  