### PR TITLE
ros2doctor: add topic check

### DIFF
--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -1,0 +1,75 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from ros2cli.node.direct import DirectNode
+from ros2cli.node.strategy import NodeStrategy
+from ros2doctor.api import DoctorCheck
+from ros2doctor.api import DoctorReport
+from ros2doctor.api import Report
+from ros2doctor.api import Result
+from ros2topic.api import get_topic_names
+
+
+def _get_topics() -> List:
+    """Get all topic names using ros2topic API."""
+    white_list = ['/parameter_events', '/rosout']
+    topics = []
+    with NodeStrategy('') as node:
+        all_topic_names = get_topic_names(node=node)
+        for t_name in all_topic_names:
+            if t_name not in white_list:
+                topics.append(t_name)
+    return topics
+
+
+class TopicCheck(DoctorCheck):
+    """Check for pub without sub or sub without pub."""
+
+    def category(self):
+        return 'topic'
+
+    def check(self):
+        """Check publisher and subscriber counts."""
+        result = Result()
+        to_be_checked = _get_topics()
+        for topic in to_be_checked:
+            with DirectNode(topic) as node:
+                pub_count = node.count_publishers(topic)
+                sub_count = node.count_subscribers(topic)
+                if pub_count > sub_count:
+                    result.add_warning('Publisher without subscriber detected on %s.' % topic)
+                elif pub_count < sub_count:
+                    result.add_warning('Subscriber without publisher detected on %s.' % topic)
+        return result
+
+
+class TopicReport(DoctorReport):
+    """Report `ros2 topic info` output."""
+
+    def category(self):
+        return 'topic'
+
+    def report(self):
+        report = Report('TOPIC LIST')
+        to_be_reported = _get_topics()
+        if not to_be_reported:
+            report.add_to_report('topic', 'none')
+        for topic in to_be_reported:
+            with DirectNode(topic) as node:
+                report.add_to_report('topic', topic)
+                report.add_to_report('publisher count', node.count_publishers(topic))
+                report.add_to_report('subscriber count', node.count_subscribers(topic))
+        return report

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -66,6 +66,8 @@ class TopicReport(DoctorReport):
         to_be_reported = _get_topic_names()
         if not to_be_reported:
             report.add_to_report('topic', 'none')
+            report.add_to_report('publisher count', 0)
+            report.add_to_report('subscriber count', 0)
         with DirectNode(None) as node:
             for topic in to_be_reported:
                 report.add_to_report('topic', topic)

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -23,7 +23,7 @@ from ros2doctor.api import Result
 
 
 def _get_topic_names() -> List:
-    """Get all topic names using ros2topic API."""
+    """Get all topic names using rclpy API."""
     white_list = ['/parameter_events', '/rosout']
     topics = []
     with NodeStrategy(None) as node:
@@ -56,7 +56,7 @@ class TopicCheck(DoctorCheck):
 
 
 class TopicReport(DoctorReport):
-    """Report `ros2 topic info` output."""
+    """Report topic related information."""
 
     def category(self):
         return 'topic'

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -40,12 +40,14 @@ setup(
         'ros2doctor.checks': [
             'PlatformCheck = ros2doctor.api.platform:PlatformCheck',
             'NetworkCheck = ros2doctor.api.network:NetworkCheck',
+            'TopicCheck = ros2doctor.api.topic:TopicCheck',
         ],
         'ros2doctor.report': [
             'PlatformReport = ros2doctor.api.platform:PlatformReport',
             'RosdistroReport = ros2doctor.api.platform:RosdistroReport',
             'NetworkReport = ros2doctor.api.network:NetworkReport',
             'RMWReport = ros2doctor.api.rmw:RMWReport',
+            'TopicReport = ros2doctor.api.topic:TopicReport',
         ],
     }
 )

--- a/ros2doctor/test/test_topic.py
+++ b/ros2doctor/test/test_topic.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2doctor.api import Report
+from ros2doctor.api.topic import TopicCheck
+from ros2doctor.api.topic import TopicReport
+
+
+def test_topic_check():
+    topic_check = TopicCheck()
+    check_result = topic_check.check()
+    assert check_result.error == 0
+    assert check_result.warning == 0
+
+
+def _generate_expected_report(report_name, pub_count, sub_count):
+    pass
+
+
+def test_topic_report():
+    
+    pass

--- a/ros2doctor/test/test_topic.py
+++ b/ros2doctor/test/test_topic.py
@@ -18,16 +18,24 @@ from ros2doctor.api.topic import TopicReport
 
 
 def test_topic_check():
+    """Assume no topics are publishing or subscribing other than whitelisted ones."""
     topic_check = TopicCheck()
     check_result = topic_check.check()
     assert check_result.error == 0
     assert check_result.warning == 0
 
 
-def _generate_expected_report(report_name, pub_count, sub_count):
-    pass
+def _generate_expected_report(topic, pub_count, sub_count):
+    expected_report = Report('TOPIC LIST')
+    expected_report.add_to_report('topic', topic)
+    expected_report.add_to_report('publisher count', pub_count)
+    expected_report.add_to_report('subscriber count', sub_count)
+    return expected_report
 
 
 def test_topic_report():
-    
-    pass
+    """Assume no topics are publishing or subscribing other than whitelisted ones."""
+    report = TopicReport().report()
+    expected_report = _generate_expected_report('none', 0, 0)
+    assert report.name == expected_report.name
+    assert report.items == expected_report.items


### PR DESCRIPTION
Check for cases like pub without sub or sub without pub using `ros2topic` and `ros2cli` API. Report contains same content as `ros2 topic info` outputs. Also adds unit tests for `TopicCheck` and `TopicReport`.