### PR TITLE
[WIP] Added incompatible event support to ros2 topic echo and ros2 topic pub

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -99,9 +99,11 @@ def main(args):
         subscriber(
             node.node, args.topic_name, args.message_type, callback, qos_profile)
 
+
 def handle_incompatible_qos_event(event):
     incompatible_qos_name = qos_policy_name_from_kind(event.last_policy_kind)
     print(f'Incompatible QoS Policy detected: {incompatible_qos_name}')
+
 
 def subscriber(
     node: Node,

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -61,7 +61,7 @@ class InfoVerb(VerbExtension):
                 except NotImplementedError as e:
                     return str(e)
 
-            print('Subscription count: %d' % node.count_subscribers(topic_name), end=line_end)
+            print('Subscription count: %d' % node.count_subscribers(topic_name))
             if args.verbose:
                 try:
                     for info in node.get_subscriptions_info_by_topic(topic_name):

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -61,7 +61,7 @@ class InfoVerb(VerbExtension):
                 except NotImplementedError as e:
                     return str(e)
 
-            print('Subscription count: %d' % node.count_subscribers(topic_name))
+            print('Subscription count: %d' % node.count_subscribers(topic_name), end=line_end)
             if args.verbose:
                 try:
                     for info in node.get_subscriptions_info_by_topic(topic_name):

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -93,9 +93,11 @@ def main(args):
             args.once,
             qos_profile)
 
+
 def handle_incompatible_qos_event(event):
     incompatible_qos_name = qos_policy_name_from_kind(event.last_policy_kind)
     print(f'Incompatible QoS Policy detected: {incompatible_qos_name}')
+
 
 def publisher(
     node: Node,

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -20,6 +20,8 @@ import rclpy
 from rclpy.node import Node
 from rclpy.qos import qos_policy_name_from_kind
 from rclpy.qos import QoSProfile
+from rclpy.qos_event import PublisherEventCallbacks
+from rclpy.qos_event import UnsupportedEventTypeError
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments_to_argument_parser
 from ros2topic.api import qos_profile_from_short_keys
@@ -30,7 +32,6 @@ from ros2topic.verb import VerbExtension
 from rosidl_runtime_py import set_message_fields
 from rosidl_runtime_py.utilities import get_message
 import yaml
-from rclpy.qos_event import PublisherEventCallbacks
 
 MsgType = TypeVar('MsgType')
 
@@ -94,7 +95,7 @@ def main(args):
 
 def handle_incompatible_qos_event(event):
     incompatible_qos_name = qos_policy_name_from_kind(event.last_policy_kind)
-    print('Incompatible QoS Policy detected: {name}'.format(name=incompatible_qos_name))
+    print(f'Incompatible QoS Policy detected: {incompatible_qos_name}')
 
 def publisher(
     node: Node,
@@ -113,11 +114,11 @@ def publisher(
         return 'The passed value needs to be a dictionary in YAML format'
 
     publisher_callbacks = PublisherEventCallbacks(
-        incompatible_qos=lambda event: handle_incompatible_qos_event(event))
+        incompatible_qos=handle_incompatible_qos_event)
     try:
         pub = node.create_publisher(
             msg_module, topic_name, qos_profile, event_callbacks=publisher_callbacks)
-    except UnsupportedEventTypeException:
+    except UnsupportedEventTypeError:
         pub = node.create_publisher(msg_module, topic_name, qos_profile)
 
     msg = msg_module()


### PR DESCRIPTION
**_Depends on [ros2/rclpy:459](https://github.com/ros2/rclpy/pull/459)_**

Related to the feature discussed [here](https://github.com/ros2/ros2/issues/822). This PR handles the `ON_REQUESTED_INCOMPATIBLE_QOS` and `ON_OFFERED_INCOMPATIBLE_QOS` callback events on `ros2 topic echo` and `ros2 topic pub` commands respectively. 

This way, users now will get a warning when they `echo/pub` to a topic with incompatible QoS Policies.

Signed-off-by: Jaison Titus <jaisontj92@gmail.com>