### PR TITLE
[ros2topic] make info verb display the type of the topic

### DIFF
--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from ros2cli.node.direct import DirectNode
+from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
@@ -29,7 +32,16 @@ class InfoVerb(VerbExtension):
 
     def main(self, *, args):
         with DirectNode(args) as node:
+            topic_names_and_types = get_topic_names_and_types(node=node)
             topic_name = args.topic_name
-            print('Topic: %s' % topic_name)
+            for (t_name, t_types) in topic_names_and_types:
+                if t_name == topic_name:
+                    topic_types = t_types
+                    break
+            else:
+                print("ERROR: Unknown topic '%s'" % topic_name, file=sys.stderr)
+                return
+            type_str = topic_types[0] if len(topic_types) == 1 else topic_types
+            print('Type: %s' % type_str)
             print('Publisher count: %d' % node.count_publishers(topic_name))
             print('Subscriber count: %d' % node.count_subscribers(topic_name))

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
@@ -39,8 +37,7 @@ class InfoVerb(VerbExtension):
                     topic_types = t_types
                     break
             else:
-                print("ERROR: Unknown topic '%s'" % topic_name, file=sys.stderr)
-                return
+                return "Unknown topic '%s'" % topic_name
             type_str = topic_types[0] if len(topic_types) == 1 else topic_types
             print('Type: %s' % type_str)
             print('Publisher count: %d' % node.count_publishers(topic_name))

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -273,10 +273,9 @@ class TestROS2TopicCLI(unittest.TestCase):
     def test_info_on_unknown_topic(self):
         with self.launch_topic_command(arguments=['info', '/unknown_topic']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
-        assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                "ERROR: Unknown topic '/unknown_topic'",
+                "Unknown topic '/unknown_topic'",
             ],
             text=topic_command.output,
             strict=True

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -262,7 +262,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                'Topic: /chatter',
+                'Type: std_msgs/msg/String',
                 'Publisher count: 1',
                 'Subscriber count: 0'
             ],
@@ -276,9 +276,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                'Topic: /unknown_topic',
-                'Publisher count: 0',
-                'Subscriber count: 0'
+                "ERROR: Unknown topic '/unknown_topic'",
             ],
             text=topic_command.output,
             strict=True

--- a/ros2topic/test/test_info.py
+++ b/ros2topic/test/test_info.py
@@ -20,9 +20,7 @@ from ros2topic.verb.info import InfoVerb
 
 
 def _generate_expected_error_output(topic_name):
-    return [
-        "ERROR: Unknown topic '%s'" % topic_name,
-    ]
+    return "Unknown topic '%s'" % topic_name
 
 
 def test_info_zero_publishers_subscribers():
@@ -31,6 +29,6 @@ def test_info_zero_publishers_subscribers():
     s = StringIO()
     with redirect_stderr(s):
         info_verb = InfoVerb()
-        info_verb.main(args=args)
+        err_msg = info_verb.main(args=args)
         expected_output = _generate_expected_error_output(args.topic_name)
-        assert expected_output == s.getvalue().splitlines()
+        assert expected_output == err_msg

--- a/ros2topic/test/test_info.py
+++ b/ros2topic/test/test_info.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 from argparse import Namespace
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr
 from io import StringIO
 
 from ros2topic.verb.info import InfoVerb
 
 
-def _generate_expected_output(topic_name, count_publishers, count_subscribers):
+def _generate_expected_error_output(topic_name):
     return [
-        'Topic: %s' % topic_name,
-        'Publisher count: %d' % count_publishers,
-        'Subscriber count: %d' % count_subscribers,
+        "ERROR: Unknown topic '%s'" % topic_name,
     ]
 
 
@@ -31,8 +29,8 @@ def test_info_zero_publishers_subscribers():
     args = Namespace()
     args.topic_name = '/test_ros2_topic_cli'
     s = StringIO()
-    with redirect_stdout(s):
+    with redirect_stderr(s):
         info_verb = InfoVerb()
         info_verb.main(args=args)
-        expected_output = _generate_expected_output(args.topic_name, 0, 0)
+        expected_output = _generate_expected_error_output(args.topic_name)
         assert expected_output == s.getvalue().splitlines()


### PR DESCRIPTION
Display the type(s) of a given topic
Print an error message for unknown topics


<details>
<summary>For known topics</summary>

before:

```
$ ros2 topic info /chatter
Topic: /chatter
Publisher count: 0
Subscriber count: 1
```
after:
```
$ ros2 topic info /chatter
Type: std_msgs/msg/String
Publisher count: 0
Subscriber count: 1
```

</details>

<details>
<summary>For unknown topics</summary>

before:

```
$ ros2 topic info /unknown
Topic: /unknown
Publisher count: 0
Subscriber count: 0
```
after:
```
$ ros2 topic info /unknown
Unknown topic '/unknown'
```

</details>