### PR TITLE
Multimachine communication

### DIFF
--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -20,6 +20,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>ros_testing</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -19,6 +19,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-ifcfg</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ros2cli.command import add_subparsers_on_demand
 from ros2cli.command import CommandExtension
 from ros2doctor.api import generate_reports
 from ros2doctor.api import run_checks
@@ -35,9 +36,16 @@ class DoctorCommand(CommandExtension):
             '--include-warnings', '-iw', action='store_true',
             help='Include warnings as failed checks. Warnings are ignored by default.'
         )
+        # add arguments and sub-commands of verbs
+        add_subparsers_on_demand(
+            parser, cli_name, '_verb', 'ros2doctor.verb', required=False)
 
     def main(self, *, parser, args):
         """Run checks and print report to terminal based on user input args."""
+        if hasattr(args, '_verb'):
+            extension = getattr(args, '_verb')
+            return extension.main(args=args)
+
         # `ros2 doctor -r`
         if args.report:
             all_reports = generate_reports()

--- a/ros2doctor/ros2doctor/verb/__init__.py
+++ b/ros2doctor/ros2doctor/verb/__init__.py
@@ -1,0 +1,44 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2cli.plugin_system import instantiate_extensions
+from ros2cli.plugin_system import PLUGIN_SYSTEM_VERSION
+from ros2cli.plugin_system import satisfies_version
+
+
+class VerbExtension:
+    """
+    The extension point for 'doctor' verb extensions.
+
+    The following properties must be defined:
+    * `NAME` (will be set to the entry point name)
+    The following methods must be defined:
+    * `main`
+    The following methods can be defined:
+    * `add_arguments`
+    """
+
+    NAME = None
+    EXTENSION_POINT_VERSION = '0.1'
+
+    def __init__(self):
+        super(VerbExtension, self).__init__()
+        satisfies_version(PLUGIN_SYSTEM_VERSION, '^0.1')
+
+
+def get_verb_extensions(name):
+    extensions = instantiate_extensions(name)
+    for name, extension in extensions.items():
+        extension.NAME = name
+    return extensions

--- a/ros2doctor/ros2doctor/verb/__init__.py
+++ b/ros2doctor/ros2doctor/verb/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ros2cli.plugin_system import instantiate_extensions
 from ros2cli.plugin_system import PLUGIN_SYSTEM_VERSION
 from ros2cli.plugin_system import satisfies_version
 
@@ -23,8 +22,10 @@ class VerbExtension:
 
     The following properties must be defined:
     * `NAME` (will be set to the entry point name)
+
     The following methods must be defined:
     * `main`
