### PR TITLE
Add verbose info for topic list

### DIFF
--- a/ros2topic/ros2topic/verb/list.py
+++ b/ros2topic/ros2topic/verb/list.py
@@ -19,6 +19,18 @@ from ros2topic.api import get_topic_names_and_types
 from ros2topic.verb import VerbExtension
 
 
+def show_topic_info(topic_info, isPub):
+    print('\n' + ('Published' if isPub else 'Subscribed') + ' topics:')
+    for (topic_name, topic_types, pub_cnt, sub_cnt) in topic_info:
+        cnt = pub_cnt if isPub else sub_cnt
+        if cnt:
+            topic_types_formatted = ', '.join(topic_types)
+            cnt_str = str(cnt) + ' ' + ('publisher' if isPub else 'subscriber') \
+                                     + ('s' if cnt > 1 else '')
+            msg = ' * {topic_name} [{topic_types_formatted}] {cnt_str}'
+            print(msg.format_map(locals()))
+
+
 class ListVerb(VerbExtension):
     """Output a list of available topics."""
 
@@ -54,24 +66,8 @@ class ListVerb(VerbExtension):
             print(len(topic_names_and_types))
         elif topic_names_and_types:
             if args.verbose:
-                print('Published topics:')
-                for (topic_name, topic_types, pub_cnt, sub_cnt) in topic_info:
-                    if pub_cnt < 1:
-                        continue
-                    topic_types_formatted = ', '.join(topic_types)
-                    cnt_str = str(pub_cnt) + ' publisher' + ('s' if pub_cnt > 1 else '')
-                    msg = ' * {topic_name} [{topic_types_formatted}] {cnt_str}'
-                    print(msg.format_map(locals()))
-                print('')
-                print('Subscribed topics:')
-                for (topic_name, topic_types, pub_cnt, sub_cnt) in topic_info:
-                    if sub_cnt < 1:
-                        continue
-                    topic_types_formatted = ', '.join(topic_types)
-                    cnt_str = str(sub_cnt) + ' subscriber' + ('s' if sub_cnt > 1 else '')
-                    msg = ' * {topic_name} [{topic_types_formatted}] {cnt_str}'
-                    print(msg.format_map(locals()))
-                print('')
+                show_topic_info(topic_info, isPub=True)
+                show_topic_info(topic_info, isPub=False)
             else:
                 for (topic_name, topic_types, pub_cnt, sub_cnt) in topic_info:
                     msg = '{topic_name}'

--- a/ros2topic/ros2topic/verb/list.py
+++ b/ros2topic/ros2topic/verb/list.py
@@ -26,7 +26,7 @@ def show_topic_info(topic_info, isPub):
         if cnt:
             topic_types_formatted = ', '.join(topic_types)
             cnt_str = str(cnt) + ' ' + ('publisher' if isPub else 'subscriber') \
-                                     + ('s' if cnt > 1 else '')
+                + ('s' if cnt > 1 else '')
             msg = ' * {topic_name} [{topic_types_formatted}] {cnt_str}'
             print(msg.format_map(locals()))
 

--- a/ros2topic/ros2topic/verb/list.py
+++ b/ros2topic/ros2topic/verb/list.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import get_topic_names_and_types
@@ -53,7 +52,7 @@ class ListVerb(VerbExtension):
 
     def main(self, *, args):
         topic_info = []
-        with DirectNode(args) as node:
+        with NodeStrategy(args) as node:
             topic_names_and_types = get_topic_names_and_types(
                 node=node,
                 include_hidden_topics=args.include_hidden_topics)

--- a/ros2topic/ros2topic/verb/list.py
+++ b/ros2topic/ros2topic/verb/list.py
@@ -74,4 +74,3 @@ class ListVerb(VerbExtension):
                     if args.show_types:
                         msg += ' [{topic_types_formatted}]'
                     print(msg.format_map(locals()))
-

--- a/ros2topic/ros2topic/verb/list.py
+++ b/ros2topic/ros2topic/verb/list.py
@@ -34,6 +34,9 @@ class ListVerb(VerbExtension):
         parser.add_argument(
             '--include-hidden-topics', action='store_true',
             help='Consider hidden topics as well')
