### PR TITLE
[dashing] Handle find_container_node_names error (#322)

### DIFF
--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -201,7 +201,10 @@ def find_container_node_names(*, node, node_names):
     """
     container_node_names = []
     for n in node_names:
-        services = get_service_info(node=node, remote_node_name=n.full_name)
+        try:
+            services = get_service_info(node=node, remote_node_name=n.full_name)
+        except rclpy.node.NodeNameNonExistentError:
+            continue
         if not any(s.name.endswith('_container/load_node') and
                    'composition_interfaces/srv/LoadNode' in s.types
                    for s in services):

--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -203,7 +203,7 @@ def find_container_node_names(*, node, node_names):
     for n in node_names:
         try:
             services = get_service_info(node=node, remote_node_name=n.full_name)
-        except rclpy.node.NodeNameNonExistentError:
+        except RuntimeError:
             continue
         if not any(s.name.endswith('_container/load_node') and
                    'composition_interfaces/srv/LoadNode' in s.types


### PR DESCRIPTION
Resolves https://github.com/ros2/ros2cli/issues/337

This is a backport of #322, but with a small change.

Since `NodeNameNonExistentError` doesn't exist in Dashing, we use the more generic `RuntimeError` instead.