### PR TITLE
Refactor test_echo_pub.py pytest into a launch test

### DIFF
--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -13,8 +13,19 @@
 # limitations under the License.
 
 import os
-import signal
-import subprocess
+
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import OpaqueFunction
+
+import launch_testing
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+import launch_testing_ros.tools
+
 
 import pytest
 
@@ -23,173 +34,210 @@ from rclpy.executors import SingleThreadedExecutor
 from rclpy.qos import DurabilityPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import ReliabilityPolicy
+
 from std_msgs.msg import String
+
 
 TEST_NODE = 'cli_echo_pub_test_node'
 TEST_NAMESPACE = 'cli_echo_pub'
 
 
-@pytest.fixture
-def echo_pub_node():
-    """Set up the global rclpy context and node for this test module."""
-    context = rclpy.context.Context()
-    rclpy.init(context=context)
-    node = rclpy.create_node(TEST_NODE, namespace=TEST_NAMESPACE, context=context)
-    executor = SingleThreadedExecutor(context=context)
-    executor.add_node(node)
-    yield node, executor, context
-    node.destroy_node()
-    rclpy.shutdown(context=context)
-
-
-@pytest.mark.skipif(os.name == 'nt', reason='Subprocess bug in Windows Python 3.7.4')
-@pytest.mark.timeout(60)
-@pytest.mark.parametrize(
-    'topic,provide_qos,compatible_qos', [
-        ('/clitest/topic/pub_basic', False, True),
-        ('/clitest/topic/pub_compatible_qos', True, True),
-        ('/clitest/topic/pub_incompatible_qos', True, False)
-    ]
-)
-def test_pub_basic(echo_pub_node, topic: str, provide_qos: bool, compatible_qos: bool):
-    # Check for inconsistent arguments
-    assert provide_qos if not compatible_qos else True
-    node, executor, context = echo_pub_node
-    received_message_count = 0
-    expected_minimum_message_count = 1
-    expected_maximum_message_count = 5
-    future = rclpy.task.Future()
-    pub_extra_options = []
-    subscription_qos_profile = 10
-    if provide_qos:
-        if compatible_qos:
-            # For compatible test, put publisher at very high quality and subscription at low
-            pub_extra_options = [
-                '--qos-reliability', 'reliable',
-                '--qos-durability', 'transient_local']
-            subscription_qos_profile = QoSProfile(
-                depth=10,
-                reliability=ReliabilityPolicy.BEST_EFFORT,
-                durability=DurabilityPolicy.VOLATILE)
-        else:
-            # For an incompatible example, reverse the quality extremes
-            # and expect no messages to arrive
-            pub_extra_options = [
-                '--qos-reliability', 'best_effort',
-                '--qos-durability', 'volatile']
-            subscription_qos_profile = QoSProfile(
-                depth=10,
-                reliability=ReliabilityPolicy.RELIABLE,
-                durability=DurabilityPolicy.TRANSIENT_LOCAL)
-            expected_maximum_message_count = 0
-            expected_minimum_message_count = 0
-
-    process = subprocess.Popen(
-        ['ros2', 'topic', 'pub'] + pub_extra_options + [topic, 'std_msgs/String', 'data: hello'],
-        stdout=subprocess.PIPE,
-        stdin=subprocess.DEVNULL)
-
-    def shutdown():
-        process.send_signal(signal.SIGINT)
-        future.set_result(True)
-
-    def message_callback(msg):
-        """If we receive one message, the test has succeeded."""
-        nonlocal received_message_count
-        received_message_count += 1
-        shutdown()
-
-    subscription = node.create_subscription(
-        String, topic, message_callback, subscription_qos_profile)
-    assert subscription
-
-    executor.spin_until_future_complete(future, timeout_sec=3)
-    try:
-        process.terminate()
-        process.wait(timeout=2)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        assert False, "CLI subprocess didn't shut down correctly"
-
-    # Cleanup
-    node.destroy_subscription(subscription)
-
-    # Check results
-    assert (
-        received_message_count >= expected_minimum_message_count and
-        received_message_count <= expected_maximum_message_count), \
-        'Received {} messages from pub, which is not in expected range {}-{}'.format(
-            received_message_count, expected_minimum_message_count, expected_maximum_message_count
+@pytest.mark.rostest
+@launch_testing.parametrize('rmw_implementation', ['rmw_fastrtps_cpp'])
+@launch_testing.markers.keep_alive
+def generate_test_description(rmw_implementation, ready_fn):
+    return LaunchDescription([
+        # Always restart daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                ExecuteProcess(
+                    cmd=['ros2', 'daemon', 'start'],
+                    name='daemon-start',
+                    on_exit=[
+                        OpaqueFunction(function=lambda context: ready_fn())
+                    ],
+                    additional_env={'RMW_IMPLEMENTATION': rmw_implementation}
+                )
+            ]
         )
