### PR TITLE
Make ros2 interface show fail gracefully (no traceback)

### DIFF
--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -27,6 +27,9 @@ class ShowVerb(VerbExtension):
         arg.completer = type_completer
 
     def main(self, *, args):
-        file_path = get_interface_path(args.type)
+        try:
+            file_path = get_interface_path(args.type)
+        except LookupError as e:
+            return str(e)
         with open(file_path, 'r', encoding='utf-8') as h:
             print(h.read().rstrip())


### PR DESCRIPTION
Follow-up after #371. This pull request ensures `ros2 interface show` fails nicely, with no traceback.