### PR TITLE
Update network check to fix missing flags on Windows 

### DIFF
--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -66,6 +66,8 @@ class NetworkCheck(DoctorCheck):
             return result
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
+        if not has_loopback and not has_non_loopback and not has_multicast:
+            result.add_warning('No flags found on `ifconfig/ipconfig` interface.')
         if not has_loopback:
             result.add_error('ERROR: No loopback IP address is found.')
         if not has_non_loopback:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -66,11 +66,12 @@ class NetworkCheck(DoctorCheck):
             return result
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
-        if not has_loopback and not has_non_loopback:
-            # no flags found, otherwise one of them should be True.
-            result.add_warning('No flags found. \
-                Run `ipconfig` on cmd to check network interfaces.')
-            return result
+        if not _is_unix_like_platform():
+            if not has_loopback and not has_non_loopback:
+                # no flags found, otherwise one of them should be True.
+                print('No flags found. \
+                    Run `ipconfig` on cmd to check network interfaces.')
+                return result
         if not has_loopback:
             result.add_error('ERROR: No loopback IP address is found.')
         if not has_non_loopback:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -66,8 +66,8 @@ class NetworkCheck(DoctorCheck):
             return result
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
-        if not has_loopback and not has_non_loopback and not has_multicast:
-            result.add_warning('No flags found on `ifconfig/ipconfig` interface.')
+        if not has_loopback and not has_non_loopback:
+            result.add_warning('No flags found on `ipconfig` interface.')
         if not has_loopback:
             result.add_error('ERROR: No loopback IP address is found.')
         if not has_non_loopback:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -36,7 +36,7 @@ def _is_unix_like_platform() -> bool:
 def _check_network_config_helper(ifcfg_ifaces: dict) -> Tuple[bool, bool, bool]:
     """Check if loopback and multicast IP addresses are found."""
     has_loopback, has_non_loopback, has_multicast = False, False, False
-    for _, iface in ifcfg.interfaces().items():
+    for _, iface in ifcfg_ifaces.items():
         flags = iface.get('flags')
         if flags:
             flags = flags.lower()
@@ -97,7 +97,7 @@ class NetworkReport(DoctorReport):
             return Report('')
 
         network_report = Report('NETWORK CONFIGURATION')
-        for name, iface in ifcfg_ifaces.items():
+        for _, iface in ifcfg_ifaces.items():
             for k, v in iface.items():
                 if v:
                     network_report.add_to_report(k, v)

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -69,6 +69,7 @@ class NetworkCheck(DoctorCheck):
         if not has_loopback and not has_non_loopback:
             result.add_warning('No flags found. \
                 Run `ipconfig` on cmd to check network interfaces.')
+            return result
         if not has_loopback:
             result.add_error('ERROR: No loopback IP address is found.')
         if not has_non_loopback:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -67,6 +67,7 @@ class NetworkCheck(DoctorCheck):
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
         if not has_loopback and not has_non_loopback:
+            # no flags found, otherwise one of them should be True.
             result.add_warning('No flags found. \
                 Run `ipconfig` on cmd to check network interfaces.')
             return result

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -36,7 +36,7 @@ def _is_unix_like_platform() -> bool:
 def _check_network_config_helper(ifcfg_ifaces: dict) -> Tuple[bool, bool, bool]:
     """Check if loopback and multicast IP addresses are found."""
     has_loopback, has_non_loopback, has_multicast = False, False, False
-    for _, iface in ifcfg_ifaces.items():
+    for iface in ifcfg_ifaces.values():
         flags = iface.get('flags')
         if flags:
             flags = flags.lower()
@@ -97,7 +97,7 @@ class NetworkReport(DoctorReport):
             return Report('')
 
         network_report = Report('NETWORK CONFIGURATION')
-        for _, iface in ifcfg_ifaces.items():
+        for iface in ifcfg_ifaces.values():
             for k, v in iface.items():
                 if v:
                     network_report.add_to_report(k, v)

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -67,7 +67,8 @@ class NetworkCheck(DoctorCheck):
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
         if not has_loopback and not has_non_loopback:
-            result.add_warning('No flags found on `ipconfig` interface.')
+            result.add_warning('No flags found. \
+                Run `ipconfig` on cmd to check network interfaces.')
         if not has_loopback:
             result.add_error('ERROR: No loopback IP address is found.')
         if not has_non_loopback:


### PR DESCRIPTION
Warn about missing flags on windows `ipconfig` output. Closes #403 - false negative warnings on windows. 