### PR TITLE
Enhanced ros2 topic info to display node name, node namespace, topic type and qos profile of the publishers and subscribers.

### DIFF
--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -64,17 +64,21 @@ class InfoVerb(VerbExtension):
             else:
                 return "Unknown topic '%s'" % topic_name
 
-            type_str = topic_types[0] if len(topic_types) == 1 else topic_types
-            print('Type: %s' % type_str)
+            lineend = '\n'
+            if args.verbose:
+                lineend = '\n\n'
 
-            print('\nPublisher count: %d' % node.count_publishers(topic_name))
+            type_str = topic_types[0] if len(topic_types) == 1 else topic_types
+            print('Type: %s' % type_str, end=lineend)
+
+            print('Publisher count: %d' % node.count_publishers(topic_name), end=lineend)
             if args.verbose:
                 try:
                     print_topic_info(topic_name, node.get_publishers_info_by_topic)
                 except NotImplementedError as e:
                     return str(e)
 
-            print('\nSubscription count: %d' % node.count_subscribers(topic_name))
+            print('Subscription count: %d' % node.count_subscribers(topic_name))
             if args.verbose:
                 try:
                     print_topic_info(topic_name, node.get_subscriptions_info_by_topic)

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -20,29 +20,23 @@ from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
-import logging
-logger = logging.getLogger(__name__)
+
 
 def print_topic_info(topic_name, get_topic_info_func):
-    try:
-        for info in get_topic_info_func(topic_name):
-            print('\nNode Name: %s' % info['node_name'])
-            print('Node Namespace: %s' % info['node_namespace'])
-            print('Topic Type: %s' % info['topic_type'])
-            print('GID: %s' % '.'.join(format(x, '02x') for x in info['gid']))
-            print('QoS Profile:')
-            qos_profile = info['qos_profile']
-            print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)
-            print('  Durability: %s' % QoSDurabilityPolicy(qos_profile['durability']).name)
-            print('  Lifespan: %d nanoseconds' % qos_profile['lifespan'].nanoseconds)
-            print('  Deadline: %d nanoseconds' % qos_profile['deadline'].nanoseconds)
-            print('  Liveliness: %s' % QoSLivelinessPolicy(qos_profile['liveliness']).name)
-            print('  Liveliness Lease Duration: %d nanoseconds' %
-                  qos_profile['liveliness_lease_duration'].nanoseconds)
-    except NotImplementedError as e:
-        logger.warning(str(e))
-    except Exception as e:
-        logger.error(str(e))
+    for info in get_topic_info_func(topic_name):
+        print('\nNode Name: %s' % info['node_name'])
+        print('Node Namespace: %s' % info['node_namespace'])
+        print('Topic Type: %s' % info['topic_type'])
+        print('GID: %s' % '.'.join(format(x, '02x') for x in info['gid']))
+        print('QoS Profile:')
+        qos_profile = info['qos_profile']
+        print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)
+        print('  Durability: %s' % QoSDurabilityPolicy(qos_profile['durability']).name)
+        print('  Lifespan: %d nanoseconds' % qos_profile['lifespan'].nanoseconds)
+        print('  Deadline: %d nanoseconds' % qos_profile['deadline'].nanoseconds)
+        print('  Liveliness: %s' % QoSLivelinessPolicy(qos_profile['liveliness']).name)
+        print('  Liveliness Lease Duration: %d nanoseconds' %
+              qos_profile['liveliness_lease_duration'].nanoseconds)
 
 class InfoVerb(VerbExtension):
     """Print information about a topic."""
@@ -53,7 +47,7 @@ class InfoVerb(VerbExtension):
             help="Name of the ROS topic to get info (e.g. '/chatter')")
         parser.add_argument(
             '--verbose', '-v', action='store_true',
-            help='Prints detailed information like the Node Name, Node Namespace, Topic Type, '
+            help='Prints detailed information like the node name, node namespace, topic type, '
                  'GUID and QoS Profile of the publishers and subscribers to this topic')
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')
@@ -69,12 +63,20 @@ class InfoVerb(VerbExtension):
                     break
             else:
                 return "Unknown topic '%s'" % topic_name