+        parser.add_argument(
+            '-v', '--verbose', action='store_true',
+            help='list full details about each topic')
 
     def main(self, *, args):
         with NodeStrategy(args) as node:

--- a/ros2topic/ros2topic/verb/list.py
+++ b/ros2topic/ros2topic/verb/list.py
@@ -47,7 +47,7 @@ class ListVerb(VerbExtension):
                 topic_types_formatted = ', '.join(topic_types)
                 count_str = str(count) + ' ' + ('publisher' if is_publisher else 'subscriber') \
                     + ('s' if count > 1 else '')
-                message += ' * %s [%s] %s\n' % (topic_name, topic_types_formatted, count_str)
+                message += f' * {topic_name} [{topic_types_formatted}] {count_str}\n'
         return message
 
     def main(self, *, args):
@@ -57,9 +57,12 @@ class ListVerb(VerbExtension):
                 node=node,
                 include_hidden_topics=args.include_hidden_topics)
             for (topic_name, topic_types) in topic_names_and_types:
-                pub_count = node.count_publishers(topic_name)
-                sub_count = node.count_subscribers(topic_name)
-                topic_info.append((topic_name, topic_types, pub_count, sub_count))
+                if args.verbose:
+                    pub_count = node.count_publishers(topic_name)
+                    sub_count = node.count_subscribers(topic_name)
+                    topic_info.append((topic_name, topic_types, pub_count, sub_count))
+                else:
+                    topic_info.append((topic_name, topic_types, 0, 0))
 
         if args.count_topics:
             print(len(topic_names_and_types))

--- a/ros2topic/ros2topic/verb/list.py
+++ b/ros2topic/ros2topic/verb/list.py
@@ -69,7 +69,7 @@ class ListVerb(VerbExtension):
                 show_topic_info(topic_info, isPub=True)
                 show_topic_info(topic_info, isPub=False)
             else:
-                for (topic_name, topic_types, pub_cnt, sub_cnt) in topic_info:
+                for (topic_name, topic_types, _, _) in topic_info:
                     msg = '{topic_name}'
                     topic_types_formatted = ', '.join(topic_types)
                     if args.show_types:

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -261,7 +261,6 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                '',
                 'Published topics:',
                 ' * /arrays [test_msgs/msg/Arrays] 1 publisher',
                 ' * /bounded_sequences [test_msgs/msg/BoundedSequences] 1 publisher',
@@ -274,6 +273,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 '',
                 'Subscribed topics:',
                 ' * /chit_chatter [std_msgs/msg/String] 1 subscriber',
+                '',
             ],
             text=topic_command.output,
             strict=True

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -255,6 +255,31 @@ class TestROS2TopicCLI(unittest.TestCase):
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_list_with_verbose(self):
+        with self.launch_topic_command(arguments=['list', '-v']) as topic_command:
+            assert topic_command.wait_for_shutdown(timeout=10)
+        assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                '',
+                'Published topics:',
+                ' * /arrays [test_msgs/msg/Arrays] 1 publisher',
+                ' * /bounded_sequences [test_msgs/msg/BoundedSequences] 1 publisher',
+                ' * /chatter [std_msgs/msg/String] 1 publisher',
+                ' * /cmd_vel [geometry_msgs/msg/TwistStamped] 1 publisher',
+                ' * /defaults [test_msgs/msg/Defaults] 1 publisher',
+                ' * /parameter_events [rcl_interfaces/msg/ParameterEvent] 9 publishers',
+                ' * /rosout [rcl_interfaces/msg/Log] 9 publishers',
+                ' * /unbounded_sequences [test_msgs/msg/UnboundedSequences] 1 publisher',
+                '',
+                'Subscribed topics:',
+                ' * /chit_chatter [std_msgs/msg/String] 1 subscriber',
+            ],
+            text=topic_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_count(self):
         with self.launch_topic_command(arguments=['list', '-c']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)


### PR DESCRIPTION
According to #347, the PR adds option `-v` to show more info for topic list.