### PR TITLE
[ros2topic] show default values for --qos-* options

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -186,14 +186,19 @@ def add_qos_arguments_to_argument_parser(
         '--qos-profile',
         choices=rclpy.qos.QoSPresetProfiles.short_keys(),
         default=default_preset,
-        help='Quality of service preset profile to {} with.'.format(verb))
+        help='Quality of service preset profile to {} with (default: {})'
+             .format(verb, default_preset))
+    default_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(
+        default_preset)
     parser.add_argument(
         '--qos-reliability',
         choices=rclpy.qos.QoSReliabilityPolicy.short_keys(),
-        help='Quality of service reliability setting to {} with. '
-             '(Will override reliability value of --qos-profile option)'.format(verb))
+        help='Quality of service reliability setting to {} with '
+             '(overrides reliability value of --qos-profile option, default: {})'
+             .format(verb, default_profile.reliability.short_key))
     parser.add_argument(
         '--qos-durability',
         choices=rclpy.qos.QoSDurabilityPolicy.short_keys(),
-        help='Quality of service durability setting to {} with. '
-             '(Will override durability value of --qos-profile option)'.format(verb))
+        help='Quality of service durability setting to {} with '
+             '(overrides durability value of --qos-profile option, default: {})'
+             .format(verb, default_profile.durability.short_key))


### PR DESCRIPTION
Follow up of #283. @emersonknapp FYI.

Show the actually used default value whn calling `--help`.

Requires ros2/rclpy#463.