### PR TITLE
Depend on `net-tools`

### DIFF
--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-ifcfg</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
+  <exec_depend>net-tools</exec_depend>
   
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -10,10 +10,10 @@
   <depend>ros2cli</depend>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>net-tools</exec_depend>
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-ifcfg</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
-  <exec_depend>net-tools</exec_depend>
   
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
`net-tools` (or `iproute2`) is an implicit dependency of `python3-ifcfg`, which can work with either `ip` (from `iproute2`) or `ifconfig` (from `net-tools`)

`net-tools` is a smaller dependency in terms of bytes installed and did not install recursive dependencies on the `ros:eloquent` docker image, but `ip` is more modern. If that is preferred, it's an easy change here as both packages are already in rosdep. 

Fixes https://github.com/ros2/ros2cli/issues/425