### PR TITLE
fix ros2param tests

### DIFF
--- a/ros2param/ros2param/command/param.py
+++ b/ros2param/ros2param/command/param.py
@@ -19,12 +19,13 @@ from ros2cli.command import CommandExtension
 class ParamCommand(CommandExtension):
     """Various param related sub-commands."""
 
-    def add_arguments(self, parser, cli_name):
+    def add_arguments(self, parser, cli_name, *, argv=None):
         self._subparser = parser
 
         # add arguments and sub-commands of verbs
         add_subparsers_on_demand(
-            parser, cli_name, '_verb', 'ros2param.verb', required=False)
+            parser, cli_name, '_verb', 'ros2param.verb', required=False,
+            argv=argv)
 
     def main(self, *, parser, args):
         if not hasattr(args, '_verb'):


### PR DESCRIPTION
Fixes #440 which was a regression of #436.

Same fix as ros2/sros2#175.

CI build only testing `ros2param`: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9139)](https://ci.ros2.org/job/ci_linux/9139/)