### PR TITLE
Added build-type extension #427

### DIFF
--- a/ros2pkg/ros2pkg/package_type/__init__.py
+++ b/ros2pkg/ros2pkg/package_type/__init__.py
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2cli.entry_points import get_entry_points
+from ros2cli.plugin_system import instantiate_extensions
+from ros2cli.plugin_system import PLUGIN_SYSTEM_VERSION
+from ros2cli.plugin_system import satisfies_version
+
+
+class PackageTypeExtension():
+    """
+    The interface for package-type extensions.
+
+    The following properties must be defined:
+    * `NAME` (will be set to the entry point name)
+
+    The following methods must be defined:
+    * create_package
+    """
+
+    NAME = None
+    EXTENSION_POINT_NAME = 'ros2pkg.package_type'
+    EXTENSION_POINT_VERSION = '0.1'
+    NATIVE_PACKAGE_TYPES = ['ament_cmake', 'ament_python', 'cmake']
+
+    def __init__(self):
+        super(PackageTypeExtension, self).__init__()
+        satisfies_version(PLUGIN_SYSTEM_VERSION, '^0.1')
+
+    def add_arguments(self, parser, cli_name):
+        pass
+
+    def create_package(self, args):
+        """
+        Create the ROS 2 package directory structure and content.
+
+        :raises PackageCreationError: on any any internal error
+        """
+        raise NotImplementedError
+
+
+def get_package_type_names():
+    """
+    Get the names of the combined NATIVE_PACKAGE_TYPES and the package-type extensions.
+
+    :return: Sorted list of package-type string names.
+    """
+    names = set(PackageTypeExtension.NATIVE_PACKAGE_TYPES)
+    names.update(get_entry_points(PackageTypeExtension.EXTENSION_POINT_NAME).keys())
+    names.sort()
+    return names
+
+
+def get_package_type_extensions():
+    """
+    Get all package-type extensions.
+
+    :return: List of PackageTypeExtension subclasses.
+    """
+    extensions = instantiate_extensions(PackageTypeExtension.EXTENSION_POINT_NAME)
+    for name, extension in extensions.items():
+        extension.NAME = name
+    return extensions
+
+
+def get_package_type_extension(name):
+    """
+    Get the package-type extension with name.
+
+    :param name: The name of the package-type extension to search.
+    :return: The package-type extension.
+    """
+    extensions = get_package_type_extensions()
+    return extensions.get(name)

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -32,6 +32,9 @@ from ros2pkg.api.create import populate_cpp_node
 from ros2pkg.api.create import populate_python_libary
 from ros2pkg.api.create import populate_python_node
 
+from ros2pkg.package_type import get_package_type_extension
+from ros2pkg.package_type import get_package_type_names
+
 from ros2pkg.verb import VerbExtension
 
 
@@ -64,7 +67,7 @@ class CreateVerb(VerbExtension):
         parser.add_argument(
             '--build-type',
             default='ament_cmake',
-            choices=['cmake', 'ament_cmake', 'ament_python'],
+            choices=get_package_type_names(),
             help='The build type to process the package with')
         parser.add_argument(
             '--dependencies',
@@ -85,8 +88,12 @@ class CreateVerb(VerbExtension):
             help='name of the empty library')
 
     def main(self, *, args):
-        maintainer = Person(args.maintainer_name)
+        # when a package-type extension exists, delegate package creation to it.
+        extension = get_package_type_extension(args.build_type)
+        if extension:
+            return extension.create_package(args)
 
+        maintainer = Person(args.maintainer_name)
         if args.maintainer_email:
             maintainer.email = args.maintainer_email
         else:


### PR DESCRIPTION
This PR replaces a previous submission that I closed due to some key changes that I identified after submitting. 

In Eloquent and earlier ROS2 releases build-types were hard-coded in ros2pkg. Thus it was not possible to introduce additional build-types due to the closed nature of the implementation. This PR introduces a build-type extension (entry-point) and creates 1st class build-type extensions for ament_cmake, ament_python and cmake. The build-type extension point, if approved, will prove a valuable enhancement for projects such as rclnodejs which plans to introduce a nodejs build-type.

Here's a quick look at the ros2pkg entry-points:
```python
'ros2cli.extension_point': [
            'ros2pkg.build_type = ros2pkg.build_type:BuildTypeExtension',
        ],
        'ros2pkg.build_type': [
            'ament_python = ros2pkg.build_type.ament_python:AmentPythonBuildType',
            'ament_cmake = ros2pkg.build_type.ament_cmake:AmentCMakeBuildType',
            'cmake = ros2pkg.build_type.cmake:CMakeBuildType',
        ],
```
The `ros2pkg.build_type:BuildTypeExtension` class defines the simple interface required of all build-type extensions. Additionally `ros2pkg.api.build_type:BaseBuildType` is an abstract class that provides a common implementation for subclasses to extend as required.

List of Changes:
* Added ros2pkg.build_type entry-point
* Created BuildTypeExtension interface
* Created BaseBuildType - a common build-type implementaion meant to be
subclassed and extended by new build-types
* Created build-type extensions for ament_cmake, ament_python and cmake
* Added tests for project creation for each build-type
* Added README describing how to create a build-types
* Added reference to example build-type in roscli README

