### PR TITLE
fix create_pkg dependencies for python

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -114,9 +114,12 @@ class CreateVerb(VerbExtension):
                 print('[WARNING] node name can not be equal to the library name', file=sys.stderr)
                 print('[WARNING] renaming node to %s' % node_name, file=sys.stderr)
 
-        buildtool_depends = args.build_type
-        if args.build_type == 'ament_cmake' and args.library_name:
-            buildtool_depends = 'ament_cmake_ros'
+        buildtool_depends = []
+        if args.build_type == 'ament_cmake':
+            if args.library_name:
+                buildtool_depends = ['ament_cmake_ros']
+            else:
+                buildtool_depends = ['ament_cmake']
 
         test_dependencies = []
         if args.build_type == 'ament_cmake':
@@ -139,7 +142,7 @@ class CreateVerb(VerbExtension):
             description=args.description,
             maintainers=[maintainer],
             licenses=[args.license],
-            buildtool_depends=[Dependency(buildtool_depends)],
+            buildtool_depends=[Dependency(dep) for dep in buildtool_depends],
             build_depends=[Dependency(dep) for dep in args.dependencies],
             test_depends=[Dependency(dep) for dep in test_dependencies],
             exports=[Export('build_type', content=args.build_type)]


### PR DESCRIPTION
There's no ament_python package to depend on, it just uses setuptools directly. 

Also fix syntax for cmake type.

This will cause a rosdep error after following: https://index.ros.org/doc/ros2/Tutorials/Creating-A-ROS2-Package/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8957)](http://ci.ros2.org/job/ci_linux/8957/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4727)](http://ci.ros2.org/job/ci_linux-aarch64/4727/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7329)](http://ci.ros2.org/job/ci_osx/7329/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8874)](http://ci.ros2.org/job/ci_windows/8874/)