+
             type_str = topic_types[0] if len(topic_types) == 1 else topic_types
             print('Type: %s' % type_str)
-            print('\nPublisher count    : %d' % node.count_publishers(topic_name))
-            if (args.verbose):
-                print_topic_info(topic_name, node.get_publishers_info_by_topic)
-            print('\nSubscription count : %d' % node.count_subscribers(topic_name))
-            if (args.verbose):
-                print_topic_info(topic_name, node.get_subscriptions_info_by_topic)
 
+            print('\nPublisher count: %d' % node.count_publishers(topic_name))
+            if args.verbose:
+                try:
+                    print_topic_info(topic_name, node.get_publishers_info_by_topic)
+                except NotImplementedError as e:
+                    return str(e)
+
+            print('\nSubscription count: %d' % node.count_subscribers(topic_name))
+            if args.verbose:
+                try:
+                    print_topic_info(topic_name, node.get_subscriptions_info_by_topic)
+                except NotImplementedError as e:
+                    return str(e)

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -12,31 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from rclpy.qos import QoSDurabilityPolicy
-from rclpy.qos import QoSLivelinessPolicy
-from rclpy.qos import QoSReliabilityPolicy
-
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
-
-def print_topic_endpoint_info(topic_name, get_topic_endpoint_info_func):
-    for info in get_topic_endpoint_info_func(topic_name):
-        print('Node name: %s' % info['node_name'])
-        print('Node namespace: %s' % info['node_namespace'])
-        print('Topic type: %s' % info['topic_type'])
-        print('GID: %s' % '.'.join(format(x, '02x') for x in info['gid']))
-        print('QoS profile:')
-        qos_profile = info['qos_profile']
-        print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)
-        print('  Durability: %s' % QoSDurabilityPolicy(qos_profile['durability']).name)
-        print('  Lifespan: %d nanoseconds' % qos_profile['lifespan'].nanoseconds)
-        print('  Deadline: %d nanoseconds' % qos_profile['deadline'].nanoseconds)
-        print('  Liveliness: %s' % QoSLivelinessPolicy(qos_profile['liveliness']).name)
-        print('  Liveliness lease duration: %d nanoseconds\n' %
-              qos_profile['liveliness_lease_duration'].nanoseconds)
 
 class InfoVerb(VerbExtension):
     """Print information about a topic."""
