### PR TITLE
Extend CLI daemon based features

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -69,6 +69,14 @@ def main(*, script_name='_ros2_daemon', argv=None):
                 _print_invoked_function_name(node.get_topic_names_and_types))
             server.register_function(
                 _print_invoked_function_name(node.get_service_names_and_types))
+            server.register_function(
+                _print_invoked_function_name(node.get_publisher_names_and_types_by_node))
+            server.register_function(
+                _print_invoked_function_name(node.get_subscriber_names_and_types_by_node))
+            server.register_function(
+                _print_invoked_function_name(node.get_service_names_and_types_by_node))
+            server.register_function(
+                _print_invoked_function_name(node.get_client_names_and_types_by_node))
 
             shutdown = False
 
@@ -173,11 +181,16 @@ class RequestHandler(SimpleXMLRPCRequestHandler):
 
 
 def _print_invoked_function_name(func):
-    def wrapper():
-        nonlocal func
-        print('{func.__name__}()'.format_map(locals()))
-        return func()
-    wrapper.__name__ = func.__name__
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        name = func.__name__
+        arguments = ', '.join(
+            [f'{v!r}' for v in args] +
+            [f'{k}={v!r}' for k, v in kwargs.items()]
+        )
+        print(f'{name}({arguments})')
+        return func(*args, **kwargs)
+    wrapper.__signature__ = inspect.signature(func)
     return wrapper
 
 

--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -77,6 +77,10 @@ def main(*, script_name='_ros2_daemon', argv=None):
                 _print_invoked_function_name(node.get_service_names_and_types_by_node))
             server.register_function(
                 _print_invoked_function_name(node.get_client_names_and_types_by_node))
+            server.register_function(
+                _print_invoked_function_name(node.count_publishers))
+            server.register_function(
+                _print_invoked_function_name(node.count_subscribers))
 
             shutdown = False
 

--- a/ros2cli/ros2cli/node/strategy.py
+++ b/ros2cli/ros2cli/node/strategy.py
@@ -23,10 +23,12 @@ from ros2cli.node.direct import DirectNode
 class NodeStrategy:
 
     def __init__(self, args):
-        if is_daemon_running(args):
+        use_daemon = not getattr(args, 'no_daemon', False)
+        if use_daemon and is_daemon_running(args):
             self.node = DaemonNode(args)
         else:
-            spawn_daemon(args)
+            if use_daemon:
+                spawn_daemon(args)
             self.node = DirectNode(args)
 
     def __enter__(self):
@@ -43,3 +45,7 @@ class NodeStrategy:
 def add_arguments(parser):
     add_daemon_node_arguments(parser)
     add_direct_node_arguments(parser)
+    parser.add_argument(
+        '--no-daemon', action='store_true', default=False,
+        help='Do not spawn nor use an already running daemon'
+    )

--- a/ros2cli/ros2cli/node/strategy.py
+++ b/ros2cli/ros2cli/node/strategy.py
@@ -46,6 +46,6 @@ def add_arguments(parser):
     add_daemon_node_arguments(parser)
     add_direct_node_arguments(parser)
     parser.add_argument(
-        '--no-daemon', action='store_true', default=False,
+        '--no-daemon', action='store_true',
         help='Do not spawn nor use an already running daemon'
     )


### PR DESCRIPTION
Connected to #419. This pull request:

- Augments daemon support for the ROS graph API. 
- Adds a `--no-daemon` option for `NodeStrategy` client code to use and allow users to NOT use nor spawn a daemon.