### PR TITLE
ros2node info: add action category

### DIFF
--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -14,8 +14,10 @@
 
 from collections import namedtuple
 
+from rclpy.action.graph import get_action_names_and_types
 from rclpy.node import HIDDEN_NODE_PREFIX
 from ros2cli.node.strategy import NodeStrategy
+
 
 NodeName = namedtuple('NodeName', ('name', 'namespace', 'full_name'))
 TopicInfo = namedtuple('Topic', ('name', 'types'))
@@ -74,6 +76,16 @@ def get_publisher_info(*, node, remote_node_name):
 
 def get_service_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_service_names_and_types_by_node)
+
+
+def get_action_info(*, remote_node_name):
+    node = parse_node_name(remote_node_name)
+    names_and_types = get_action_names_and_types(node)
+    return [
+        TopicInfo(
+            name=n,
+            types=t)
+        for n, t in names_and_types]
 
 
 class NodeNameCompleter:

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -78,8 +78,8 @@ def get_service_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_service_names_and_types_by_node)
 
 
-def get_action_info(*, remote_node_name):
-    node = parse_node_name(remote_node_name)
+def get_action_info(*, node):
+    # node = parse_node_name(remote_node_name)
     names_and_types = get_action_names_and_types(node)
     return [
         TopicInfo(

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -82,7 +82,7 @@ def get_service_info(*, node, remote_node_name):
 def get_action_server_info(*, node, remote_node_name):
     remote_node = parse_node_name(remote_node_name)
     names_and_types = get_action_server_names_and_types_by_node(
-                        node, remote_node.name, remote_node.namespace)
+        node, remote_node.name, remote_node.namespace)
     return [
         TopicInfo(
             name=n,
@@ -93,7 +93,7 @@ def get_action_server_info(*, node, remote_node_name):
 def get_action_client_info(*, node, remote_node_name):
     remote_node = parse_node_name(remote_node_name)
     names_and_types = get_action_client_names_and_types_by_node(
-                        node, remote_node.name, remote_node.namespace)
+        node, remote_node.name, remote_node.namespace)
     return [
         TopicInfo(
             name=n,

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -14,7 +14,8 @@
 
 from collections import namedtuple
 
-from rclpy.action.graph import get_action_names_and_types
+from rclpy.action.graph import get_action_client_names_and_types_by_node
+from rclpy.action.graph import get_action_server_names_and_types_by_node
 from rclpy.node import HIDDEN_NODE_PREFIX
 from ros2cli.node.strategy import NodeStrategy
 
@@ -78,9 +79,21 @@ def get_service_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_service_names_and_types_by_node)
 
 
-def get_action_info(*, node):
-    # node = parse_node_name(remote_node_name)
-    names_and_types = get_action_names_and_types(node)
+def get_action_server_info(*, node, remote_node_name):
+    remote_node = parse_node_name(remote_node_name)
+    names_and_types = get_action_server_names_and_types_by_node(
+                        node, remote_node.name, remote_node.namespace)
+    return [
+        TopicInfo(
+            name=n,
+            types=t)
+        for n, t in names_and_types]
+
+
+def get_action_client_info(*, node, remote_node_name):
+    remote_node = parse_node_name(remote_node_name)
+    names_and_types = get_action_client_names_and_types_by_node(
+                        node, remote_node.name, remote_node.namespace)
     return [
         TopicInfo(
             name=n,

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -15,6 +15,7 @@
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
+from ros2node.api import get_action_info
 from ros2node.api import get_node_names
 from ros2node.api import get_publisher_info
 from ros2node.api import get_service_info
@@ -52,5 +53,8 @@ class InfoVerb(VerbExtension):
                 services = get_service_info(node=node, remote_node_name=args.node_name)
                 print('  Services:')
                 print_names_and_types(services)
+                actions = get_action_info(remote_node_name=args.node_name)
+                print('  Actions:')
+                print_names_and_types(actions)
         else:
             return "Unable to find node '" + args.node_name + "'"

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -15,7 +15,8 @@
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2node.api import get_action_info
+from ros2node.api import get_action_client_info
+from ros2node.api import get_action_server_info
 from ros2node.api import get_node_names
 from ros2node.api import get_publisher_info
 from ros2node.api import get_service_info
@@ -53,8 +54,13 @@ class InfoVerb(VerbExtension):
                 services = get_service_info(node=node, remote_node_name=args.node_name)
                 print('  Services:')
                 print_names_and_types(services)
-                actions = get_action_info(node=node)
-                print('  Actions:')
-                print_names_and_types(actions)
+                actions_servers = get_action_server_info(
+                                    node=node, remote_node_name=args.node_name)
+                print('  Actions Servers:')
+                print_names_and_types(actions_servers)
+                actions_clients = get_action_client_info(
+                                    node=node, remote_node_name=args.node_name)
+                print('  Actions Clients:')
+                print_names_and_types(actions_clients)
         else:
             return "Unable to find node '" + args.node_name + "'"

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -53,7 +53,7 @@ class InfoVerb(VerbExtension):
                 services = get_service_info(node=node, remote_node_name=args.node_name)
                 print('  Services:')
                 print_names_and_types(services)
-                actions = get_action_info(remote_node_name=args.node_name)
+                actions = get_action_info(node=node)
                 print('  Actions:')
                 print_names_and_types(actions)
         else:

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -55,11 +55,11 @@ class InfoVerb(VerbExtension):
                 print('  Services:')
                 print_names_and_types(services)
                 actions_servers = get_action_server_info(
-                                    node=node, remote_node_name=args.node_name)
+                    node=node, remote_node_name=args.node_name)
                 print('  Actions Servers:')
                 print_names_and_types(actions_servers)
                 actions_clients = get_action_client_info(
-                                    node=node, remote_node_name=args.node_name)
+                    node=node, remote_node_name=args.node_name)
                 print('  Actions Clients:')
                 print_names_and_types(actions_clients)
         else:


### PR DESCRIPTION
Signed-off-by: claireyywang <clairewang@openrobotics.org>

Resolves #344 

Adds separate action category to `ros2 node info`. Output looks like 
```
clairewang@karr:~/ros2_ws/src/ros2/ros2cli/ros2node$ ros2 node info /fibonacci_action_server /fibonacci_action_server
  Subscribers:

  Publishers:
    /fibonacci/_action/feedback: action_tutorials_interfaces/action/Fibonacci_FeedbackMessage
    /fibonacci/_action/status: action_msgs/msg/GoalStatusArray
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /rosout: rcl_interfaces/msg/Log
  Services:
    /fibonacci/_action/cancel_goal: action_msgs/srv/CancelGoal
    /fibonacci/_action/get_result: action_tutorials_interfaces/action/Fibonacci_GetResult
    /fibonacci/_action/send_goal: action_tutorials_interfaces/action/Fibonacci_SendGoal
    /fibonacci_action_server/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /fibonacci_action_server/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /fibonacci_action_server/get_parameters: rcl_interfaces/srv/GetParameters
    /fibonacci_action_server/list_parameters: rcl_interfaces/srv/ListParameters
    /fibonacci_action_server/set_parameters: rcl_interfaces/srv/SetParameters
    /fibonacci_action_server/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
  Actions:
    /fibonacci: action_tutorials_interfaces/action/Fibonacci
```
Should I also modify `Services` category? It seems to include more than what's mentioned in #344 