### PR TITLE
[ros2lifecycle] Add test coverage for CLI

### DIFF
--- a/ros2lifecycle/package.xml
+++ b/ros2lifecycle/package.xml
@@ -20,7 +20,6 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
-
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros_testing</test_depend>
   <test_depend>ros2lifecycle_test_fixtures</test_depend>

--- a/ros2lifecycle/package.xml
+++ b/ros2lifecycle/package.xml
@@ -20,7 +20,9 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>lifecycle</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>ros_testing</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2lifecycle/package.xml
+++ b/ros2lifecycle/package.xml
@@ -20,9 +20,10 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
-  <test_depend>lifecycle</test_depend>
+
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros_testing</test_depend>
+  <test_depend>ros2lifecycle_test_fixtures</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -212,7 +212,20 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         )
 
     @launch_testing.markers.retry_on_failure(times=5)
-    def test_list_all_lifecycle_hidden_node_transitions(self):
+    def test_list_all_lifecycle_hidden_node_transitions_without_hidden_flag(self):
+        with self.launch_lifecycle_command(
+            arguments=['list', '_hidden_lc_node', '-a']
+        ) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=20)
+        assert lifecycle_command.exit_code == 1
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Node not found'],
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_list_all_lifecycle_hidden_node_transitions_with_hidden_flag(self):
         with self.launch_lifecycle_command(
             arguments=['list', '--include-hidden-nodes', '_hidden_lc_node', '-a']
         ) as lifecycle_command:

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -128,14 +128,14 @@ def generate_test_description(rmw_implementation):
                         Node(
                             package='ros2lifecycle_test_fixtures',
                             node_executable='simple_lifecycle_node',
-                            node_name='lc_node',
+                            node_name='test_lifecycle_node',
                             output='screen',
                             additional_env=additional_env
                         ),
                         Node(
                             package='ros2lifecycle_test_fixtures',
                             node_executable='simple_lifecycle_node',
-                            node_name='_hidden_lc_node',
+                            node_name='_hidden_test_lifecycle_node',
                             output='screen',
                             additional_env=additional_env
                         ),
