### PR TITLE
Start version at 0.1.0

### DIFF
--- a/ros2pkg/ros2pkg/resource/ament_python/setup.py.em
+++ b/ros2pkg/ros2pkg/resource/ament_python/setup.py.em
@@ -4,7 +4,7 @@ package_name = '@project_name'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='0.1.0',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',

--- a/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(@(project_name))
 
 set(@(project_name)_MAJOR_VERSION 0)
-set(@(project_name)_MINOR_VERSION 0)
+set(@(project_name)_MINOR_VERSION 1)
 set(@(project_name)_PATCH_VERSION 0)
 set(@(project_name)_VERSION
   ${@(project_name)_MAJOR_VERSION}.${@(project_name)_MINOR_VERSION}.${@(project_name)_PATCH_VERSION})

--- a/ros2pkg/ros2pkg/resource/package_environment/package.xml.em
+++ b/ros2pkg/ros2pkg/resource/package_environment/package.xml.em
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format@(package_format).xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="@package_format">
   <name>@package_name</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>@package_description</description>
   <maintainer email="@maintainer_email">@maintainer_name</maintainer>
   <license>@package_license</license>


### PR DESCRIPTION
This changes package templates to start at version `0.1.0` instead of `0.0.0`. [0.1.0 is recommended by Semantic Versioning](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase). I think it makes sense to change it for the benefit of those that do use semantic versioning, assuming those who don't also don't care what the start version of the template is.