### PR TITLE
partially revert [dashing backport] add service clients to ros2node info

### DIFF
--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -72,26 +72,8 @@ def get_publisher_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_publisher_names_and_types_by_node)
 
 
-# for backward compatibility only
 def get_service_info(*, node, remote_node_name):
-    return get_service_server_info(
-        node=node, remote_node_name=remote_node_name)
-
-
-def get_service_client_info(*, node, remote_node_name, include_hidden=False):
-    return get_topics(
-        remote_node_name,
-        node.get_client_names_and_types_by_node,
-        include_hidden_topics=include_hidden
-    )
-
-
-def get_service_server_info(*, node, remote_node_name, include_hidden=False):
-    return get_topics(
-        remote_node_name,
-        node.get_service_names_and_types_by_node,
-        include_hidden_topics=include_hidden
-    )
+    return get_topics(remote_node_name, node.get_service_names_and_types_by_node)
 
 
 class NodeNameCompleter:

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -72,7 +72,13 @@ def get_publisher_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_publisher_names_and_types_by_node)
 
 
+# for backward compatibility only
 def get_service_info(*, node, remote_node_name):
+    return get_service_server_info(
+        node=node, remote_node_name=remote_node_name)
+
+
+def get_service_server_info(*, node, remote_node_name):
     return get_topics(remote_node_name, node.get_service_names_and_types_by_node)
 
 

--- a/ros2node/ros2node/verb/info.py
+++ b/ros2node/ros2node/verb/info.py
@@ -17,8 +17,7 @@ from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2node.api import get_node_names
 from ros2node.api import get_publisher_info
-from ros2node.api import get_service_client_info
-from ros2node.api import get_service_server_info
+from ros2node.api import get_service_info
 from ros2node.api import get_subscriber_info
 from ros2node.api import NodeNameCompleter
 from ros2node.verb import VerbExtension
@@ -50,13 +49,8 @@ class InfoVerb(VerbExtension):
                 publishers = get_publisher_info(node=node, remote_node_name=args.node_name)
                 print('  Publishers:')
                 print_names_and_types(publishers)
-                service_servers = get_service_server_info(
-                    node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
-                print('  Service Servers:')
-                print_names_and_types(service_servers)
-                service_clients = get_service_client_info(
-                    node=node, remote_node_name=args.node_name, include_hidden=args.include_hidden)
-                print('  Service Clients:')
-                print_names_and_types(service_clients)
+                services = get_service_info(node=node, remote_node_name=args.node_name)
+                print('  Services:')
+                print_names_and_types(services)
         else:
             return "Unable to find node '" + args.node_name + "'"


### PR DESCRIPTION
Fixes #417 by reverting #409 and only adding the API for cross-distro compatibility.

The other parts (fetching client information as well as the hidden topic option require other changes which are not available in Dashing).