### PR TITLE
add build-type extension-point for the ros2 pkg create verb #427

### DIFF
--- a/ros2pkg/ros2pkg/api/create.py
+++ b/ros2pkg/ros2pkg/api/create.py
@@ -27,6 +27,7 @@ def _expand_template(template_file, data, output_file):
         options={
             em.BUFFERED_OPT: True,
             em.RAW_OPT: True,
+            em.BANGPATH_OPT: True,
         },
         globals=data,
     )

--- a/ros2pkg/ros2pkg/build_type/__init__.py
+++ b/ros2pkg/ros2pkg/build_type/__init__.py
@@ -1,0 +1,66 @@
+# Copyright 2020 Wayne Parrott
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2cli.entry_points import load_entry_points
+from ros2cli.plugin_system import instantiate_extensions
+from ros2cli.plugin_system import PLUGIN_SYSTEM_VERSION
+from ros2cli.plugin_system import satisfies_version
+
+
+class BuildTypeExtension:
+    """
+    The interface for verb extensions.
+
+    The following properties must be defined:
+    * `NAME` (will be set to the entry point name)
+
+    The following methods must be defined:
+    * `main`
+    """
+
+    NAME = None
+    EXTENSION_POINT_VERSION = '0.1'
+    EXTENSION_POINT_NAME = 'ros2pkg.build_type'
+    NATIVE_BUILD_TYPES = ['cmake', 'ament_cmake', 'ament_python']
+
+    def __init__(self):
+        super(BuildTypeExtension, self).__init__()
+        satisfies_version(PLUGIN_SYSTEM_VERSION, '^0.1')
+
+    def populate(self, package, package_directory, node_name, library_name):
+        pass
+
+
+def get_build_types():
+    build_types = BuildTypeExtension.NATIVE_BUILD_TYPES.copy()
+    extension_pts = load_entry_points(BuildTypeExtension.EXTENSION_POINT_NAME)
+    for name, extension_pt in extension_pts.items():
+      build_types.append(name)
+    #build_types.sort()
+    return build_types
+
+def is_extended_build_type(name):
+    extension_pts = load_entry_points(BuildTypeExtension.EXTENSION_POINT_NAME)
+    return extension_pts.get(name) != None
+
+def get_build_type_extensions():
+    extensions = instantiate_extensions(BuildTypeExtension.EXTENSION_POINT_NAME)
+    for name, extension in extensions.items():
+        extension.NAME = name
+    return extensions
+
+def get_build_type_extension(name):
+    extensions = get_build_type_extensions()
+    return extensions.get(name)
+

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -32,9 +32,9 @@ from ros2pkg.api.create import populate_cpp_node
 from ros2pkg.api.create import populate_python_libary
 from ros2pkg.api.create import populate_python_node
 
-from ros2pkg.build_type import get_build_types
 from ros2pkg.build_type import get_build_type_extension
-from ros2pkg.build_type import is_extended_build_type
+from ros2pkg.build_type import get_build_type_names
+from ros2pkg.build_type import has_build_type_extension
 
 from ros2pkg.verb import VerbExtension
 
@@ -68,7 +68,7 @@ class CreateVerb(VerbExtension):
         parser.add_argument(
             '--build-type',
             default='ament_cmake',
-            choices=get_build_types(),
+            choices=get_build_type_names(),
             help='The build type to process the package with')
         parser.add_argument(
             '--dependencies',
@@ -175,7 +175,7 @@ class CreateVerb(VerbExtension):
             return 'unable to create folder: ' + args.destination_directory
 
         # delegate to build_type extension
-        if is_extended_build_type(package.get_build_type()):
+        if has_build_type_extension(package.get_build_type()):
             extension = get_build_type_extension(package.get_build_type())
             extension.populate(package, package_directory, source_directory, node_name)
             return

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -32,6 +32,10 @@ from ros2pkg.api.create import populate_cpp_node
 from ros2pkg.api.create import populate_python_libary
 from ros2pkg.api.create import populate_python_node
 
+from ros2pkg.build_type import get_build_types
+from ros2pkg.build_type import get_build_type_extension
+from ros2pkg.build_type import is_extended_build_type
+
 from ros2pkg.verb import VerbExtension
 
 
@@ -64,7 +68,7 @@ class CreateVerb(VerbExtension):
         parser.add_argument(
             '--build-type',
             default='ament_cmake',
-            choices=['cmake', 'ament_cmake', 'ament_python'],
+            choices=get_build_types(),
             help='The build type to process the package with')
         parser.add_argument(
             '--dependencies',
@@ -169,6 +173,12 @@ class CreateVerb(VerbExtension):
             create_package_environment(package, args.destination_directory)
         if not package_directory:
             return 'unable to create folder: ' + args.destination_directory
+
+        # delegate to build_type extension
+        if is_extended_build_type(package.get_build_type()):
+            extension = get_build_type_extension(package.get_build_type())
+            extension.populate(package, package_directory, source_directory, node_name)
+            return
 
         if args.build_type == 'cmake':
             populate_cmake(package, package_directory, node_name, library_name)

--- a/ros2pkg/setup.py
+++ b/ros2pkg/setup.py
@@ -38,6 +38,7 @@ The package provides the pkg command for the ROS 2 command line tools.""",
         ],
         'ros2cli.extension_point': [
             'ros2pkg.verb = ros2pkg.verb:VerbExtension',
+            'ros2pkg.build_type = ros2pkg.build_type:BuildTypeExtension',
         ],
         'ros2pkg.verb': [
             'create = ros2pkg.verb.create:CreateVerb',
@@ -45,9 +46,6 @@ The package provides the pkg command for the ROS 2 command line tools.""",
             'list = ros2pkg.verb.list:ListVerb',
             'prefix = ros2pkg.verb.prefix:PrefixVerb',
             'xml = ros2pkg.verb.xml:XmlVerb',
-        ],
-        'ros2cli.extension_point': [
-            'ros2pkg.build_type = ros2pkg.build_type:BuildTypeExtension',
         ],
     },
     package_data={

--- a/ros2pkg/setup.py
+++ b/ros2pkg/setup.py
@@ -46,6 +46,9 @@ The package provides the pkg command for the ROS 2 command line tools.""",
             'prefix = ros2pkg.verb.prefix:PrefixVerb',
             'xml = ros2pkg.verb.xml:XmlVerb',
         ],
+        'ros2cli.extension_point': [
+            'ros2pkg.build_type = ros2pkg.build_type:BuildTypeExtension',
+        ],
     },
     package_data={
         'ros2pkg': [


### PR DESCRIPTION
This PR introduces the new extension-point **ros2pkg.build_type** for contributing custom build-types to ros2, see #427. 

A developer would implement a custom build-type extension as follows:

In his python package's setup.py include:

```
entry_points={
        'ros2pkg.build_type': [
            'foobar = myproject.build_type.foobar:FooBarBuildType',
        ],
}
```

In his build-type package implement:
```
from ros2pkg.build_type import BuildTypeExtension
class FooBarBuildType(BuildTypeExtension):

    def __init__(self):
        super(FooBarBuildType, self).__init__()

    def populate(self, package, package_directory, node_name, library_name):
       #custom build stuff here
```

Note: I did not include tests (yet) as I will need guidance on how one should go about testing an extension point.