+    ])
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='Subprocess bug in Windows Python 3.7.4')
-@pytest.mark.timeout(60)
-@pytest.mark.parametrize(
-    'topic,provide_qos,compatible_qos', [
-        ('/clitest/topic/echo_basic', False, True),
-        ('/clitest/topic/echo_compatible_qos', True, True),
-        ('/clitest/topic/echo_incompatible_qos', True, False)
-    ]
-)
-def test_echo_basic(echo_pub_node, topic: str, provide_qos: bool, compatible_qos: bool):
-    """Run a local publisher, check that `ros2 topic echo` receives at least one message."""
-    # Check for inconsistent arguments
-    assert provide_qos if not compatible_qos else True
-    node, executor, context = echo_pub_node
-    echo_extra_options = []
-    publisher_qos_profile = 10
-    if provide_qos:
-        if compatible_qos:
-            # For compatible test, put publisher at very high quality and subscription at low
-            echo_extra_options = [
-                '--qos-reliability', 'best_effort',
-                '--qos-durability', 'volatile']
-            publisher_qos_profile = QoSProfile(
-                depth=10,
-                reliability=ReliabilityPolicy.RELIABLE,
-                durability=DurabilityPolicy.TRANSIENT_LOCAL)
-        else:
-            # For an incompatible example, reverse the quality extremes
-            # and expect no messages to arrive
-            echo_extra_options = [
-                '--qos-reliability', 'reliable',
-                '--qos-durability', 'transient_local']
-            publisher_qos_profile = QoSProfile(
-                depth=10,
-                reliability=ReliabilityPolicy.BEST_EFFORT,
-                durability=DurabilityPolicy.VOLATILE)
+class TestROS2TopicEchoPub(unittest.TestCase):
 
-    process = subprocess.Popen(
-        ['ros2', 'topic', 'echo'] + echo_extra_options + [topic],
-        stdout=subprocess.PIPE,
-        stdin=subprocess.DEVNULL)
+    @classmethod
+    def setUpClass(cls, rmw_implementation):
+        os.environ['RMW_IMPLEMENTATION'] = rmw_implementation
+        cls.context = rclpy.context.Context()
+        rclpy.init(context=cls.context)
+        cls.node = rclpy.create_node(TEST_NODE, namespace=TEST_NAMESPACE, context=cls.context)
+        cls.executor = SingleThreadedExecutor(context=cls.context)
+        cls.executor.add_node(cls.node)
 
-    publisher = node.create_publisher(String, topic, publisher_qos_profile)
-    assert publisher
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown(context=cls.context)
 
-    def publish_message():
-        publisher.publish(String(data='hello'))
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_pub_basic(self, launch_service, proc_info, proc_output, rmw_implementation):
+        params = [
+            ('/clitest/topic/pub_basic', False, True),
+            ('/clitest/topic/pub_compatible_qos', True, True),
+            ('/clitest/topic/pub_incompatible_qos', True, False)
+        ]
+        for topic, provide_qos, compatible_qos in params:
+            with self.subTest(topic=topic, provide_qos=provide_qos, compatible_qos=compatible_qos):
+                # Check for inconsistent arguments
+                assert provide_qos if not compatible_qos else True
 
-    publish_timer = node.create_timer(0.5, publish_message)
-    # The future won't complete - we will hit the timeout
-    executor.spin_until_future_complete(rclpy.task.Future(), timeout_sec=4)
-    # Note it is important to send SIGINT - terminate will make the stdout unavailable
-    process.send_signal(signal.SIGINT)
-    try:
-        out, _ = process.communicate(timeout=0.5)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        assert False, "CLI subprocess didn't shut down correctly"
+                received_message_count = 0
+                expected_minimum_message_count = 1
+                expected_maximum_message_count = 5
 
