### PR TITLE
Remove ready_fn, self.proc_info

### DIFF
--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -20,9 +20,9 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
 import launch_testing.tools
@@ -37,7 +37,7 @@ import yaml
 
 @pytest.mark.rostest
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
-def generate_test_description(rmw_implementation, ready_fn):
+def generate_test_description(rmw_implementation):
     path_to_action_server_executable = os.path.join(
         os.path.dirname(__file__), 'fixtures', 'fibonacci_action_server.py'
     )
@@ -55,7 +55,7 @@ def generate_test_description(rmw_implementation, ready_fn):
                             cmd=[sys.executable, path_to_action_server_executable],
                             additional_env={'RMW_IMPLEMENTATION': rmw_implementation}
                         ),
-                        OpaqueFunction(function=lambda context: ready_fn())
+                        launch_testing.actions.ReadyToTest()
                     ],
                     additional_env={'RMW_IMPLEMENTATION': rmw_implementation}
                 )

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -19,9 +19,9 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
 import launch_testing.tools
@@ -54,8 +54,8 @@ some_interfaces = (
 
 @pytest.mark.rostest
 @launch_testing.markers.keep_alive
-def generate_test_description(ready_fn):
-    return LaunchDescription([OpaqueFunction(function=lambda context: ready_fn())])
+def generate_test_description():
+    return LaunchDescription([launch_testing.actions.ReadyToTest()])
 
 
 class TestROS2InterfaceCLI(unittest.TestCase):

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -21,11 +21,11 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 from launch_ros.actions import Node
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
 import launch_testing.tools
@@ -38,7 +38,7 @@ from rclpy.utilities import get_available_rmw_implementations
 
 @pytest.mark.rostest
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
-def generate_test_description(rmw_implementation, ready_fn):
+def generate_test_description(rmw_implementation):
     path_to_complex_node_script = os.path.join(
         os.path.dirname(__file__), 'fixtures', 'complex_node.py'
     )
@@ -66,7 +66,7 @@ def generate_test_description(rmw_implementation, ready_fn):
                             node_name='_hidden_complex_node',
                             additional_env=additional_env
                         ),
-                        OpaqueFunction(function=lambda context: ready_fn())
+                        launch_testing.actions.ReadyToTest()
                     ],
                     additional_env=additional_env
                 )

--- a/ros2pkg/test/test_cli.py
+++ b/ros2pkg/test/test_cli.py
@@ -20,9 +20,9 @@ import xml.etree.ElementTree as ET
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
 import launch_testing.tools
@@ -38,8 +38,8 @@ some_cli_packages = [
 
 @pytest.mark.rostest
 @launch_testing.markers.keep_alive
-def generate_test_description(ready_fn):
-    return LaunchDescription([OpaqueFunction(function=lambda context: ready_fn())])
+def generate_test_description():
+    return LaunchDescription([launch_testing.actions.ReadyToTest()])
 
 
 class TestROS2PkgCLI(unittest.TestCase):

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -22,10 +22,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 from launch_ros.actions import Node
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
 import launch_testing.tools
@@ -56,7 +56,7 @@ def get_echo_call_output(**kwargs):
 
 @pytest.mark.rostest
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
-def generate_test_description(rmw_implementation, ready_fn):
+def generate_test_description(rmw_implementation):
     path_to_echo_server_script = os.path.join(
         os.path.dirname(__file__), 'fixtures', 'echo_server.py'
     )
@@ -87,7 +87,7 @@ def generate_test_description(rmw_implementation, ready_fn):
                             remappings=[('echo', '_echo')],
                             additional_env=additional_env,
                         ),
-                        OpaqueFunction(function=lambda context: ready_fn())
+                        launch_testing.actions.ReadyToTest()
                     ],
                     additional_env=additional_env
                 )

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -22,11 +22,11 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 from launch_ros.actions import Node
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
 import launch_testing.tools
@@ -39,7 +39,7 @@ from rclpy.utilities import get_available_rmw_implementations
 
 @pytest.mark.rostest
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
-def generate_test_description(rmw_implementation, ready_fn):
+def generate_test_description(rmw_implementation):
     path_to_fixtures = os.path.join(os.path.dirname(__file__), 'fixtures')
     additional_env = {
         'RMW_IMPLEMENTATION': rmw_implementation, 'PYTHONUNBUFFERED': '1'
@@ -132,7 +132,7 @@ def generate_test_description(rmw_implementation, ready_fn):
                         unbounded_sequences_repeater_node_action,
                         # Add stamped data publisher.
                         cmd_vel_controller_node_action,
-                        OpaqueFunction(function=lambda context: ready_fn())
+                        launch_testing.actions.ReadyToTest()
                     ],
                     additional_env=additional_env
                 )

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -16,9 +16,9 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
 import launch_testing.tools
@@ -42,7 +42,7 @@ TEST_NAMESPACE = 'cli_echo_pub'
 
 @pytest.mark.rostest
 @launch_testing.markers.keep_alive
-def generate_test_description(ready_fn):
+def generate_test_description():
     return LaunchDescription([
         # Always restart daemon to isolate tests.
         ExecuteProcess(
@@ -53,7 +53,7 @@ def generate_test_description(ready_fn):
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',
                     on_exit=[
-                        OpaqueFunction(function=lambda context: ready_fn())
+                        launch_testing.actions.ReadyToTest()
                     ],
                 )
             ]


### PR DESCRIPTION
The ready_fn will be deprecated in the future in favor of the ReadyToTest() action in launch_testing. See ros2/launch#346 (comment) for background information

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>