@@ -181,7 +181,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_list_lifecycle_node_transitions(self):
         with self.launch_lifecycle_command(
-            arguments=['list', 'lc_node']
+            arguments=['list', 'test_lifecycle_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -201,7 +201,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_list_all_lifecycle_node_transitions(self):
         with self.launch_lifecycle_command(
-            arguments=['list', 'lc_node', '-a']
+            arguments=['list', 'test_lifecycle_node', '-a']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -214,7 +214,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_list_all_lifecycle_hidden_node_transitions_without_hidden_flag(self):
         with self.launch_lifecycle_command(
-            arguments=['list', '_hidden_lc_node', '-a']
+            arguments=['list', '_hidden_test_lifecycle_node', '-a']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == 1
@@ -227,7 +227,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_list_all_lifecycle_hidden_node_transitions_with_hidden_flag(self):
         with self.launch_lifecycle_command(
-            arguments=['list', '--include-hidden-nodes', '_hidden_lc_node', '-a']
+            arguments=['list', '--include-hidden-nodes', '_hidden_test_lifecycle_node', '-a']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -243,7 +243,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
-            expected_lines=['/lc_node'],
+            expected_lines=['/test_lifecycle_node'],
             text=lifecycle_command.output,
             strict=True
         )
@@ -255,8 +255,8 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                '/_hidden_lc_node',
-                '/lc_node'
+                '/_hidden_test_lifecycle_node',
+                '/test_lifecycle_node'
             ],
             text=lifecycle_command.output,
             strict=True
@@ -283,7 +283,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_set_lifecycle_node_invalid_transition(self):
         with self.launch_lifecycle_command(
-            arguments=['set', '/lc_node', 'noop']
+            arguments=['set', '/test_lifecycle_node', 'noop']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == 1
@@ -300,7 +300,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_set_nonexistent_lifecycle_node_state(self):
         with self.launch_lifecycle_command(
-            arguments=['set', '/nonexistent_lc_node', 'configure']
+            arguments=['set', '/nonexistent_test_lifecycle_node', 'configure']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == 1
@@ -313,7 +313,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_set_hidden_lifecycle_node_transition(self):
         with self.launch_lifecycle_command(
-            arguments=['set', '/_hidden_lc_node', 'configure']
+            arguments=['set', '/_hidden_test_lifecycle_node', 'configure']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == 1
@@ -326,7 +326,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_get_nonexistent_lifecycle_node_state(self):
         with self.launch_lifecycle_command(
-            arguments=['get', '/nonexistent_lc_node']
+            arguments=['get', '/nonexistent_test_lifecycle_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == 1
@@ -339,7 +339,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_get_hidden_lifecycle_node_state(self):
         with self.launch_lifecycle_command(
-            arguments=['get', '/_hidden_lc_node']
+            arguments=['get', '/_hidden_test_lifecycle_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == 1
@@ -350,7 +350,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         )
 
         with self.launch_lifecycle_command(
-            arguments=['get', '--include-hidden-nodes', '/_hidden_lc_node']
+            arguments=['get', '--include-hidden-nodes', '/_hidden_test_lifecycle_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -363,7 +363,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_get_lifecycle_node_state(self):
         with self.launch_lifecycle_command(
-            arguments=['get', '/lc_node']
+            arguments=['get', '/test_lifecycle_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -383,7 +383,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         ]
         for current_state, next_action in lifecycle:
             with self.launch_lifecycle_command(
-                arguments=['get', '--include-hidden-nodes', '/_hidden_lc_node']
+                arguments=['get', '--include-hidden-nodes', '/_hidden_test_lifecycle_node']
             ) as lifecycle_command:
                 assert lifecycle_command.wait_for_shutdown(timeout=20)
             assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -394,7 +394,9 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             )
 
             with self.launch_lifecycle_command(
-                arguments=['set', '--include-hidden-nodes', '/_hidden_lc_node', next_action]
+                arguments=[
+                    'set', '--include-hidden-nodes', '/_hidden_test_lifecycle_node', next_action
+                ]
             ) as lifecycle_command:
                 assert lifecycle_command.wait_for_shutdown(timeout=20)
             assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -405,7 +407,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             )
 
         with self.launch_lifecycle_command(
-            arguments=['get', '--include-hidden-nodes', '/_hidden_lc_node']
+            arguments=['get', '--include-hidden-nodes', '/_hidden_test_lifecycle_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -1,0 +1,342 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch_ros.actions import Node
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+import launch_testing_ros.tools
+
+import pytest
+
+from rmw_implementation import get_available_rmw_implementations
+
+
+ALL_LIFECYCLE_TALKER_TRANSITIONS = [
+    '- configure [1]',
+    '\tStart: unconfigured',
+    '\tGoal: configuring',
+    '- transition_success [10]',
+    '\tStart: configuring',
+    '\tGoal: inactive',
+    '- transition_failure [11]',
+    '\tStart: configuring',
+    '\tGoal: unconfigured',
+    '- transition_error [12]',
+    '\tStart: configuring',
+    '\tGoal: errorprocessing',
+    '- cleanup [2]',
+    '\tStart: inactive',
+    '\tGoal: cleaningup',
+    '- transition_success [20]',
+    '\tStart: cleaningup',
+    '\tGoal: unconfigured',
+    '- transition_failure [21]',
+    '\tStart: cleaningup',
+    '\tGoal: inactive',
+    '- transition_error [22]',
+    '\tStart: cleaningup',
+    '\tGoal: errorprocessing',
+    '- activate [3]',
+    '\tStart: inactive',
+    '\tGoal: activating',
+    '- transition_success [30]',
+    '\tStart: activating',
+    '\tGoal: active',
+    '- transition_failure [31]',
+    '\tStart: activating',
+    '\tGoal: inactive',
+    '- transition_error [32]',
+    '\tStart: activating',
+    '\tGoal: errorprocessing',
+    '- deactivate [4]',
+    '\tStart: active',
+    '\tGoal: deactivating',
+    '- transition_success [40]',
+    '\tStart: deactivating',
+    '\tGoal: inactive',
+    '- transition_failure [41]',
+    '\tStart: deactivating',
+    '\tGoal: active',
+    '- transition_error [42]',
+    '\tStart: deactivating',
+    '\tGoal: errorprocessing',
+    '- shutdown [5]',
+    '\tStart: unconfigured',
+    '\tGoal: shuttingdown',
+    '- shutdown [6]',
+    '\tStart: inactive',
+    '\tGoal: shuttingdown',
+    '- shutdown [7]',
+    '\tStart: active',
+    '\tGoal: shuttingdown',
+    '- transition_success [50]',
+    '\tStart: shuttingdown',
+    '\tGoal: finalized',
+    '- transition_failure [51]',
+    '\tStart: shuttingdown',
+    '\tGoal: finalized',
+    '- transition_error [52]',
+    '\tStart: shuttingdown',
+    '\tGoal: errorprocessing',
+    '- transition_success [60]',
+    '\tStart: errorprocessing',
+    '\tGoal: unconfigured',
+    '- transition_failure [61]',
+    '\tStart: errorprocessing',
+    '\tGoal: finalized',
+    '- transition_error [62]',
+    '\tStart: errorprocessing',
+    '\tGoal: finalized'
+]
+
+
+@pytest.mark.rostest
+@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+def generate_test_description(rmw_implementation):
+    additional_env = {'RMW_IMPLEMENTATION': rmw_implementation}
+    return LaunchDescription([
+        # Always restart daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                ExecuteProcess(
+                    cmd=['ros2', 'daemon', 'start'],
+                    name='daemon-start',
+                    on_exit=[
+                        # Add test fixture actions.
+                        Node(
+                            package='lifecycle',
+                            node_executable='lifecycle_talker',
+                            node_name='lc_talker',
+                            output='screen',
+                            additional_env=additional_env
+                        ),
+                        Node(
+                            package='lifecycle',
+                            node_executable='lifecycle_talker',
+                            node_name='_hidden_lc_talker',
+                            output='screen',
+                            additional_env=additional_env
+                        ),
+                        launch_testing.actions.ReadyToTest()
+                    ],
+                    additional_env=additional_env
+                )
+            ]
+        ),
+    ])
+
+
+class TestROS2LifecycleCLI(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(
+        cls,
+        launch_service,
+        proc_info,
+        proc_output,
+        rmw_implementation
+    ):
+        @contextlib.contextmanager
+        def launch_lifecycle_command(self, arguments):
+            lifecycle_command_action = ExecuteProcess(
+                cmd=['ros2', 'lifecycle', *arguments],
+                additional_env={
+                    'RMW_IMPLEMENTATION': rmw_implementation,
+                    'PYTHONUNBUFFERED': '1'
+                },
+                name='ros2lifecycle-cli',
+                output='screen'
+            )
+            with launch_testing.tools.launch_process(
+                launch_service, lifecycle_command_action, proc_info, proc_output,
+                output_filter=launch_testing_ros.tools.basic_output_filter(
+                    filtered_rmw_implementation=rmw_implementation
+                )
+            ) as lifecycle_command:
+                yield lifecycle_command
+        cls.launch_lifecycle_command = launch_lifecycle_command
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_list_lifecycle_node_transitions(self):
+        with self.launch_lifecycle_command(
+            arguments=['list', 'lc_talker']
+        ) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                '- configure [1]',
+                '\tStart: unconfigured',
+                '\tGoal: configuring',
+                '- shutdown [5]',
+                '\tStart: unconfigured',
+                '\tGoal: shuttingdown'
+            ],
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_list_all_lifecycle_node_transitions(self):
+        with self.launch_lifecycle_command(
+            arguments=['list', 'lc_talker', '-a']
+        ) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=ALL_LIFECYCLE_TALKER_TRANSITIONS,
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_list_all_lifecycle_hidden_node_transitions(self):
+        with self.launch_lifecycle_command(
+            arguments=['list', '_hidden_lc_talker', '-a']
+        ) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=ALL_LIFECYCLE_TALKER_TRANSITIONS,
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_list_lifecycle_nodes(self):
+        with self.launch_lifecycle_command(arguments=['nodes']) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=['/lc_talker'],
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_list_all_lifecycle_nodes(self):
+        with self.launch_lifecycle_command(arguments=['nodes', '-a']) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                '/_hidden_lc_talker',
+                '/lc_talker'
+            ],
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_count_all_lifecycle_nodes(self):
+        with self.launch_lifecycle_command(arguments=['nodes', '-a', '-c']) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+        output_lines = lifecycle_command.output.splitlines()
+        assert len(output_lines) == 1
+        assert int(output_lines[0]) == 2
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_set_lifecycle_node_invalid_transition(self):
+        with self.launch_lifecycle_command(
+            arguments=['set', '/lc_talker', 'noop']
+        ) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == 1
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                'Unknown transition requested, available ones are:',
+                '- configure [1]',
+                '- shutdown [5]'
+            ],
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_set_nonexistent_node_state(self):
+        with self.launch_lifecycle_command(
+            arguments=['set', '/nonexistent_talker', 'configure']
+        ) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == 1
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Node not found'],
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_get_nonexistent_node_state(self):
+        with self.launch_lifecycle_command(
+            arguments=['get', '/nonexistent_talker']
+        ) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == 1
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Node not found'],
+            text=lifecycle_command.output,
+            strict=True
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_node_lifecycle(self):
+        lifecycle = [
+            ('unconfigured [1]', 'configure'),
+            ('inactive [2]', 'activate'),
+            ('active [3]', 'deactivate'),
+            ('inactive [2]', 'cleanup')
+        ]
+        for current_state, next_action in lifecycle:
+            with self.launch_lifecycle_command(
+                arguments=['get', '--include-hidden-nodes', '/_hidden_lc_talker']
+            ) as lifecycle_command:
+                assert lifecycle_command.wait_for_shutdown(timeout=10)
+            assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+            assert launch_testing.tools.expect_output(
+                expected_lines=[current_state],
+                text=lifecycle_command.output,
+                strict=True
+            )
+
+            with self.launch_lifecycle_command(
+                arguments=['set', '--include-hidden-nodes', '/_hidden_lc_talker', next_action]
+            ) as lifecycle_command:
+                assert lifecycle_command.wait_for_shutdown(timeout=10)
+            assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+            assert launch_testing.tools.expect_output(
+                expected_lines=['Transitioning successful'],
+                text=lifecycle_command.output,
+                strict=True
+            )
+
+        with self.launch_lifecycle_command(
+            arguments=['get', '--include-hidden-nodes', '/_hidden_lc_talker']
+        ) as lifecycle_command:
+            assert lifecycle_command.wait_for_shutdown(timeout=10)
+        assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[lifecycle[0][0]], text=lifecycle_command.output, strict=True
+        )

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -31,7 +31,7 @@ import pytest
 from rmw_implementation import get_available_rmw_implementations
 
 
-ALL_LIFECYCLE_TALKER_TRANSITIONS = [
+ALL_LIFECYCLE_NODE_TRANSITIONS = [
     '- configure [1]',
     '\tStart: unconfigured',
     '\tGoal: configuring',
@@ -126,16 +126,16 @@ def generate_test_description(rmw_implementation):
                     on_exit=[
                         # Add test fixture actions.
                         Node(
-                            package='lifecycle',
-                            node_executable='lifecycle_talker',
-                            node_name='lc_talker',
+                            package='ros2lifecycle_test_fixtures',
+                            node_executable='simple_lifecycle_node',
+                            node_name='lc_node',
                             output='screen',
                             additional_env=additional_env
                         ),
                         Node(
-                            package='lifecycle',
-                            node_executable='lifecycle_talker',
-                            node_name='_hidden_lc_talker',
+                            package='ros2lifecycle_test_fixtures',
+                            node_executable='simple_lifecycle_node',
+                            node_name='_hidden_lc_node',
                             output='screen',
                             additional_env=additional_env
                         ),
@@ -181,7 +181,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_list_lifecycle_node_transitions(self):
         with self.launch_lifecycle_command(
-            arguments=['list', 'lc_talker']
+            arguments=['list', 'lc_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=10)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -201,12 +201,12 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_list_all_lifecycle_node_transitions(self):
         with self.launch_lifecycle_command(
-            arguments=['list', 'lc_talker', '-a']
+            arguments=['list', 'lc_node', '-a']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=10)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
-            expected_lines=ALL_LIFECYCLE_TALKER_TRANSITIONS,
+            expected_lines=ALL_LIFECYCLE_NODE_TRANSITIONS,
             text=lifecycle_command.output,
             strict=True
         )
@@ -214,12 +214,12 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_list_all_lifecycle_hidden_node_transitions(self):
         with self.launch_lifecycle_command(
-            arguments=['list', '_hidden_lc_talker', '-a']
+            arguments=['list', '_hidden_lc_node', '-a']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=10)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
-            expected_lines=ALL_LIFECYCLE_TALKER_TRANSITIONS,
+            expected_lines=ALL_LIFECYCLE_NODE_TRANSITIONS,
             text=lifecycle_command.output,
             strict=True
         )
@@ -230,7 +230,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             assert lifecycle_command.wait_for_shutdown(timeout=10)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
-            expected_lines=['/lc_talker'],
+            expected_lines=['/lc_node'],
             text=lifecycle_command.output,
             strict=True
         )
@@ -242,8 +242,8 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                '/_hidden_lc_talker',
-                '/lc_talker'
+                '/_hidden_lc_node',
+                '/lc_node'
             ],
             text=lifecycle_command.output,
             strict=True
@@ -261,7 +261,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_set_lifecycle_node_invalid_transition(self):
         with self.launch_lifecycle_command(
-            arguments=['set', '/lc_talker', 'noop']
+            arguments=['set', '/lc_node', 'noop']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=10)
         assert lifecycle_command.exit_code == 1
@@ -278,7 +278,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_set_nonexistent_node_state(self):
         with self.launch_lifecycle_command(
-            arguments=['set', '/nonexistent_talker', 'configure']
+            arguments=['set', '/nonexistent_node', 'configure']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=10)
         assert lifecycle_command.exit_code == 1
@@ -291,7 +291,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_get_nonexistent_node_state(self):
         with self.launch_lifecycle_command(
-            arguments=['get', '/nonexistent_talker']
+            arguments=['get', '/nonexistent_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=10)
         assert lifecycle_command.exit_code == 1
@@ -311,7 +311,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         ]
         for current_state, next_action in lifecycle:
             with self.launch_lifecycle_command(
-                arguments=['get', '--include-hidden-nodes', '/_hidden_lc_talker']
+                arguments=['get', '--include-hidden-nodes', '/_hidden_lc_node']
             ) as lifecycle_command:
                 assert lifecycle_command.wait_for_shutdown(timeout=10)
             assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -322,7 +322,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             )
 
             with self.launch_lifecycle_command(
-                arguments=['set', '--include-hidden-nodes', '/_hidden_lc_talker', next_action]
+                arguments=['set', '--include-hidden-nodes', '/_hidden_lc_node', next_action]
             ) as lifecycle_command:
                 assert lifecycle_command.wait_for_shutdown(timeout=10)
             assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -333,7 +333,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             )
 
         with self.launch_lifecycle_command(
-            arguments=['get', '--include-hidden-nodes', '/_hidden_lc_talker']
+            arguments=['get', '--include-hidden-nodes', '/_hidden_lc_node']
         ) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=10)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK

--- a/ros2lifecycle_test_fixtures/CMakeLists.txt
+++ b/ros2lifecycle_test_fixtures/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(ros2lifecycle_test_fixtures)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(rclcpp REQUIRED)
+
+include_directories(
+  ${rclcpp_lifecycle_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS})
+
+add_executable(simple_lifecycle_node
+  src/simple_lifecycle_node.cpp)
+target_link_libraries(simple_lifecycle_node
+  ${rclcpp_lifecycle_LIBRARIES}
+)
+
+install(TARGETS
+  simple_lifecycle_node
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros2lifecycle_test_fixtures/package.xml
+++ b/ros2lifecycle_test_fixtures/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ros2lifecycle_test_fixtures</name>
+  <version>0.8.3</version>
+  <description>Package containing fixture nodes for ros2lifecycle tests</description>
+  <maintainer email="michel@ekumenlabs.com">Michel Hidalgo</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2lifecycle_test_fixtures/src/simple_lifecycle_node.cpp
+++ b/ros2lifecycle_test_fixtures/src/simple_lifecycle_node.cpp
@@ -1,0 +1,94 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+using namespace std::chrono_literals;
+
+class SimpleLifecycleNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit SimpleLifecycleNode(const std::string & node_name)
+  : rclcpp_lifecycle::LifecycleNode(node_name)
+  {}
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State &)
+  {
+    RCLCPP_INFO(get_logger(), "on_configure() is called.");
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State &)
+  {
+    RCLCPP_INFO(get_logger(), "on_activate() is called.");
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State &)
+  {
+    RCLCPP_INFO(get_logger(), "on_deactivate() is called.");
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State &)
+  {
+    RCLCPP_INFO(get_logger(), "on cleanup is called.");
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_shutdown(const rclcpp_lifecycle::State & state)
+  {
+    RCLCPP_INFO(
+      get_logger(),
+      "on shutdown is called from state %s.",
+      state.label().c_str());
+
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+};
+
+int main(int argc, char * argv[])
+{
+  // force flush of the stdout buffer.
+  // this ensures a correct sync of all prints
+  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+  rclcpp::init(argc, argv);
+
+  auto lc_node = std::make_shared<SimpleLifecycleNode>("lc_node");
+
+  rclcpp::spin(lc_node->get_node_base_interface());
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/ros2lifecycle_test_fixtures/src/simple_lifecycle_node.cpp
+++ b/ros2lifecycle_test_fixtures/src/simple_lifecycle_node.cpp
@@ -84,7 +84,7 @@ int main(int argc, char * argv[])
 
   rclcpp::init(argc, argv);
 
-  auto lc_node = std::make_shared<SimpleLifecycleNode>("lc_node");
+  auto lc_node = std::make_shared<SimpleLifecycleNode>("test_lifecycle_node");
 
   rclcpp::spin(lc_node->get_node_base_interface());
 


### PR DESCRIPTION
Precisely what the title says. This pull requests adds integration for each and every `ros2 lifecycle` verb.

~It current depends on the `lifecycle` package in the `ros2/demos` repository, creating a circular repo dependency. Fixture nodes must be duplicated and relocated, maybe simplifying these in the process.~