### PR TITLE
[ros2node] Add option to info verb to display hidden names

### DIFF
--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -202,7 +202,8 @@ def find_container_node_names(*, node, node_names):
     container_node_names = []
     for n in node_names:
         try:
-            services = get_service_info(node=node, remote_node_name=n.full_name)
+            services = get_service_info(
+                node=node, remote_node_name=n.full_name, include_hidden=True)
         except rclpy.node.NodeNameNonExistentError:
             continue
         if not any(s.name.endswith('_container/load_node') and

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -26,10 +26,7 @@ TopicInfo = namedtuple('Topic', ('name', 'types'))
 
 def _is_hidden_name(name):
     # note, we're assuming the hidden node prefix is the same for other hidden names
-    return (
-        name and
-        any(part.startswith(HIDDEN_NODE_PREFIX) for part in name.split('/'))
-    )
+    return any(part.startswith(HIDDEN_NODE_PREFIX) for part in name.split('/'))
 
 
 def get_absolute_node_name(node_name):
@@ -65,7 +62,7 @@ def get_node_names(*, node, include_hidden_nodes=False):
     ]
 
 
-def get_topics(remote_node_name, func, include_hidden_topics=False):
+def get_topics(remote_node_name, func, *, include_hidden_topics=False):
     node = parse_node_name(remote_node_name)
     names_and_types = func(node.name, node.namespace)
     return [
@@ -77,17 +74,26 @@ def get_topics(remote_node_name, func, include_hidden_topics=False):
 
 def get_subscriber_info(*, node, remote_node_name, include_hidden=False):
     return get_topics(
-        remote_node_name, node.get_subscriber_names_and_types_by_node, include_hidden)
+        remote_node_name,
+        node.get_subscriber_names_and_types_by_node,
+        include_hidden_topics=include_hidden
+    )
 
 
 def get_publisher_info(*, node, remote_node_name, include_hidden=False):
     return get_topics(
-        remote_node_name, node.get_publisher_names_and_types_by_node, include_hidden)
+        remote_node_name,
+        node.get_publisher_names_and_types_by_node,
+        include_hidden_topics=include_hidden
+    )
 
 
 def get_service_info(*, node, remote_node_name, include_hidden=False):
     return get_topics(
-        remote_node_name, node.get_service_names_and_types_by_node, include_hidden)
+        remote_node_name,
+        node.get_service_names_and_types_by_node,
+        include_hidden_topics=include_hidden
+    )
 
 
 def get_action_server_info(*, node, remote_node_name, include_hidden=False):

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -24,6 +24,14 @@ NodeName = namedtuple('NodeName', ('name', 'namespace', 'full_name'))
 TopicInfo = namedtuple('Topic', ('name', 'types'))
 
 
+def _is_hidden_name(name):
+    # note, we're assuming the hidden node prefix is the same for other hidden names
+    return (
+        name and
+        any(part.startswith(HIDDEN_NODE_PREFIX) for part in name.split('/'))
+    )
+
+
 def get_absolute_node_name(node_name):
     if not node_name:
         return None
@@ -57,29 +65,32 @@ def get_node_names(*, node, include_hidden_nodes=False):
     ]
 
 
-def get_topics(remote_node_name, func):
+def get_topics(remote_node_name, func, include_hidden_topics=False):
     node = parse_node_name(remote_node_name)
     names_and_types = func(node.name, node.namespace)
     return [
         TopicInfo(
             name=t[0],
             types=t[1])
-        for t in names_and_types]
+        for t in names_and_types if include_hidden_topics or not _is_hidden_name(t[0])]
 
 
-def get_subscriber_info(*, node, remote_node_name):
-    return get_topics(remote_node_name, node.get_subscriber_names_and_types_by_node)
+def get_subscriber_info(*, node, remote_node_name, include_hidden=False):
+    return get_topics(
+        remote_node_name, node.get_subscriber_names_and_types_by_node, include_hidden)
 
 
-def get_publisher_info(*, node, remote_node_name):
-    return get_topics(remote_node_name, node.get_publisher_names_and_types_by_node)
+def get_publisher_info(*, node, remote_node_name, include_hidden=False):
+    return get_topics(
+        remote_node_name, node.get_publisher_names_and_types_by_node, include_hidden)
 
 
-def get_service_info(*, node, remote_node_name):
-    return get_topics(remote_node_name, node.get_service_names_and_types_by_node)
+def get_service_info(*, node, remote_node_name, include_hidden=False):
+    return get_topics(
+        remote_node_name, node.get_service_names_and_types_by_node, include_hidden)
 
 
-def get_action_server_info(*, node, remote_node_name):
+def get_action_server_info(*, node, remote_node_name, include_hidden=False):
     remote_node = parse_node_name(remote_node_name)
     names_and_types = get_action_server_names_and_types_by_node(
         node, remote_node.name, remote_node.namespace)
@@ -87,10 +98,10 @@ def get_action_server_info(*, node, remote_node_name):
         TopicInfo(
             name=n,
             types=t)
-        for n, t in names_and_types]
+        for n, t in names_and_types if include_hidden or not _is_hidden_name(n)]
 
 
-def get_action_client_info(*, node, remote_node_name):
+def get_action_client_info(*, node, remote_node_name, include_hidden=False):
     remote_node = parse_node_name(remote_node_name)
     names_and_types = get_action_client_names_and_types_by_node(
         node, remote_node.name, remote_node.namespace)
