### PR TITLE
add completion for parameter name arguments

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -15,7 +15,9 @@
 from rcl_interfaces.msg import ParameterType
 from rcl_interfaces.msg import ParameterValue
 from rcl_interfaces.srv import GetParameters
+from rcl_interfaces.srv import ListParameters
 from rcl_interfaces.srv import SetParameters
+from ros2cli.node.direct import DirectNode
 import rclpy
 import yaml
 
@@ -139,3 +141,40 @@ def call_set_parameters(*, node, node_name, parameters):
             'Exception while calling service of node '
             "'{args.node_name}': {e}".format_map(locals()))
     return response
+
+
+def call_list_parameters(*, node, node_name, prefix=None):
+    # create client
+    client = node.create_client(
+        ListParameters,
+        '{node_name}/list_parameters'.format_map(locals()))
+
+    # call as soon as ready
+    ready = client.wait_for_service(timeout_sec=5.0)
+    if not ready:
+        raise RuntimeError('Wait for service timed out')
+
+    request = ListParameters.Request()
+    future = client.call_async(request)
+    rclpy.spin_until_future_complete(node, future)
+
+    # handle response
+    response = future.result()
+    if response is None:
+        e = future.exception()
+        raise RuntimeError(
+            "Exception while calling service of node '{node_name}': {e}"
+            .format_map(locals()))
+    return response.result.names
+
+
+class ParameterNameCompleter:
+    """Callable returning a list of parameter names."""
+
+    def __call__(self, prefix, parsed_args, **kwargs):
+        with DirectNode(parsed_args) as node:
+            parameter_names = call_list_parameters(
+                node=node, node_name=parsed_args.node_name)
+            return [
+                n for n in parameter_names
+                if not prefix or n.startswith(prefix)]

--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -17,8 +17,8 @@ from rcl_interfaces.msg import ParameterValue
 from rcl_interfaces.srv import GetParameters
 from rcl_interfaces.srv import ListParameters
 from rcl_interfaces.srv import SetParameters
-from ros2cli.node.direct import DirectNode
 import rclpy
+from ros2cli.node.direct import DirectNode
 import yaml
 
 

--- a/ros2param/ros2param/verb/delete.py
+++ b/ros2param/ros2param/verb/delete.py
@@ -24,6 +24,7 @@ from ros2node.api import get_absolute_node_name
 from ros2node.api import get_node_names
 from ros2node.api import NodeNameCompleter
 from ros2param.api import call_set_parameters
+from ros2param.api import ParameterNameCompleter
 from ros2param.verb import VerbExtension
 
 
@@ -39,8 +40,9 @@ class DeleteVerb(VerbExtension):
         parser.add_argument(
             '--include-hidden-nodes', action='store_true',
             help='Consider hidden nodes as well')
-        parser.add_argument(
-            'name', help='Name of the parameter')
+        arg = parser.add_argument(
+            'parameter_name', help='Name of the parameter')
+        arg.completer = ParameterNameCompleter()
 
     def main(self, *, args):  # noqa: D102
         with NodeStrategy(args) as node:
@@ -53,7 +55,7 @@ class DeleteVerb(VerbExtension):
 
         with DirectNode(args) as node:
             parameter = Parameter()
-            Parameter.name = args.name
+            Parameter.name = args.parameter_name
             value = ParameterValue()
             value.type = ParameterType.PARAMETER_NOT_SET
             parameter.value = value

--- a/ros2param/ros2param/verb/get.py
+++ b/ros2param/ros2param/verb/get.py
@@ -20,6 +20,7 @@ from ros2node.api import get_absolute_node_name
 from ros2node.api import get_node_names
 from ros2node.api import NodeNameCompleter
 from ros2param.api import call_get_parameters
+from ros2param.api import ParameterNameCompleter
 from ros2param.verb import VerbExtension
 
 
@@ -35,8 +36,9 @@ class GetVerb(VerbExtension):
         parser.add_argument(
             '--include-hidden-nodes', action='store_true',
             help='Consider hidden nodes as well')
-        parser.add_argument(
-            'name', help='Name of the parameter')
+        arg = parser.add_argument(
+            'parameter_name', help='Name of the parameter')
+        arg.completer = ParameterNameCompleter()
         parser.add_argument(
             '--hide-type', action='store_true',
             help='Hide the type information')
@@ -53,7 +55,7 @@ class GetVerb(VerbExtension):
         with DirectNode(args) as node:
             response = call_get_parameters(
                 node=node, node_name=args.node_name,
-                parameter_names=[args.name])
+                parameter_names=[args.parameter_name])
 
             assert len(response.values) <= 1
 

--- a/ros2param/ros2param/verb/set.py
+++ b/ros2param/ros2param/verb/set.py
@@ -23,6 +23,7 @@ from ros2node.api import get_node_names
 from ros2node.api import NodeNameCompleter
 from ros2param.api import call_set_parameters
 from ros2param.api import get_parameter_value
+from ros2param.api import ParameterNameCompleter
 from ros2param.verb import VerbExtension
 
 
@@ -38,8 +39,9 @@ class SetVerb(VerbExtension):
         parser.add_argument(
             '--include-hidden-nodes', action='store_true',
             help='Consider hidden nodes as well')
-        parser.add_argument(
-            'name', help='Name of the parameter')
+        arg = parser.add_argument(
+            'parameter_name', help='Name of the parameter')
+        arg.completer = ParameterNameCompleter()
         parser.add_argument(
             'value', help='Value of the parameter')
 
@@ -54,7 +56,7 @@ class SetVerb(VerbExtension):
 
         with DirectNode(args) as node:
             parameter = Parameter()
-            Parameter.name = args.name
+            Parameter.name = args.parameter_name
             parameter.value = get_parameter_value(string_value=args.value)
 
             response = call_set_parameters(


### PR DESCRIPTION
For the `get` and `delete` verbs. Also naming the argument `parameter_name` (rather than `name`) in the usage.