@@ -46,7 +26,9 @@ class InfoVerb(VerbExtension):
             'topic_name',
             help="Name of the ROS topic to get info (e.g. '/chatter')")
         parser.add_argument(
-            '--verbose', '-v', action='store_true',
+            '--verbose',
+            '-v',
+            action='store_true',
             help='Prints detailed information like the node name, node namespace, topic type, '
                  'GUID and QoS Profile of the publishers and subscribers to this topic')
         arg.completer = TopicNameCompleter(
@@ -74,13 +56,15 @@ class InfoVerb(VerbExtension):
             print('Publisher count: %d' % node.count_publishers(topic_name), end=lineend)
             if args.verbose:
                 try:
-                    print_topic_endpoint_info(topic_name, node.get_publishers_info_by_topic)
+                    for info in node.get_publishers_info_by_topic(topic_name):
+                        print(info, end=lineend)
                 except NotImplementedError as e:
                     return str(e)
 
             print('Subscription count: %d' % node.count_subscribers(topic_name))
             if args.verbose:
                 try:
-                    print_topic_endpoint_info(topic_name, node.get_subscriptions_info_by_topic)
+                    for info in node.get_subscriptions_info_by_topic(topic_name):
+                        print(info, end=lineend)
                 except NotImplementedError as e:
                     return str(e)

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -22,8 +22,8 @@ from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
 
-def print_topic_info(topic_name, get_topic_info_func):
-    for info in get_topic_info_func(topic_name):
+def print_topic_endpoint_info(topic_name, get_topic_endpoint_info_func):
+    for info in get_topic_endpoint_info_func(topic_name):
         print('Node name: %s' % info['node_name'])
         print('Node namespace: %s' % info['node_namespace'])
         print('Topic type: %s' % info['topic_type'])
@@ -74,13 +74,13 @@ class InfoVerb(VerbExtension):
             print('Publisher count: %d' % node.count_publishers(topic_name), end=lineend)
             if args.verbose:
                 try:
-                    print_topic_info(topic_name, node.get_publishers_info_by_topic)
+                    print_topic_endpoint_info(topic_name, node.get_publishers_info_by_topic)
                 except NotImplementedError as e:
                     return str(e)
 
             print('Subscription count: %d' % node.count_subscribers(topic_name))
             if args.verbose:
                 try:
-                    print_topic_info(topic_name, node.get_subscriptions_info_by_topic)
+                    print_topic_endpoint_info(topic_name, node.get_subscriptions_info_by_topic)
                 except NotImplementedError as e:
                     return str(e)

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -20,21 +20,29 @@ from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
+import logging
+logger = logging.getLogger(__name__)
 
-def print_topic_info(info):
-    print('\nNode Name: %s' % info['node_name'])
-    print('Node Namespace: %s' % info['node_namespace'])
-    print('Topic Type: %s' % info['topic_type'])
-    print('GID: %s' % info['gid'])
-    print('QoS Profile:')
-    qos_profile = info['qos_profile']
-    print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)
-    print('  Durability: %s' % QoSDurabilityPolicy(qos_profile['durability']).name)
-    print('  Lifespan: %d nanoseconds' % qos_profile['lifespan'].nanoseconds)
-    print('  Deadline: %d nanoseconds' % qos_profile['deadline'].nanoseconds)
-    print('  Liveliness: %s' % QoSLivelinessPolicy(qos_profile['liveliness']).name)
-    print('  Liveliness Lease Duration: %d nanoseconds' %
-          qos_profile['liveliness_lease_duration'].nanoseconds)
+def print_topic_info(topic_name, get_topic_info_func):
+    try:
+        for info in get_topic_info_func(topic_name):
+            print('\nNode Name: %s' % info['node_name'])
+            print('Node Namespace: %s' % info['node_namespace'])
+            print('Topic Type: %s' % info['topic_type'])
+            print('GID: %s' % info['gid'])
+            print('QoS Profile:')
+            qos_profile = info['qos_profile']
+            print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)
+            print('  Durability: %s' % QoSDurabilityPolicy(qos_profile['durability']).name)
+            print('  Lifespan: %d nanoseconds' % qos_profile['lifespan'].nanoseconds)
+            print('  Deadline: %d nanoseconds' % qos_profile['deadline'].nanoseconds)
+            print('  Liveliness: %s' % QoSLivelinessPolicy(qos_profile['liveliness']).name)
+            print('  Liveliness Lease Duration: %d nanoseconds' %
+                  qos_profile['liveliness_lease_duration'].nanoseconds)
+    except NotImplementedError as e:
+        logger.warning(str(e))
+    except Exception as e:
+        logger.error(str(e))
 
 class InfoVerb(VerbExtension):
     """Print information about a topic."""
@@ -43,6 +51,10 @@ class InfoVerb(VerbExtension):
         arg = parser.add_argument(
             'topic_name',
             help="Name of the ROS topic to get info (e.g. '/chatter')")
+        parser.add_argument(
+            '--verbose', '-v', action='store_true',
+            help='Prints detailed information like the Node Name, Node Namespace, Topic Type, '
+                 'GUID and QoS Profile of the publishers and subscribers to this topic')
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')
 
@@ -60,8 +72,9 @@ class InfoVerb(VerbExtension):
             type_str = topic_types[0] if len(topic_types) == 1 else topic_types
             print('Type: %s' % type_str)
             print('\nPublisher count    : %d' % node.count_publishers(topic_name))
-            for publisher_info in node.get_publishers_info_by_topic(topic_name):
-                print_topic_info(publisher_info)
+            if (args.verbose):
+                print_topic_info(topic_name, node.get_publishers_info_by_topic)
             print('\nSubscription count : %d' % node.count_subscribers(topic_name))