@@ -98,7 +109,7 @@ def get_action_client_info(*, node, remote_node_name):
         TopicInfo(
             name=n,
             types=t)
-        for n, t in names_and_types]
+        for n, t in names_and_types if include_hidden or not _is_hidden_name(n)]
 
 
 class NodeNameCompleter:

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -38,6 +38,9 @@ class InfoVerb(VerbExtension):
             'node_name',
             help='Node name to request information')
         argument.completer = NodeNameCompleter()
+        parser.add_argument(
+            '--include-hidden', action='store_true',
+            help='Display hidden topics, services, and actions as well')
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
@@ -45,21 +48,24 @@ class InfoVerb(VerbExtension):
         if args.node_name in (n.full_name for n in node_names):
             with DirectNode(args) as node:
                 print(args.node_name)
-                subscribers = get_subscriber_info(node=node, remote_node_name=args.node_name)
+                subscribers = get_subscriber_info(
+                    node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
                 print('  Subscribers:')
                 print_names_and_types(subscribers)
-                publishers = get_publisher_info(node=node, remote_node_name=args.node_name)
+                publishers = get_publisher_info(
+                    node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
                 print('  Publishers:')
                 print_names_and_types(publishers)
-                services = get_service_info(node=node, remote_node_name=args.node_name)
+                services = get_service_info(
+                    node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
                 print('  Services:')
                 print_names_and_types(services)
                 actions_servers = get_action_server_info(
-                    node=node, remote_node_name=args.node_name)
+                    node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
                 print('  Action Servers:')
                 print_names_and_types(actions_servers)
                 actions_clients = get_action_client_info(
-                    node=node, remote_node_name=args.node_name)
+                    node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
                 print('  Action Clients:')
                 print_names_and_types(actions_clients)
         else:


### PR DESCRIPTION
Changes behavior so that hidden names are not shown by default.

Before this change, if we ran turtlesim and retrieved the node info we'd see hidden topics and services related to the action server, e.g.

    $ ros2 run turtlesim turtlesim_node

```sh
$ ros2 node info /turtlesim
/turtlesim
  Subscribers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /turtle1/cmd_vel: geometry_msgs/msg/Twist
  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /rosout: rcl_interfaces/msg/Log
    /turtle1/color_sensor: turtlesim/msg/Color
    /turtle1/pose: turtlesim/msg/Pose
    /turtle1/rotate_absolute/_action/feedback: turtlesim/action/RotateAbsolute_FeedbackMessage
    /turtle1/rotate_absolute/_action/status: action_msgs/msg/GoalStatusArray
  Services:
    /clear: std_srvs/srv/Empty
    /kill: turtlesim/srv/Kill
    /reset: std_srvs/srv/Empty
    /spawn: turtlesim/srv/Spawn
    /turtle1/rotate_absolute/_action/cancel_goal: action_msgs/srv/CancelGoal
    /turtle1/rotate_absolute/_action/get_result: turtlesim/action/RotateAbsolute_GetResult
    /turtle1/rotate_absolute/_action/send_goal: turtlesim/action/RotateAbsolute_SendGoal
    /turtle1/set_pen: turtlesim/srv/SetPen
    /turtle1/teleport_absolute: turtlesim/srv/TeleportAbsolute
    /turtle1/teleport_relative: turtlesim/srv/TeleportRelative
    /turtlesim/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /turtlesim/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /turtlesim/get_parameters: rcl_interfaces/srv/GetParameters
    /turtlesim/list_parameters: rcl_interfaces/srv/ListParameters
    /turtlesim/set_parameters: rcl_interfaces/srv/SetParameters
    /turtlesim/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
  Action Servers:
    /turtle1/rotate_absolute: turtlesim/action/RotateAbsolute
  Action Clients:
```

Now, we can get the same output if we add the `--include-hidden` option, but by default we don't see the hidden entities like `/turtle1/rotate_absoulte/_action/cancel_goal`:

```
/turtlesim
  Subscribers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /turtle1/cmd_vel: geometry_msgs/msg/Twist
  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /rosout: rcl_interfaces/msg/Log
    /turtle1/color_sensor: turtlesim/msg/Color
    /turtle1/pose: turtlesim/msg/Pose
  Services:
    /clear: std_srvs/srv/Empty
    /kill: turtlesim/srv/Kill
    /reset: std_srvs/srv/Empty
    /spawn: turtlesim/srv/Spawn
    /turtle1/set_pen: turtlesim/srv/SetPen
    /turtle1/teleport_absolute: turtlesim/srv/TeleportAbsolute
    /turtle1/teleport_relative: turtlesim/srv/TeleportRelative
    /turtlesim/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /turtlesim/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /turtlesim/get_parameters: rcl_interfaces/srv/GetParameters
    /turtlesim/list_parameters: rcl_interfaces/srv/ListParameters
    /turtlesim/set_parameters: rcl_interfaces/srv/SetParameters
    /turtlesim/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
  Action Servers:
    /turtle1/rotate_absolute: turtlesim/action/RotateAbsolute
  Action Clients:
```