-    # Cleanup
-    node.destroy_timer(publish_timer)
-    node.destroy_publisher(publisher)
+                pub_extra_options = []
+                subscription_qos_profile = 10
+                if provide_qos:
+                    if compatible_qos:
+                        # For compatible test, put publisher at very high quality
+                        # and subscription at low
+                        pub_extra_options = [
+                            '--qos-reliability', 'reliable',
+                            '--qos-durability', 'transient_local']
+                        subscription_qos_profile = QoSProfile(
+                            depth=10,
+                            reliability=ReliabilityPolicy.BEST_EFFORT,
+                            durability=DurabilityPolicy.VOLATILE)
+                    else:
+                        # For an incompatible example, reverse the quality extremes
+                        # and expect no messages to arrive
+                        pub_extra_options = [
+                            '--qos-reliability', 'best_effort',
+                            '--qos-durability', 'volatile']
+                        subscription_qos_profile = QoSProfile(
+                            depth=10,
+                            reliability=ReliabilityPolicy.RELIABLE,
+                            durability=DurabilityPolicy.TRANSIENT_LOCAL)
+                        expected_maximum_message_count = 0
+                        expected_minimum_message_count = 0
 
-    # Check results
-    if compatible_qos:
-        assert out, 'Echo CLI printed no output'
-        lines = out.decode('utf-8').split('\n')
-        assert 'data: hello' in lines, 'Echo CLI did not print expected message'
-    else:
-        assert not out, 'Echo CLI should not have received anything with incompatible QoS'
+                future = rclpy.task.Future()
+
+                def message_callback(msg):
+                    """If we receive one message, the test has succeeded."""
+                    nonlocal received_message_count
+                    received_message_count += 1
+                    future.set_result(True)
+
+                subscription = self.node.create_subscription(
+                    String, topic, message_callback, subscription_qos_profile)
+                assert subscription
+
+                try:
+                    command_action = ExecuteProcess(
+                        cmd=(['ros2', 'topic', 'pub'] + pub_extra_options +
+                             [topic, 'std_msgs/String', 'data: hello']),
+                        additional_env={'RMW_IMPLEMENTATION': rmw_implementation},
+                        output='screen'
+                    )
+                    with launch_testing.tools.launch_process(
+                        launch_service, command_action, proc_info, proc_output,
+                        output_filter=launch_testing_ros.tools.basic_output_filter(
+                            filtered_rmw_implementation=rmw_implementation
+                        )
+                    ) as command:
+                        self.executor.spin_until_future_complete(future, timeout_sec=10)
+                    command.wait_for_shutdown(timeout=10)
+
+                    # Check results
+                    assert (
+                        received_message_count >= expected_minimum_message_count and
+                        received_message_count <= expected_maximum_message_count), \
+                        'Received {} messages from pub, which is not in expected range {}-{}' \
+                        .format(
+                            received_message_count,
+                            expected_minimum_message_count,
+                            expected_maximum_message_count
+                        )
+                finally:
+                    # Cleanup
+                    self.node.destroy_subscription(subscription)
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_echo_basic(self, launch_service, proc_info, proc_output, rmw_implementation):
+        params = [
+            ('/clitest/topic/echo_basic', False, True),
+            ('/clitest/topic/echo_compatible_qos', True, True),
+            ('/clitest/topic/echo_incompatible_qos', True, False)
+        ]
+        for topic, provide_qos, compatible_qos in params:
+            with self.subTest(topic=topic, provide_qos=provide_qos, compatible_qos=compatible_qos):
+                # Check for inconsistent arguments
+                assert provide_qos if not compatible_qos else True
+                echo_extra_options = []
+                publisher_qos_profile = 10
+                if provide_qos:
+                    if compatible_qos:
+                        # For compatible test, put publisher at very high quality
+                        # and subscription at low
+                        echo_extra_options = [
+                            '--qos-reliability', 'best_effort',
+                            '--qos-durability', 'volatile']
+                        publisher_qos_profile = QoSProfile(
+                            depth=10,
+                            reliability=ReliabilityPolicy.RELIABLE,
+                            durability=DurabilityPolicy.TRANSIENT_LOCAL)
+                    else:
+                        # For an incompatible example, reverse the quality extremes
+                        # and expect no messages to arrive
+                        echo_extra_options = [
+                            '--qos-reliability', 'reliable',
+                            '--qos-durability', 'transient_local']
+                        publisher_qos_profile = QoSProfile(
+                            depth=10,
+                            reliability=ReliabilityPolicy.BEST_EFFORT,
+                            durability=DurabilityPolicy.VOLATILE)
+
+                publisher = self.node.create_publisher(String, topic, publisher_qos_profile)
+                assert publisher
+
+                def publish_message():
+                    publisher.publish(String(data='hello'))
+
+                publish_timer = self.node.create_timer(0.5, publish_message)
+
+                try:
+                    command_action = ExecuteProcess(
+                        cmd=(['ros2', 'topic', 'echo'] +
+                             echo_extra_options +
+                             [topic, 'std_msgs/String']),
+                        additional_env={'RMW_IMPLEMENTATION': rmw_implementation},
+                        output='screen'
+                    )
+                    with launch_testing.tools.launch_process(
+                        launch_service, command_action, proc_info, proc_output,
+                        output_filter=launch_testing_ros.tools.basic_output_filter(
+                            filtered_rmw_implementation=rmw_implementation
+                        )
+                    ) as command:
+                        # The future won't complete - we will hit the timeout
+                        self.executor.spin_until_future_complete(
+                            rclpy.task.Future(), timeout_sec=20
+                        )
+                    command.wait_for_shutdown(timeout=10)
+                    # Check results
+                    if compatible_qos:
+                        assert command.output, 'Echo CLI printed no output'
+                        assert 'data: hello' in command.output.splitlines(), (
+                            'Echo CLI did not print expected message'
+                        )
+                    else:
+                        assert not command.output, (
+                            'Echo CLI should not have received anything with incompatible QoS'
+                        )
+                finally:
+                    # Cleanup
+                    self.node.destroy_timer(publish_timer)
+                    self.node.destroy_publisher(publisher)

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -35,6 +35,8 @@ from rclpy.qos import DurabilityPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import ReliabilityPolicy
 
