### PR TITLE
Fix multicast entrypoint

### DIFF
--- a/ros2multicast/setup.py
+++ b/ros2multicast/setup.py
@@ -34,7 +34,7 @@ The package provides the multicast command for the ROS 2 command line tools.""",
     tests_require=['pytest'],
     entry_points={
         'ros2cli.command': [
-            'multicast = ros2node.command.multicast:MulticastCommand',
+            'multicast = ros2multicast.command.multicast:MulticastCommand',
         ],
         'ros2cli.extension_point': [
             'ros2node.verb = ros2node.verb:VerbExtension',

--- a/ros2multicast/setup.py
+++ b/ros2multicast/setup.py
@@ -37,7 +37,7 @@ The package provides the multicast command for the ROS 2 command line tools.""",
             'multicast = ros2multicast.command.multicast:MulticastCommand',
         ],
         'ros2cli.extension_point': [
-            'ros2node.verb = ros2node.verb:VerbExtension',
+            'ros2multicast.verb = ros2multicast.verb:VerbExtension',
         ],
         'ros2multicast.verb': [
             'receive = ros2multicast.verb.receive:ReceiveVerb',


### PR DESCRIPTION
Otherwise, we see an error every time we run a ros2 command:

    Failed to load entry point 'multicast': No module named 'ros2node.command.multicast'

Bug introduced in #346 