### PR TITLE
Handle bad or missing package on ros2 interface show

### DIFF
--- a/ros2interface/ros2interface/api/__init__.py
+++ b/ros2interface/ros2interface/api/__init__.py
@@ -41,6 +41,8 @@ def get_interfaces(package_name):
 
 def get_interface_path(parts):
     prefix_path = has_resource('packages', parts[0])
+    if not prefix_path:
+        raise LookupError('Unknown package {}'.format(parts[0]))
     joined = '/'.join(parts)
     if len(parts[-1].rsplit('.', 1)) == 1:
         joined += '.idl'


### PR DESCRIPTION
Precisely what the title says. A #304 spin-off, comprehensive test coverage can be found there.