+from rmw_implementation import get_available_rmw_implementations
+
 from std_msgs.msg import String
 
 
@@ -43,7 +45,7 @@ TEST_NAMESPACE = 'cli_echo_pub'
 
 
 @pytest.mark.rostest
-@launch_testing.parametrize('rmw_implementation', ['rmw_fastrtps_cpp'])
+@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 @launch_testing.markers.keep_alive
 def generate_test_description(rmw_implementation, ready_fn):
     return LaunchDescription([
@@ -139,7 +141,10 @@ class TestROS2TopicEchoPub(unittest.TestCase):
                     command_action = ExecuteProcess(
                         cmd=(['ros2', 'topic', 'pub'] + pub_extra_options +
                              [topic, 'std_msgs/String', 'data: hello']),
-                        additional_env={'RMW_IMPLEMENTATION': rmw_implementation},
+                        additional_env={
+                            'RMW_IMPLEMENTATION': rmw_implementation,
+                            'PYTHONUNBUFFERED': '1'
+                        },
                         output='screen'
                     )
                     with launch_testing.tools.launch_process(
@@ -213,7 +218,10 @@ class TestROS2TopicEchoPub(unittest.TestCase):
                         cmd=(['ros2', 'topic', 'echo'] +
                              echo_extra_options +
                              [topic, 'std_msgs/String']),
-                        additional_env={'RMW_IMPLEMENTATION': rmw_implementation},
+                        additional_env={
+                            'RMW_IMPLEMENTATION': rmw_implementation,
+                            'PYTHONUNBUFFERED': '1'
+                        },
                         output='screen'
                     )
                     with launch_testing.tools.launch_process(
@@ -224,7 +232,7 @@ class TestROS2TopicEchoPub(unittest.TestCase):
                     ) as command:
                         # The future won't complete - we will hit the timeout
                         self.executor.spin_until_future_complete(
-                            rclpy.task.Future(), timeout_sec=20
+                            rclpy.task.Future(), timeout_sec=5
                         )
                     command.wait_for_shutdown(timeout=10)
                     # Check results


### PR DESCRIPTION
Closes #375. As a side note, running these tests against RTI Connext or ADLINK Opensplice fails -- which can now be easily configured by applying the following patch:


```bash
--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -35,6 +35,8 @@ from rclpy.qos import DurabilityPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import ReliabilityPolicy
 
+from rmw_implementation import get_available_rmw_implementations
+
 from std_msgs.msg import String
 
 
@@ -43,7 +45,7 @@ TEST_NAMESPACE = 'cli_echo_pub'
 
 
 @pytest.mark.rostest
-@launch_testing.parametrize('rmw_implementation', ['rmw_fastrtps_cpp'])
+@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 @launch_testing.markers.keep_alive
 def generate_test_description(rmw_implementation, ready_fn):
     return LaunchDescription([
```

 CC @emersonknapp 