### PR TITLE
[ros2interface] Allow stdin input for 'ros2 interface show'

### DIFF
--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -40,7 +40,7 @@ class ShowVerb(VerbExtension):
         arg = parser.add_argument(
             'type',
             action=ReadStdinPipe,
-            help="Show an interface definition (e.g. 'std_msgs/msg/String'). "
+            help="Show an interface definition (e.g. 'example_interfaces/msg/String'). "
                  "Passing '-' reads the argument from stdin (e.g. "
                  "'ros2 topic type /chatter | ros2 interface show -').")
         arg.completer = type_completer

--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -28,6 +28,8 @@ class ReadStdinPipe(argparse.Action):
             if sys.stdin.isatty():
                 parser.error('expected stdin pipe')
             values = sys.stdin.readline().strip()
+        if not values:
+            parser.error('the passed value is empty')
         setattr(namespace, self.dest, values)
 
 

--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -25,12 +25,10 @@ class ReadStdinPipe(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         if values == '-':
-            if not sys.stdin.isatty():
-                setattr(namespace, self.dest, sys.stdin.readline().strip())
-            else:
+            if sys.stdin.isatty():
                 parser.error('expected stdin pipe')
-        else:
-            setattr(namespace, self.dest, values)
+            values = sys.stdin.readline().strip()
+        setattr(namespace, self.dest, values)
 
 
 class ShowVerb(VerbExtension):

--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -14,7 +14,6 @@
 
 import sys
 import argparse
-import textwrap
 
 from ros2interface.api import type_completer
 from ros2interface.verb import VerbExtension
@@ -38,18 +37,12 @@ class ShowVerb(VerbExtension):
     """Output the interface definition."""
 
     def add_arguments(self, parser, cli_name):
-        parser.formatter_class = argparse.RawTextHelpFormatter
-        parser.epilog = textwrap.dedent("""\
-                additional usage:
-                    show the interface definition of a topic, service or action
-                    (e.g. ros2 topic type /chatter | ros2 interface show -)""")
-
         arg = parser.add_argument(
-                'type',
-                action=ReadStdinPipe,
-                help=textwrap.dedent("""\
-                        Show an interface definition (e.g. "std_msgs/msg/String")
-                        Set to "-" to read the interface type from the stdin pipe"""))
+            'type',
+            action=ReadStdinPipe,
+            help="Show an interface definition (e.g. 'std_msgs/msg/String'). "
+                 "Passing '-' reads the argument from stdin (e.g. "
+                 "'ros2 topic type /chatter | ros2 interface show -').")
         arg.completer = type_completer
 
     def main(self, *, args):

--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import argparse
+import sys
 
 from ros2interface.api import type_completer
 from ros2interface.verb import VerbExtension

--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -12,18 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+import argparse
+import textwrap
+
 from ros2interface.api import type_completer
 from ros2interface.verb import VerbExtension
 from rosidl_runtime_py import get_interface_path
+
+
+class ReadStdinPipe(argparse.Action):
+    """Get argument from stdin pipe."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values == '-':
+            if not sys.stdin.isatty():
+                setattr(namespace, self.dest, sys.stdin.readline().strip())
+            else:
+                parser.error('expected stdin pipe')
+        else:
+            setattr(namespace, self.dest, values)
 
 
 class ShowVerb(VerbExtension):
     """Output the interface definition."""
 
     def add_arguments(self, parser, cli_name):
+        parser.formatter_class = argparse.RawTextHelpFormatter
+        parser.epilog = textwrap.dedent("""\
+                additional usage:
+                    show the interface definition of a topic, service or action
+                    (e.g. ros2 topic type /chatter | ros2 interface show -)""")
+
         arg = parser.add_argument(
                 'type',
-                help="Show an interface definition (e.g. 'example_interfaces/msg/String')")
+                action=ReadStdinPipe,
+                help=textwrap.dedent("""\
+                        Show an interface definition (e.g. "std_msgs/msg/String")
+                        Set to "-" to read the interface type from the stdin pipe"""))
         arg.completer = type_completer
 
     def main(self, *, args):

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -340,14 +340,14 @@ class TestROS2InterfaceCLI(unittest.TestCase):
     def test_show_stdin(self):
         with self.launch_interface_command(
             arguments=['show', '-'],
-            prepend_arguments=[sys.executable, '-c', r'"print(\"std_msgs/msg/String\")"', '|'],
+            prepend_arguments=[sys.executable, '-c', r'"print(\"test_msgs/msg/Nested\")"', '|'],
             shell=True
         ) as interface_command:
             assert interface_command.wait_for_shutdown(timeout=2)
         assert interface_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                'string data'
+                'BasicTypes basic_types_value'
             ],
             text=interface_command.output,
             strict=True


### PR DESCRIPTION
Implements #349.

Interface types can now be piped directly into show, like this:
`$ ros2 topic type /chatter | ros2 interface show`