-            for subscription_info in node.get_subscriptions_info_by_topic(topic_name):
-                print_topic_info(subscription_info)
+            if (args.verbose):
+                print_topic_info(topic_name, node.get_subscriptions_info_by_topic)
+

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -24,18 +24,18 @@ from ros2topic.verb import VerbExtension
 
 def print_topic_info(topic_name, get_topic_info_func):
     for info in get_topic_info_func(topic_name):
-        print('\nNode Name: %s' % info['node_name'])
-        print('Node Namespace: %s' % info['node_namespace'])
-        print('Topic Type: %s' % info['topic_type'])
+        print('Node name: %s' % info['node_name'])
+        print('Node namespace: %s' % info['node_namespace'])
+        print('Topic type: %s' % info['topic_type'])
         print('GID: %s' % '.'.join(format(x, '02x') for x in info['gid']))
-        print('QoS Profile:')
+        print('QoS profile:')
         qos_profile = info['qos_profile']
         print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)
         print('  Durability: %s' % QoSDurabilityPolicy(qos_profile['durability']).name)
         print('  Lifespan: %d nanoseconds' % qos_profile['lifespan'].nanoseconds)
         print('  Deadline: %d nanoseconds' % qos_profile['deadline'].nanoseconds)
         print('  Liveliness: %s' % QoSLivelinessPolicy(qos_profile['liveliness']).name)
-        print('  Liveliness Lease Duration: %d nanoseconds' %
+        print('  Liveliness lease duration: %d nanoseconds\n' %
               qos_profile['liveliness_lease_duration'].nanoseconds)
 
 class InfoVerb(VerbExtension):

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -46,18 +46,18 @@ class InfoVerb(VerbExtension):
             else:
                 return "Unknown topic '%s'" % topic_name
 
-            lineend = '\n'
+            line_end = '\n'
             if args.verbose:
-                lineend = '\n\n'
+                line_end = '\n\n'
 
             type_str = topic_types[0] if len(topic_types) == 1 else topic_types
-            print('Type: %s' % type_str, end=lineend)
+            print('Type: %s' % type_str, end=line_end)
 
-            print('Publisher count: %d' % node.count_publishers(topic_name), end=lineend)
+            print('Publisher count: %d' % node.count_publishers(topic_name), end=line_end)
             if args.verbose:
                 try:
                     for info in node.get_publishers_info_by_topic(topic_name):
-                        print(info, end=lineend)
+                        print(info, end=line_end)
                 except NotImplementedError as e:
                     return str(e)
 
@@ -65,6 +65,6 @@ class InfoVerb(VerbExtension):
             if args.verbose:
                 try:
                     for info in node.get_subscriptions_info_by_topic(topic_name):
-                        print(info, end=lineend)
+                        print(info, end=line_end)
                 except NotImplementedError as e:
                     return str(e)

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -12,11 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSLivelinessPolicy
+from rclpy.qos import QoSReliabilityPolicy
+
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
+def print_topic_info(info):
+    print('\nNode Name: %s' % info['node_name'])
+    print('Node Namespace: %s' % info['node_namespace'])
+    print('Topic Type: %s' % info['topic_type'])
+    print('GID: %s' % info['gid'])
+    print('QoS Profile:')
+    qos_profile = info['qos_profile']
+    print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)
+    print('  Durability: %s' % QoSDurabilityPolicy(qos_profile['durability']).name)
+    print('  Lifespan: %d nanoseconds' % qos_profile['lifespan'].nanoseconds)
+    print('  Deadline: %d nanoseconds' % qos_profile['deadline'].nanoseconds)
+    print('  Liveliness: %s' % QoSLivelinessPolicy(qos_profile['liveliness']).name)
+    print('  Liveliness Lease Duration: %d nanoseconds' %
+          qos_profile['liveliness_lease_duration'].nanoseconds)
 
 class InfoVerb(VerbExtension):
     """Print information about a topic."""