+
     The following methods can be defined:
     * `add_arguments`
     """
@@ -36,9 +37,8 @@ class VerbExtension:
         super(VerbExtension, self).__init__()
         satisfies_version(PLUGIN_SYSTEM_VERSION, '^0.1')
 
+    def add_arguments(self, parser, cli_name):
+        pass
 
-def get_verb_extensions(name):
-    extensions = instantiate_extensions(name)
-    for name, extension in extensions.items():
-        extension.NAME = name
-    return extensions
+    def main(self, *, args):
+        raise NotImplementedError()

--- a/ros2doctor/ros2doctor/verb/call.py
+++ b/ros2doctor/ros2doctor/verb/call.py
@@ -249,10 +249,10 @@ class SummaryTable():
         """Increment subscribed msg count from different host(s)."""
         self.lock.acquire()
         try:
-            if hostname not in self.receive:
-                self.receive[hostname] = 1
+            if hostname not in self.sub:
+                self.sub[hostname] = 1
             else:
-                self.receive[hostname] += 1
+                self.sub[hostname] += 1
         finally:
             self.lock.release()
 
@@ -268,10 +268,10 @@ class SummaryTable():
         """Increment multicast-received msg count from different host(s)."""
         self.lock.acquire()
         try:
-            if hostname not in self.sub:
-                self.sub[hostname] = 1
+            if hostname not in self.receive:
+                self.receive[hostname] = 1
             else:
-                self.sub[hostname] += 1
+                self.receive[hostname] += 1
         finally:
             self.lock.release()
 

--- a/ros2doctor/ros2doctor/verb/call.py
+++ b/ros2doctor/ros2doctor/verb/call.py
@@ -1,0 +1,178 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+import struct
+import threading
+import time
+
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from ros2doctor.verb import VerbExtension
+
+from std_msgs.msg import String
+
+DEFAULT_GROUP = '225.0.0.1'
+DEFAULT_PORT = 49150
+DEFAULT_TOPIC = 'knockknock'
+summary_table = {}
+
+
+class CallVerb(VerbExtension):
+    """Publish and subscribe, multicast send and receive, print table."""
+
+    def main(self, *, args):
+        rclpy.init()
+        pub_node = Talker()
+        sub_node = Listener()
+
+        executor = MultiThreadedExecutor()
+        executor.add_node(pub_node)
+        executor.add_node(sub_node)
+        try:
+            count = 0
+            _spawn_summary_table()
+            while True:
+                if (count % 20 == 0 and count != 0):
+                    format_print(summary_table)
+                    _spawn_summary_table()
+                # pub/sub threads
+                executor.spin_once()
+                executor.spin_once()
+                # multicast threads
+                send_thread = threading.Thread(target=send, args=())
+                send_thread.daemon = True
+                receive_thread = threading.Thread(target=receive, args=())
+                receive_thread.daemon = True
+                receive_thread.start()
+                send_thread.start()
+                count += 1
+                time.sleep(0.1)
+        except KeyboardInterrupt:
+            executor.shutdown()
+            pub_node.destroy_node()
+            sub_node.destroy_node()
+
+
+class Talker(Node):
+    """Initialize talker node."""
+
+    def __init__(self):
+        super().__init__('talker')
+        self.i = 0
+        self.pub = self.create_publisher(String, DEFAULT_TOPIC, 10)
+        time_period = 0.1
+        self.timer = self.create_timer(time_period, self.timer_callback)
+
+    def timer_callback(self):
+        msg = String()
+        hostname = socket.gethostname()
+        # publish
+        msg.data = f'Publish hello from {hostname}'
+        summary_table['pub'] += 1
+        self.pub.publish(msg)
+        self.i += 1
+
+
+class Listener(Node):
+    """Initialize listener node."""
+
+    def __init__(self):
+        super().__init__('listener')
+        self.sub = self.create_subscription(String,
+                                            DEFAULT_TOPIC,
+                                            self.sub_callback,
+                                            10)
+
+    def sub_callback(self, msg):
+        # subscribe
+        msg_data = msg.data.split()
+        caller_hostname = msg_data[-1]
+        if caller_hostname != socket.gethostname():
+            if caller_hostname not in summary_table['sub']:
+                summary_table['sub'][caller_hostname] = 1
+            else:
+                summary_table['sub'][caller_hostname] += 1
+
+
+def send():
+    """Multicast send."""
+    hostname = socket.gethostname()
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    try:
+        summary_table['send'] += 1
+        s.sendto(f'Multicast hello from {hostname}'.encode('utf-8'), (DEFAULT_GROUP, DEFAULT_PORT))
+    finally:
+        s.close()
+
+
+def receive():
+    """Multicast receive."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    try:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except AttributeError:
+            # not available on Windows
+            pass
+        s.bind(('', DEFAULT_PORT))
+
+        s.settimeout(None)
+
+        mreq = struct.pack('4sl', socket.inet_aton(DEFAULT_GROUP), socket.INADDR_ANY)
+        s.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+        try:
+            data, _ = s.recvfrom(4096)
+            data = data.decode('utf-8')
+            sender_hostname = data.split()[-1]
+            if sender_hostname != socket.gethostname():
+                if sender_hostname not in summary_table['receive']:
+                    summary_table['receive'][sender_hostname] = 1
+                else:
+                    summary_table['receive'][sender_hostname] += 1
+        finally:
+            s.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP, mreq)
+    finally:
+        s.close()
+
+
+def _spawn_summary_table():
+    """Spawn summary table with new content after each print."""
+    summary_table['pub'] = 0
+    summary_table['sub'] = {}
+    summary_table['send'] = 0
+    summary_table['receive'] = {}
+
+
+def _format_print_helper(table):
+    """Format summary table."""
+    print('{:<15} {:<20} {:<10}'.format('', 'Hostname', 'Msg Count /2s'))
+    for name, count in table.items():
+        print('{:<15} {:<20} {:<10}'.format('', name, count))
+
+
+def format_print(summary_table):
+    """Print content in summary table."""
+    pub_count = summary_table['pub']
+    send_count = summary_table['send']
+    print('MULTIMACHINE COMMUNICATION SUMMARY')
+    print(f'Topic: {DEFAULT_TOPIC}, Published Msg Count: {pub_count}')
+    print('Subscribed from:')
+    _format_print_helper(summary_table['sub'])
+    print(f'Multicast Group/Port: {DEFAULT_GROUP}/{DEFAULT_PORT}, Sent Msg Count: {send_count}')
+    print('Received from:')
+    _format_print_helper(summary_table['receive'])
+    print('-'*60)

