### PR TITLE
Request for backport of 428 to eloquent

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -114,9 +114,12 @@ class CreateVerb(VerbExtension):
                 print('[WARNING] node name can not be equal to the library name', file=sys.stderr)
                 print('[WARNING] renaming node to %s' % node_name, file=sys.stderr)
 
-        buildtool_depends = args.build_type
-        if args.build_type == 'ament_cmake' and args.library_name:
-            buildtool_depends = 'ament_cmake_ros'
+        buildtool_depends = []
+        if args.build_type == 'ament_cmake':
+            if args.library_name:
+                buildtool_depends = ['ament_cmake_ros']
+            else:
+                buildtool_depends = ['ament_cmake']
 
         test_dependencies = []
         if args.build_type == 'ament_cmake':
@@ -139,7 +142,7 @@ class CreateVerb(VerbExtension):
             description=args.description,
             maintainers=[maintainer],
             licenses=[args.license],
-            buildtool_depends=[Dependency(buildtool_depends)],
+            buildtool_depends=[Dependency(dep) for dep in buildtool_depends],
             build_depends=[Dependency(dep) for dep in args.dependencies],
             test_depends=[Dependency(dep) for dep in test_dependencies],
             exports=[Export('build_type', content=args.build_type)]


### PR DESCRIPTION
Currently the generated packages fail to pass rosdep making them hard to reuse.
Ideally this would be backported and released in Dashing as well.

Note: The tutorials refering to this invalid builtool dependency explicitly would need to be updated. That'll make them valid when used with the nightly archives as well that don't list that dependency.