@@ -41,5 +59,9 @@ class InfoVerb(VerbExtension):
                 return "Unknown topic '%s'" % topic_name
             type_str = topic_types[0] if len(topic_types) == 1 else topic_types
             print('Type: %s' % type_str)
-            print('Publisher count: %d' % node.count_publishers(topic_name))
-            print('Subscriber count: %d' % node.count_subscribers(topic_name))
+            print('\nPublisher count    : %d' % node.count_publishers(topic_name))
+            for publisher_info in node.get_publishers_info_by_topic(topic_name):
+                print_topic_info(publisher_info)
+            print('\nSubscription count : %d' % node.count_subscribers(topic_name))
+            for subscription_info in node.get_subscriptions_info_by_topic(topic_name):
+                print_topic_info(subscription_info)

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -29,7 +29,7 @@ def print_topic_info(topic_name, get_topic_info_func):
             print('\nNode Name: %s' % info['node_name'])
             print('Node Namespace: %s' % info['node_namespace'])
             print('Topic Type: %s' % info['topic_type'])
-            print('GID: %s' % info['gid'])
+            print('GID: %s' % '.'.join(map(str, info['gid'])))
             print('QoS Profile:')
             qos_profile = info['qos_profile']
             print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -29,7 +29,7 @@ def print_topic_info(topic_name, get_topic_info_func):
             print('\nNode Name: %s' % info['node_name'])
             print('Node Namespace: %s' % info['node_namespace'])
             print('Topic Type: %s' % info['topic_type'])
-            print('GID: %s' % '.'.join(map(str, info['gid'])))
+            print('GID: %s' % '.'.join(format(x, '02x') for x in info['gid']))
             print('QoS Profile:')
             qos_profile = info['qos_profile']
             print('  Reliability: %s' % QoSReliabilityPolicy(qos_profile['reliability']).name)

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -272,7 +272,7 @@ class TestROS2TopicCLI(unittest.TestCase):
 
     @launch_testing.markers.retry_on_failure(times=5)
     def test_topic_endpoint_info_verbose(self):
-        with self.launch_topic_command(arguments=['info', '--verbose', '/chatter']) as topic_command:
+        with self.launch_topic_command(arguments=['info', '-v', '/chatter']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
@@ -284,6 +284,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 re.compile(r'Node name: \w+'),
                 'Node namespace: /',
                 'Topic type: std_msgs/msg/String',
+                re.compile(r'Endpoint type: (INVALID|PUBLISHER|SUBSCRIPTION)'),
                 re.compile(r'GID: [\w\.]+'),
                 'QoS profile:',
                 re.compile(r'  Reliability: RMW_QOS_POLICY_RELIABILITY_\w+'),

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -264,7 +264,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             expected_lines=[
                 'Type: std_msgs/msg/String',
                 'Publisher count: 1',
-                'Subscriber count: 0'
+                'Subscription count: 0'
             ],
             text=topic_command.output,
             strict=True

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -517,7 +517,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10)
             assert self.listener_node.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
-                    re.compile(r'\[INFO\] \[\d+.\d*\] \[listener\]: I heard: \[foo\]')
+                    re.compile(r'\[INFO\] \[\d+\.\d*\] \[listener\]: I heard: \[foo\]')
                 ] * 3, strict=False
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
@@ -541,7 +541,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             assert topic_command.wait_for_shutdown(timeout=10)
             assert self.listener_node.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
-                    re.compile(r'\[INFO\] \[\d+.\d*\] \[listener\]: I heard: \[bar\]')
+                    re.compile(r'\[INFO\] \[\d+\.\d*\] \[listener\]: I heard: \[bar\]')
                 ], strict=False
             ), timeout=10)
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -567,7 +567,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10), 'Output does not match: ' + topic_command.output
             assert self.listener_node.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