--- a/ros2doctor/ros2doctor/verb/call.py
+++ b/ros2doctor/ros2doctor/verb/call.py
@@ -94,6 +94,8 @@ class CallVerb(VerbExtension):
                 count += 1
                 time.sleep(0.1)
         except KeyboardInterrupt:
+            pass
+        finally:
             executor.shutdown()
             rclpy.shutdown()
             pub_node.destroy_node()

--- a/ros2doctor/ros2doctor/verb/call.py
+++ b/ros2doctor/ros2doctor/verb/call.py
@@ -31,7 +31,31 @@ summary_table = {}
 
 
 class CallVerb(VerbExtension):
-    """Publish and subscribe, multicast send and receive, print table."""
+    """
+    Check network connectivity between multiple hosts.
+
+    This command can be invoked on multiple hosts to confirm that they can talk to each other
+    by using talker/listener, multicast send/receive to check topic discovering and
+    UDP communication.
+    This command outputs a summary table of msgs statistics at a custom rate(Hz).
+    """
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            'topic_name', nargs='?', default='/canyouhearme',
+            help="Name of ROS topic to publish to (default: '/canyouhearme')")
+        parser.add_argument(
+            'time_period', nargs='?', default=0.1,
+            help='Time period to publish/send one message (default: 0.1s)')
+        parser.add_argument(
+            'duration', nargs='?', default=20, type=positive_int,
+            help='How long this process runs (default: 20s)')
+        parser.add_argument(
+            '-r', '--rate', metavar='N', type=float, default=1.0,
+            help='Rate in Hz to print summary table (default: 1.0)')
+        parser.add_argument(
+            '--ttl', type=positive_int,
+            help='TTL for multicast send (default: None)')
 
     def main(self, *, args):
         rclpy.init()

--- a/ros2doctor/ros2doctor/verb/call.py
+++ b/ros2doctor/ros2doctor/verb/call.py
@@ -49,13 +49,15 @@ class CallVerb(VerbExtension):
                     format_print(summary_table)
                     _spawn_summary_table()
                 # pub/sub threads
-                executor.spin_once()
-                executor.spin_once()
+                exec_thread = threading.Thread(target=executor.spin)
+                exec_thread.daemon=True
                 # multicast threads
                 send_thread = threading.Thread(target=send, args=())
                 send_thread.daemon = True
                 receive_thread = threading.Thread(target=receive, args=())
                 receive_thread.daemon = True
+
+                exec_thread.start()
                 receive_thread.start()
                 send_thread.start()
                 count += 1

--- a/ros2doctor/ros2doctor/verb/hello.py
+++ b/ros2doctor/ros2doctor/verb/hello.py
@@ -40,7 +40,7 @@ def positive_int(string: str) -> int:
     return value
 
 
-class CallVerb(VerbExtension):
+class HelloVerb(VerbExtension):
     """
     Check network connectivity between multiple hosts.
 

--- a/ros2doctor/ros2doctor/verb/hello.py
+++ b/ros2doctor/ros2doctor/verb/hello.py
@@ -47,7 +47,7 @@ class HelloVerb(VerbExtension):
     This command can be invoked on multiple hosts to confirm that they can talk to each other
     by using talker/listener, multicast send/receive to check topic discovering and
     UDP communication.
-    This command outputs a summary table of msgs statistics at a custom rate(Hz).
+    This command outputs a summary table of msgs statistics at a custom period(s).
     """
 
     def add_arguments(self, parser, cli_name):
