### PR TITLE
Avoid passing None to rclpy.init

### DIFF
--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -29,7 +29,9 @@ class DirectNode:
             nonlocal timeout_reached
             timeout_reached = True
 
-        rclpy.init()
+        argv = getattr(args, 'argv', [])
+
+        rclpy.init(args=argv)
 
         node_name_suffix = getattr(
             args, 'node_name_suffix', '_%d' % os.getpid())


### PR DESCRIPTION
Otherwise, all CLI arguments will be parsed as ROS arguments, which can lead
to rcl warnings or incorrect legacy remapping behavior.

This change does not pass arguments to rclpy.init from any of the CLI
tools, but it leaves the opportunity to do so in the future by setting the
parser argument 'argv'. For example, we could take the remaining arguments
and pass them to rclpy.init, similar to what is done in ros2run:

https://github.com/ros2/ros2cli/blob/4c5d9327026ecb2ea10a16b3429908b4f6f64ca6/ros2run/ros2run/command/run.py#L51-L53

Fixes #336.

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9150)](https://ci.ros2.org/job/ci_linux/9150/) (test failure [occurring on nightly](https://ci.ros2.org/view/nightly/job/nightly_linux_release/1426/testReport/junit/ros2action.test/test_cli/test_cli/))
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4777)](http://ci.ros2.org/job/ci_linux-aarch64/4777/)
* macOS [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7473)](https://ci.ros2.org/job/ci_osx/7473/) (test failures [occurring on nightly](https://ci.ros2.org/view/nightly/job/nightly_osx_debug/1507/testReport/junit/ros2node.test/test_cli/test_cli/))
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9075)](https://ci.ros2.org/job/ci_windows/9075/)