-                    re.compile(r'\[INFO\] \[\d+.\d*\] \[listener\]: I heard: \[fizz\]')
+                    re.compile(r'\[INFO\] \[\d+\.\d*\] \[listener\]: I heard: \[fizz\]')
                 ], strict=False
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -270,6 +270,35 @@ class TestROS2TopicCLI(unittest.TestCase):
             strict=True
         )
 
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_topic_info_verbose(self):
+        with self.launch_topic_command(arguments=['info', '--verbose', '/chatter']) as topic_command:
+            assert topic_command.wait_for_shutdown(timeout=10)
+        assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                'Type: std_msgs/msg/String',
+                '',
+                'Publisher count: 1',
+                '',
+                re.compile(r'Node name: \w+'),
+                'Node namespace: /',
+                'Topic type: std_msgs/msg/String',
+                re.compile(r'GID: [\w\.]+'),
+                'QoS profile:',
+                re.compile(r'  Reliability: RMW_QOS_POLICY_RELIABILITY_\w+'),
+                re.compile(r'  Durability: RMW_QOS_POLICY_DURABILITY_\w+'),
+                re.compile(r'  Lifespan: \d+ nanoseconds'),
+                re.compile(r'  Deadline: \d+ nanoseconds'),
+                re.compile(r'  Liveliness: RMW_QOS_POLICY_LIVELINESS_\w+'),
+                re.compile(r'  Liveliness lease duration: \d+ nanoseconds'),
+                '',
+                'Subscription count: 0'
+            ],
+            text=topic_command.output,
+            strict=True
+        )
+
     def test_info_on_unknown_topic(self):
         with self.launch_topic_command(arguments=['info', '/unknown_topic']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -256,7 +256,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert int(output_lines[0]) == 9
 
     @launch_testing.markers.retry_on_failure(times=5)
-    def test_topic_info(self):
+    def test_topic_endpoint_info(self):
         with self.launch_topic_command(arguments=['info', '/chatter']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -271,7 +271,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         )
 
     @launch_testing.markers.retry_on_failure(times=5)
-    def test_topic_info_verbose(self):
+    def test_topic_endpoint_info_verbose(self):
         with self.launch_topic_command(arguments=['info', '--verbose', '/chatter']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK


### PR DESCRIPTION
**NOTE: DO NOT MERGE until [rmw #186](https://github.com/ros2/rmw/pull/186),  [rmw_implementation #72](https://github.com/ros2/rmw_implementation/pull/72),  [rcl #511](https://github.com/ros2/rcl/pull/511) and [rclpy #454](https://github.com/ros2/rclpy/pull/454) are merged.**

This PR makes the necessary changes to implement [this](https://github.com/ros2/rmw/issues/151) feature request. Once all the dependent PRs are merged, the `ros2cli` layer can now use the `node.get_publishers_info_by_topic` and `node.get_subscriptions_info_by_topic` functions to enhance the output of `ros2 topic info <topic_name>` as follows:

```
$ ros2 topic info rosout

Topic              : rosout

Publisher count    : 2

Node Name: _NODE_NAME_UNKNOWN_
Node Namespace: _NODE_NAMESPACE_UNKNOWN_
Topic Type: rcl_interfaces::msg::dds_::Log_
QoS Profile:
  Reliability: RMW_QOS_POLICY_RELIABILITY_RELIABLE
  Durability: RMW_QOS_POLICY_DURABILITY_VOLATILE
  Lifespan: 2147483651294967295 nanoseconds
  Deadline: 2147483651294967295 nanoseconds
  Liveliness: RMW_QOS_POLICY_LIVELINESS_AUTOMATIC
  Liveliness Lease Duration: 2147483651294967295 nanoseconds

Node Name: listener
Node Namespace: /
Topic Type: rcl_interfaces::msg::dds_::Log_
QoS Profile:
  Reliability: RMW_QOS_POLICY_RELIABILITY_RELIABLE
  Durability: RMW_QOS_POLICY_DURABILITY_VOLATILE
  Lifespan: 2147483651294967295 nanoseconds
  Deadline: 2147483651294967295 nanoseconds
  Liveliness: RMW_QOS_POLICY_LIVELINESS_AUTOMATIC
  Liveliness Lease Duration: 2147483651294967295 nanoseconds

Subscription count : 0
```

Related to issues in aws-roadmap [#86](https://github.com/ros-security/aws-roadmap/issues/86)