### PR TITLE
Update failed modules message

### DIFF
--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -49,7 +49,7 @@ class DoctorCommand(CommandExtension):
         failed_cats, fail, total = run_checks(include_warnings=args.include_warnings)
         if fail:
             print('\n%d/%d checks failed\n' % (fail, total))
-            print('Failed modules: ', *failed_cats)
+            print('Failed modules:', *failed_cats)
         else:
             print('\nAll %d checks passed\n' % total)
 

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -49,7 +49,7 @@ class DoctorCommand(CommandExtension):
         failed_cats, fail, total = run_checks(include_warnings=args.include_warnings)
         if fail:
             print('\n%d/%d checks failed\n' % (fail, total))
-            print('Failed modules are ', *failed_cats)
+            print('Failed modules: ', *failed_cats)
         else:
             print('\nAll %d checks passed\n' % total)
 


### PR DESCRIPTION
The message previously said, for example
```
Failed modules are  network
```
Which is confusing when there's only one module

Changing to:
```
Failed modules: network
```
Which works if there's one or more failed modules