### PR TITLE
Able to show info of hidden topic.

### DIFF
--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -30,7 +30,8 @@ class InfoVerb(VerbExtension):
 
     def main(self, *, args):
         with DirectNode(args) as node:
-            topic_names_and_types = get_topic_names_and_types(node=node)
+            topic_names_and_types = get_topic_names_and_types(
+                node=node, include_hidden_topics=True)
             topic_name = args.topic_name
             for (t_name, t_types) in topic_names_and_types:
                 if t_name == topic_name:


### PR DESCRIPTION
According #411, support show hidden topic info with `ros2 topic info <hidden topic>`
However, I'm not sure whether it's fine to show hidden topic directly or it's necessary to add extra option, like `--include-hidden-topics`.