### PR TITLE
add service clients to ros2node info

### DIFF
--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -27,7 +27,7 @@ import rclpy
 from ros2cli.node.direct import DirectNode
 from ros2cli.node.strategy import NodeStrategy
 from ros2node.api import get_node_names
-from ros2node.api import get_service_info
+from ros2node.api import get_service_server_info
 from ros2param.api import get_parameter_value
 from ros2pkg.api import get_executable_paths
 from ros2pkg.api import PackageNotFound
@@ -191,7 +191,7 @@ def unload_component_from_container(*, node, remote_container_node_name, compone
 
 def find_container_node_names(*, node, node_names):
     """
-    Identify container nodes from a a list of node names.
+    Identify container nodes from a list of node names.
 
     :param node: a `ros2cli.node.DirectNode` instance
     :param node_names: list of `ros2node.api.NodeName` instances, as returned
@@ -202,7 +202,7 @@ def find_container_node_names(*, node, node_names):
     container_node_names = []
     for n in node_names:
         try:
-            services = get_service_info(
+            services = get_service_server_info(
                 node=node, remote_node_name=n.full_name, include_hidden=True)
         except rclpy.node.NodeNameNonExistentError:
             continue

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -88,7 +88,15 @@ def get_publisher_info(*, node, remote_node_name, include_hidden=False):
     )
 
 
-def get_service_info(*, node, remote_node_name, include_hidden=False):
+def get_service_client_info(*, node, remote_node_name, include_hidden=False):
+    return get_topics(
+        remote_node_name,
+        node.get_client_names_and_types_by_node,
+        include_hidden_topics=include_hidden
+    )
+
+
+def get_service_server_info(*, node, remote_node_name, include_hidden=False):
     return get_topics(
         remote_node_name,
         node.get_service_names_and_types_by_node,

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -19,7 +19,8 @@ from ros2node.api import get_action_client_info
 from ros2node.api import get_action_server_info
 from ros2node.api import get_node_names
 from ros2node.api import get_publisher_info
-from ros2node.api import get_service_info
+from ros2node.api import get_service_client_info
+from ros2node.api import get_service_server_info
 from ros2node.api import get_subscriber_info
 from ros2node.api import NodeNameCompleter
 from ros2node.verb import VerbExtension
@@ -56,10 +57,14 @@ class InfoVerb(VerbExtension):
                     node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
                 print('  Publishers:')
                 print_names_and_types(publishers)
-                services = get_service_info(
+                service_servers = get_service_server_info(
                     node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
-                print('  Services:')
-                print_names_and_types(services)
+                print('  Service Servers:')
+                print_names_and_types(service_servers)
+                service_clients = get_service_client_info(
+                    node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
+                print('  Service Clients:')
+                print_names_and_types(service_clients)
                 actions_servers = get_action_server_info(
                     node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
                 print('  Action Servers:')

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -167,11 +167,13 @@ class TestROS2NodeCLI(unittest.TestCase):
                 '    /arrays: test_msgs/msg/Arrays',
                 '    /parameter_events: rcl_interfaces/msg/ParameterEvent',
                 '    /rosout: rcl_interfaces/msg/Log',
-                '  Services:',
+                '  Service Servers:',
                 '    /basic: test_msgs/srv/BasicTypes',
             ], itertools.repeat(re.compile(
                 r'\s*/complex_node/.*parameter.*: rcl_interfaces/srv/.*Parameter.*'
             ), 6), [
+                '  Service Clients:',
+                '',
                 '  Action Servers:',
                 '    /fibonacci: test_msgs/action/Fibonacci',
                 '  Action Clients:',


### PR DESCRIPTION
Currently `ros2 node info` shows only service servers:
```
$ ros2 run demo_nodes_py add_two_ints_client &
$ ros2 node info /add_two_ints_client
/add_two_ints_client
  Subscribers:

  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /rosout: rcl_interfaces/msg/Log
  Services:
    /add_two_ints_client/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /add_two_ints_client/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /add_two_ints_client/get_parameters: rcl_interfaces/srv/GetParameters
    /add_two_ints_client/list_parameters: rcl_interfaces/srv/ListParameters
    /add_two_ints_client/set_parameters: rcl_interfaces/srv/SetParameters
    /add_two_ints_client/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
  Action Servers:

  Action Clients:


```

After this PR:
```
$ ros2 run demo_nodes_py add_two_ints_client &
$ ros2 node info /add_two_ints_client
$ ros2 node info /add_two_ints_client
/add_two_ints_client
  Subscribers:

  Publishers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /rosout: rcl_interfaces/msg/Log
  Service Servers:
    /add_two_ints_client/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /add_two_ints_client/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /add_two_ints_client/get_parameters: rcl_interfaces/srv/GetParameters
    /add_two_ints_client/list_parameters: rcl_interfaces/srv/ListParameters
    /add_two_ints_client/set_parameters: rcl_interfaces/srv/SetParameters
    /add_two_ints_client/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
  Service Clients:
    /add_two_ints: example_interfaces/srv/AddTwoInts
  Action Servers:

  Action Clients:

```

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>