### PR TITLE
Fix ros2 topic pub --node-name

### DIFF
--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -35,8 +35,13 @@ class DirectNode:
             args, 'node_name_suffix', '_%d' % os.getpid())
         start_parameter_services = getattr(
             args, 'start_parameter_services', False)
+
+        node_name = NODE_NAME_PREFIX + node_name_suffix
+        if hasattr(args, 'node_name') and args.node_name:
+            node_name = args.node_name
+
         self.node = rclpy.create_node(
-            NODE_NAME_PREFIX + node_name_suffix,
+            node_name,
             start_parameter_services=start_parameter_services)
         timeout = getattr(args, 'spin_time', DEFAULT_TIMEOUT)
         timer = self.node.create_timer(timeout, timer_callback)

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -22,7 +22,7 @@ DEFAULT_TIMEOUT = 0.5
 
 class DirectNode:
 
-    def __init__(self, args):
+    def __init__(self, args, *, node_name=None):
         timeout_reached = False
 
         def timer_callback():
@@ -36,9 +36,8 @@ class DirectNode:
         start_parameter_services = getattr(
             args, 'start_parameter_services', False)
 
-        node_name = NODE_NAME_PREFIX + node_name_suffix
-        if hasattr(args, 'node_name') and args.node_name:
-            node_name = args.node_name
+        if not node_name:
+            node_name = NODE_NAME_PREFIX + node_name_suffix
 
         self.node = rclpy.create_node(
             node_name,

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -36,7 +36,7 @@ class DirectNode:
         start_parameter_services = getattr(
             args, 'start_parameter_services', False)
 
-        if not node_name:
+        if node_name is None:
             node_name = NODE_NAME_PREFIX + node_name_suffix
 
         self.node = rclpy.create_node(

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -79,7 +79,7 @@ class PubVerb(VerbExtension):
 def main(args):
     qos_profile = qos_profile_from_short_keys(
         args.qos_profile, reliability=args.qos_reliability, durability=args.qos_durability)
-    with DirectNode(args) as node:
+    with DirectNode(args, node_name=args.node_name) as node:
         return publisher(
             node.node,
             args.message_type,


### PR DESCRIPTION
`ros2 topic pub` has a `--node-name` option, but it appears to not do anything. This PR fixes that by making the direct_node take a keyword argument `node_name`.

To reproduce:

This should publish a string message on the topic `/foo/asdf`

```
ros2 topic pub -n "foo" "~/asdf" std_msgs/msg/String "data: be"
```

Without this PR, it appears the node name was not changed.

```
$ ros2 topic list --include-hidden-topics
/_ros2cli_982/asdf
```