### PR TITLE
fix new linter warnings as of flake8-comprehensions 3.1.0

### DIFF
--- a/ros2action/ros2action/api/__init__.py
+++ b/ros2action/ros2action/api/__init__.py
@@ -84,10 +84,10 @@ def get_action_types(package_name):
     interface_names = content.splitlines()
     # TODO(jacobperron) this logic should come from a rosidl related package
     # Only return actions in action folder
-    return list(sorted({
+    return {
         n[7:-7]
         for n in interface_names
-        if n.startswith('action/') and n[-7:] in ('.idl', '.action')}))
+        if n.startswith('action/') and n[-7:] in ('.idl', '.action')}
 
 
 def get_all_action_types():
@@ -117,8 +117,9 @@ def action_name_completer(prefix, parsed_args, **kwargs):
 def action_type_completer(**kwargs):
     """Callable returning a list of action types."""
     action_types = []
-    for package_name, action_names in get_all_action_types().items():
-        for action_name in action_names:
+    action_types_dict = get_all_action_types()
+    for package_name in sorted(action_types_dict.keys()):
+        for action_name in sorted(action_types_dict[package_name]):
             action_types.append(
                 '{package_name}/action/{action_name}'.format_map(locals()))
     return action_types

--- a/ros2msg/ros2msg/api/__init__.py
+++ b/ros2msg/ros2msg/api/__init__.py
@@ -38,10 +38,10 @@ def get_message_types(package_name):
     interface_names = content.splitlines()
     # TODO(dirk-thomas) this logic should come from a rosidl related package
     # Only return messages in msg folder
-    return list(sorted({
+    return {
         n[4:-4]
         for n in interface_names
-        if n.startswith('msg/') and n[-4:] in ('.idl', '.msg')}))
+        if n.startswith('msg/') and n[-4:] in ('.idl', '.msg')}
 
 
 def get_message_path(package_name, message_name):
@@ -62,8 +62,9 @@ def message_package_name_completer(**kwargs):
 def message_type_completer(**kwargs):
     """Callable returning a list of message types."""
     message_types = []
-    for package_name, message_names in get_all_message_types().items():
-        for message_name in message_names:
+    message_types_dict = get_all_message_types()
+    for package_name in sorted(message_types_dict.keys()):
+        for message_name in sorted(message_types_dict[package_name]):
             message_types.append(
                 '{package_name}/msg/{message_name}'.format_map(locals()))
     return message_types
@@ -77,4 +78,4 @@ class MessageNameCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         package_name = getattr(parsed_args, self.package_name_key)
-        return get_message_types(package_name)
+        return sorted(get_message_types(package_name))

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -157,7 +157,7 @@ class CreateVerb(VerbExtension):
         print('version:', package.version)
         print('description:', package.description)
         print('maintainer:', [str(maintainer) for maintainer in package.maintainers])
-        print('licenses:', [license_ for license_ in package.licenses])
+        print('licenses:', package.licenses)
         print('build type:', package.get_build_type())
         print('dependencies:', [str(dependency) for dependency in package.build_depends])
         if node_name:

--- a/ros2srv/ros2srv/api/__init__.py
+++ b/ros2srv/ros2srv/api/__init__.py
@@ -38,10 +38,10 @@ def get_service_types(package_name):
     interface_names = content.splitlines()
     # TODO(dirk-thomas) this logic should come from a rosidl related package
     # Only return services in srv folder
-    return list(sorted({
+    return {
         n[4:-4]
         for n in interface_names
-        if n.startswith('srv/') and n[-4:] in ('.idl', '.srv')}))
+        if n.startswith('srv/') and n[-4:] in ('.idl', '.srv')}
 
 
 def get_service_path(package_name, service_name):
@@ -62,8 +62,9 @@ def service_package_name_completer(**kwargs):
 def service_type_completer(**kwargs):
     """Callable returning a list of service types."""
     service_types = []
-    for package_name, service_names in get_all_service_types().items():
-        for service_name in service_names:
+    service_types_dict = get_all_service_types()
+    for package_name in sorted(service_types_dict.keys()):
+        for service_name in sorted(service_types_dict[package_name]):
             service_types.append(
                 '{package_name}/srv/{service_name}'.format_map(locals()))
     return service_types
@@ -77,4 +78,4 @@ class ServiceNameCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         package_name = getattr(parsed_args, self.package_name_key)
-        return get_service_types(package_name)
+        return sorted(get_service_types(package_name))

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -78,8 +78,9 @@ def import_message_type(topic_name, message_type):
 def message_type_completer(**kwargs):
     """Callable returning a list of message types."""
     message_types = []
-    for package_name, message_names in get_message_interfaces().items():
-        for message_name in message_names:
+    message_types_dict = get_message_interfaces()
+    for package_name in sorted(message_types_dict.keys()):
+        for message_name in sorted(message_types_dict[package_name]):
             message_types.append(f'{package_name}/{message_name}')
     return message_types
 


### PR DESCRIPTION
Address new linter warnings.

It didn't make sense that the functions were already sorting their return value since in several cases the caller doesn't care about the order. Therefore I moved the sorting to the callers where applicable.