@@ -55,7 +55,7 @@ class HelloVerb(VerbExtension):
             '-t', '--topic', nargs='?', default='/canyouhearme',
             help="Name of ROS topic to publish to (default: '/canyouhearme')")
         parser.add_argument(
-            '-rp', '--emit-period', metavar='N', type=float, default=0.1,
+            '-ep', '--emit-period', metavar='N', type=float, default=0.1,
             help='Time period to publish/send one message (default: 0.1s)')
         parser.add_argument(
             '-pp', '--print-period', metavar='N', type=float, default=1.0,

--- a/ros2doctor/ros2doctor/verb/hello.py
+++ b/ros2doctor/ros2doctor/verb/hello.py
@@ -52,17 +52,20 @@ class HelloVerb(VerbExtension):
 
     def add_arguments(self, parser, cli_name):
         parser.add_argument(
-            '--topic', nargs='?', default='/canyouhearme',
+            '-t', '--topic', nargs='?', default='/canyouhearme',
             help="Name of ROS topic to publish to (default: '/canyouhearme')")
         parser.add_argument(
-            '--emit-period', metavar='N', type=float, default=0.1,
+            '-rp', '--emit-period', metavar='N', type=float, default=0.1,
             help='Time period to publish/send one message (default: 0.1s)')
         parser.add_argument(
-            '--print-period', metavar='N', type=float, default=1.0,
+            '-pp', '--print-period', metavar='N', type=float, default=1.0,
             help='Time period to print summary table (default: 1.0s)')
         parser.add_argument(
             '--ttl', type=positive_int,
             help='TTL for multicast send (default: None)')
+        parser.add_argument(
+            '-1', '--once', action='store_true', default=False,
+            help='Publish and multicast send for one emit period then exit; used in test case.')
 
     def main(self, *, args):
         global summary_table
@@ -91,6 +94,8 @@ class HelloVerb(VerbExtension):
                 receive_thread.start()
                 send_thread.start()
                 time.sleep(args.emit_period)
+                if args.once:
+                    return summary_table
         except KeyboardInterrupt:
             pass
         finally:

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -51,5 +51,8 @@ setup(
             'TopicReport = ros2doctor.api.topic:TopicReport',
             'PackageReport = ros2doctor.api.package:PackageReport',
         ],
+        'ros2doctor.verb': [
+            'call = ros2doctor.verb.call:CallVerb'
+        ]
     }
 )

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -52,7 +52,7 @@ setup(
             'PackageReport = ros2doctor.api.package:PackageReport',
         ],
         'ros2doctor.verb': [
-            'call = ros2doctor.verb.call:CallVerb'
+            'hello = ros2doctor.verb.hello:HelloVerb'
         ]
     }
 )

--- a/ros2doctor/test/test_hello.py
+++ b/ros2doctor/test/test_hello.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 from argparse import Namespace
-from contextlib import redirect_stderr
-from io import StringIO
 
 from ros2doctor.verb.hello import HelloVerb
 from ros2doctor.verb.hello import SummaryTable
@@ -37,12 +35,10 @@ def test_hello_single_host():
     args.print_period = 1.0
     args.ttl = None
     args.once = True
-    s = StringIO()
-    with redirect_stderr(s):
-        hello_verb = HelloVerb()
-        summary = hello_verb.main(args=args)
-        expected_summary = _generate_expected_summary_table()
-        assert summary._pub == expected_summary._pub
-        assert summary._sub == expected_summary._sub
-        assert summary._send == expected_summary._send
-        assert summary._receive == expected_summary._receive
+    hello_verb = HelloVerb()
+    summary = hello_verb.main(args=args)
+    expected_summary = _generate_expected_summary_table()
+    assert summary._pub == expected_summary._pub
+    assert summary._sub == expected_summary._sub
+    assert summary._send == expected_summary._send
+    assert summary._receive == expected_summary._receive

--- a/ros2doctor/test/test_hello.py
+++ b/ros2doctor/test/test_hello.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import Namespace
+from contextlib import redirect_stderr
+from io import StringIO
+
+from ros2doctor.verb.hello import HelloVerb
+from ros2doctor.verb.hello import SummaryTable
+
+
+def _generate_expected_summary_table():
+    """Generate expected summary table for one emit period on a single host."""
+    expected_summary = SummaryTable()
+    # 1 pub/send per default emit period
+    expected_summary.increment_pub()
+    expected_summary.increment_send()
+    return expected_summary
+
+
+def test_hello_single_host():
+    """Run HelloVerb for one emit period on a single host."""
+    args = Namespace()
+    args.topic = '/canyouhearme'
+    args.emit_period = 0.1
+    args.print_period = 1.0
+    args.ttl = None
+    args.once = True
+    s = StringIO()
+    with redirect_stderr(s):
+        hello_verb = HelloVerb()
+        summary = hello_verb.main(args=args)
+        expected_summary = _generate_expected_summary_table()
+        assert summary._pub == expected_summary._pub
+        assert summary._sub == expected_summary._sub
+        assert summary._send == expected_summary._send
+        assert summary._receive == expected_summary._receive

--- a/ros2doctor/test/test_hello.py
+++ b/ros2doctor/test/test_hello.py
@@ -16,8 +16,8 @@ from argparse import Namespace
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
+import launch_testing.actions
 import launch_testing.markers
 
 import pytest
@@ -28,7 +28,7 @@ from ros2doctor.verb.hello import SummaryTable
 
 @pytest.mark.rostest
 @launch_testing.markers.keep_alive
-def generate_test_description(ready_fn):
+def generate_test_description():
     return LaunchDescription([
         # Always restart daemon to isolate tests.
         ExecuteProcess(
@@ -39,7 +39,7 @@ def generate_test_description(ready_fn):
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',
                     on_exit=[
-                        OpaqueFunction(function=lambda context: ready_fn())
+                        launch_testing.actions.ReadyToTest()
                     ]
                 )
             ]

--- a/ros2doctor/test/test_hello.py
+++ b/ros2doctor/test/test_hello.py
@@ -14,8 +14,37 @@
 
 from argparse import Namespace
 
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import OpaqueFunction
+
+import launch_testing.markers
+
+import pytest
+
 from ros2doctor.verb.hello import HelloVerb
 from ros2doctor.verb.hello import SummaryTable
+
+
+@pytest.mark.rostest
+@launch_testing.markers.keep_alive
+def generate_test_description(ready_fn):
+    return LaunchDescription([
+        # Always restart daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                ExecuteProcess(
+                    cmd=['ros2', 'daemon', 'start'],
+                    name='daemon-start',
+                    on_exit=[
+                        OpaqueFunction(function=lambda context: ready_fn())
+                    ]
+                )
+            ]
+        )
+    ])
 
 
 def _generate_expected_summary_table():

--- a/ros2doctor/test/test_topic.py
+++ b/ros2doctor/test/test_topic.py
@@ -12,9 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import OpaqueFunction
+
+import launch_testing.markers
+
+import pytest
+
 from ros2doctor.api import Report
 from ros2doctor.api.topic import TopicCheck
 from ros2doctor.api.topic import TopicReport
+
+
+@pytest.mark.rostest
+@launch_testing.markers.keep_alive
+def generate_test_description(ready_fn):
+    return LaunchDescription([
+        # Always restart daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                ExecuteProcess(
+                    cmd=['ros2', 'daemon', 'start'],
+                    name='daemon-start',
+                    on_exit=[
+                        OpaqueFunction(function=lambda context: ready_fn())
+                    ]
+                )
+            ]
+        )
+    ])
 
 
 def test_topic_check():

--- a/ros2doctor/test/test_topic.py
+++ b/ros2doctor/test/test_topic.py
@@ -14,8 +14,8 @@
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
+import launch_testing.actions
 import launch_testing.markers
 
 import pytest
@@ -27,7 +27,7 @@ from ros2doctor.api.topic import TopicReport
 
 @pytest.mark.rostest
 @launch_testing.markers.keep_alive
-def generate_test_description(ready_fn):
+def generate_test_description():
     return LaunchDescription([
         # Always restart daemon to isolate tests.
         ExecuteProcess(
@@ -38,7 +38,7 @@ def generate_test_description(ready_fn):
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',
                     on_exit=[
-                        OpaqueFunction(function=lambda context: ready_fn())
+                        launch_testing.actions.ReadyToTest()
                     ]
                 )
             ]


### PR DESCRIPTION
> How about a verb called “yell” (or something more clever), where the program just spins and sends “hello-world” and it’s hostname once per second, over both a hard-coded ROS2/DDS topic and a “custom” multicast UDP packet as well. At the same time, it is listening for other messages on that same ROS2 topic and/or UDP multicast port and printing a summary table periodically of which other hosts it has heard from, message counts, and so on. This would help debug the current #1 problem we are seeing, where people have messaging working on localhost but can’t receive those messages on another host. This spins into a debug cycle of trying to figure out if the problem lies with their software, their network configuration, DDS discovery or transport bugs, the network infrastructure, and so on. Currently we debug this using known-good ros2 nodes such as examples_rclpy_minimal_* , wireshark, ping, ros2multicast, ros2node, and so on, but having a nicer way to do it would be great. 

Run `ros2 doctor call` command to test pub/sub, multicast send/receive quality across multiple machines. The command outputs a summary table /1s. 
```bash
MULTIMACHINE COMMUNICATION SUMMARY
Topic: knockknock, Published Msg Count: 20
Subscribed from:
                Hostname             Msg Count /2s
Multicast Group/Port: 225.0.0.1/49150, Sent Msg Count: 20
Received from:
                Hostname             Msg Count /2s
                Claires-MBP          3         
------------------------------------------------------------

```
Test cases will be submitted in a separate PR. 