### PR TITLE
[ros2doctor] Improve doctor_warn() 

### DIFF
--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -71,12 +71,10 @@ class Result:
         self.error = 0
         self.warning = 0
 
-    def add_error(self, msg) -> None:
-        doctor_warn(msg)
+    def add_error(self) -> None:
         self.error += 1
 
-    def add_warning(self, msg) -> None:
-        doctor_warn(msg)
+    def add_warning(self) -> None:
         self.warning += 1
 
 
@@ -94,11 +92,11 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
         try:
             check_class = check_entry_pt.load()
         except (ImportError, UnknownExtra):
-            doctor_warn(f'Check entry point {check_entry_pt.name} fails to load.')
+            doctor_warn()(f'Check entry point {check_entry_pt.name} fails to load.', RuntimeWarning)
         try:
             check_instance = check_class()
         except Exception:
-            doctor_warn(f'Unable to instantiate check object from {check_entry_pt.name}.')
+            doctor_warn()(f'Unable to instantiate check object from {check_entry_pt.name}.', RuntimeWarning)
         try:
             check_category = check_instance.category()
             result = check_instance.check()
@@ -107,7 +105,7 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
                 failed_cats.add(check_category)
             total += 1
         except Exception:
-            doctor_warn(f'Fail to call {check_entry_pt.name} class functions.')
+            doctor_warn()(f'Fail to call {check_entry_pt.name} class functions.', RuntimeWarning)
     return failed_cats, fail, total
 
 
@@ -122,11 +120,11 @@ def generate_reports(*, categories=None) -> List[Report]:
         try:
             report_class = report_entry_pt.load()
         except (ImportError, UnknownExtra):
-            doctor_warn(f'Report entry point {report_entry_pt.name} fails to load.')
+            doctor_warn()(f'Report entry point {report_entry_pt.name} fails to load.', RuntimeWarning)
         try:
             report_instance = report_class()
         except Exception:
-            doctor_warn(f'Unable to instantiate report object from {report_entry_pt.name}.')
+            doctor_warn()(f'Unable to instantiate report object from {report_entry_pt.name}.', RuntimeWarning)
         try:
             report_category = report_instance.category()
             report = report_instance.report()
@@ -136,5 +134,5 @@ def generate_reports(*, categories=None) -> List[Report]:
             else:
                 reports.append(report)
         except Exception:
-            doctor_warn(f'Fail to call {report_entry_pt.name} class functions.')
+            doctor_warn()(f'Fail to call {report_entry_pt.name} class functions.', RuntimeWarning)
     return reports

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -85,28 +85,28 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
     :return: 3-tuple (categories of failed checks, number of failed checks,
              total number of checks)
     """
-    failed_cats = set()  # remove repeating elements
+    fail_categories = set()  # remove repeating elements
     fail = 0
     total = 0
     for check_entry_pt in iter_entry_points('ros2doctor.checks'):
         try:
             check_class = check_entry_pt.load()
         except (ImportError, UnknownExtra):
-            doctor_warn()(f'Check entry point {check_entry_pt.name} fails to load.', RuntimeWarning)
+            doctor_warn()(f'Check entry point {check_entry_pt.name} fails to load.')
         try:
             check_instance = check_class()
         except Exception:
-            doctor_warn()(f'Unable to instantiate check object from {check_entry_pt.name}.', RuntimeWarning)
+            doctor_warn()(f'Unable to instantiate check object from {check_entry_pt.name}.')
         try:
             check_category = check_instance.category()
             result = check_instance.check()
             if result.error or (include_warnings and result.warning):
                 fail += 1
-                failed_cats.add(check_category)
+                fail_categories.add(check_category)
             total += 1
         except Exception:
-            doctor_warn()(f'Fail to call {check_entry_pt.name} class functions.', RuntimeWarning)
-    return failed_cats, fail, total
+            doctor_warn()(f'Fail to call {check_entry_pt.name} class functions.')
+    return fail_categories, fail, total
 
 
 def generate_reports(*, categories=None) -> List[Report]:
@@ -120,11 +120,11 @@ def generate_reports(*, categories=None) -> List[Report]:
         try:
             report_class = report_entry_pt.load()
         except (ImportError, UnknownExtra):
-            doctor_warn()(f'Report entry point {report_entry_pt.name} fails to load.', RuntimeWarning)
+            doctor_warn()(f'Report entry point {report_entry_pt.name} fails to load.')
         try:
             report_instance = report_class()
         except Exception:
-            doctor_warn()(f'Unable to instantiate report object from {report_entry_pt.name}.', RuntimeWarning)
+            doctor_warn()(f'Unable to instantiate report object from {report_entry_pt.name}.')
         try:
             report_category = report_instance.category()
             report = report_instance.report()
@@ -134,5 +134,5 @@ def generate_reports(*, categories=None) -> List[Report]:
             else:
                 reports.append(report)
         except Exception:
-            doctor_warn()(f'Fail to call {report_entry_pt.name} class functions.', RuntimeWarning)
+            doctor_warn()(f'Fail to call {report_entry_pt.name} class functions.')
     return reports

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -56,7 +56,7 @@ class Report:
         self.name = name
         self.items = []
 
-    def add_to_report(self, item_name: str, item_info: str) -> None:
+    def add_to_report(self, item_name: str, item_info: str):
         """Add report content to items list (list of string tuples)."""
         self.items.append((item_name, item_info))
 
@@ -71,10 +71,10 @@ class Result:
         self.error = 0
         self.warning = 0
 
-    def add_error(self) -> None:
+    def add_error(self):
         self.error += 1
 
-    def add_warning(self) -> None:
+    def add_warning(self):
         self.warning += 1
 
 

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -56,7 +56,7 @@ class Report:
         self.name = name
         self.items = []
 
-    def add_to_report(self, item_name: str, item_info: str):
+    def add_to_report(self, item_name: str, item_info: str) -> None:
         """Add report content to items list (list of string tuples)."""
         self.items.append((item_name, item_info))
 
@@ -92,11 +92,11 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
         try:
             check_class = check_entry_pt.load()
         except (ImportError, UnknownExtra):
-            doctor_warn()(f'Check entry point {check_entry_pt.name} fails to load.')
+            doctor_warn(f'Check entry point {check_entry_pt.name} fails to load.')
         try:
             check_instance = check_class()
         except Exception:
-            doctor_warn()(f'Unable to instantiate check object from {check_entry_pt.name}.')
+            doctor_warn(f'Unable to instantiate check object from {check_entry_pt.name}.')
         try:
             check_category = check_instance.category()
             result = check_instance.check()
@@ -105,7 +105,7 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
                 fail_categories.add(check_category)
             total += 1
         except Exception:
-            doctor_warn()(f'Fail to call {check_entry_pt.name} class functions.')
+            doctor_warn(f'Fail to call {check_entry_pt.name} class functions.')
     return fail_categories, fail, total
 
 
@@ -120,11 +120,11 @@ def generate_reports(*, categories=None) -> List[Report]:
         try:
             report_class = report_entry_pt.load()
         except (ImportError, UnknownExtra):
-            doctor_warn()(f'Report entry point {report_entry_pt.name} fails to load.')
+            doctor_warn(f'Report entry point {report_entry_pt.name} fails to load.')
         try:
             report_instance = report_class()
         except Exception:
-            doctor_warn()(f'Unable to instantiate report object from {report_entry_pt.name}.')
+            doctor_warn(f'Unable to instantiate report object from {report_entry_pt.name}.')
         try:
             report_category = report_instance.category()
             report = report_instance.report()
@@ -134,5 +134,5 @@ def generate_reports(*, categories=None) -> List[Report]:
             else:
                 reports.append(report)
         except Exception:
-            doctor_warn()(f'Fail to call {report_entry_pt.name} class functions.')
+            doctor_warn(f'Fail to call {report_entry_pt.name} class functions.')
     return reports

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -94,11 +94,11 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
         try:
             check_class = check_entry_pt.load()
         except (ImportError, UnknownExtra):
-            doctor_warn('Check entry point %s fails to load.' % check_entry_pt.name)
+            doctor_warn(f'Check entry point {check_entry_pt.name} fails to load.')
         try:
             check_instance = check_class()
         except Exception:
-            doctor_warn('Unable to instantiate check object from %s.' % check_entry_pt.name)
+            doctor_warn(f'Unable to instantiate check object from {check_entry_pt.name}.')
         try:
             check_category = check_instance.category()
             result = check_instance.check()
@@ -107,7 +107,7 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
                 failed_cats.add(check_category)
             total += 1
         except Exception:
-            doctor_warn('Fail to call %s class functions.' % check_entry_pt.name)
+            doctor_warn(f'Fail to call {check_entry_pt.name} class functions.')
     return failed_cats, fail, total
 
 
@@ -122,11 +122,11 @@ def generate_reports(*, categories=None) -> List[Report]:
         try:
             report_class = report_entry_pt.load()
         except (ImportError, UnknownExtra):
-            doctor_warn('Report entry point %s fails to load.' % report_entry_pt.name)
+            doctor_warn(f'Report entry point {report_entry_pt.name} fails to load.')
         try:
             report_instance = report_class()
         except Exception:
-            doctor_warn('Unable to instantiate report object from %s.' % report_entry_pt.name)
+            doctor_warn(f'Unable to instantiate report object from {report_entry_pt.name}.')
         try:
             report_category = report_instance.category()
             report = report_instance.report()
@@ -136,5 +136,5 @@ def generate_reports(*, categories=None) -> List[Report]:
             else:
                 reports.append(report)
         except Exception:
-            doctor_warn('Fail to call %s class functions.' % report_entry_pt.name)
+            doctor_warn(f'Fail to call {report_entry_pt.name} class functions.')
     return reports

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
 from typing import List
 from typing import Tuple
 import warnings
@@ -46,7 +45,6 @@ def compute_padding(report_items: List[Tuple[str, str]]) -> int:
     return padding
 
 
-
 def custom_warning_format(msg, cat, filename, linenum, file=None, line=None):
     return '%s: %s: %s: %s\n' % (filename, linenum, cat.__name__, msg)
 
@@ -61,6 +59,7 @@ class CustomWarningFormat:
     def __exit__(self, t, v, trb):
         """
         Define exit action for context manager.
+
         :param t: type
         :param v: value
         :param trb: traceback

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -46,13 +46,43 @@ def compute_padding(report_items: List[Tuple[str, str]]) -> int:
     return padding
 
 
-def doctor_warn() -> Callable:
+
+def custom_warning_format(msg, cat, filename, linenum, file=None, line=None):
+    return '%s: %s: %s: %s\n' % (filename, linenum, cat.__name__, msg)
+
+
+class CustomWarningFormat:
+    """Support custom warning format without modifying default format."""
+
+    def __enter__(self):
+        self._default_format = warnings.formatwarning
+        warnings.formatwarning = custom_warning_format
+
+    def __exit__(self, t, v, trb):
+        """
+        Define exit action for context manager.
+        :param t: type
+        :param v: value
+        :param trb: traceback
+        """
+        warnings.formatwarning = self._default_format
+
+
+def doctor_warn(msg: str) -> None:
     """
     Print customized warning message with package and line info.
 
     :param msg: warning message to be printed
     """
-    def custom_warning_format(message, category, filename, lineno, file=None, line=None):
-        return f'{filename}:{lineno}: {category.__name__}: {message}\n'
-    warnings.formatwarning = custom_warning_format
-    return warnings.warn
+    with CustomWarningFormat():
+        warnings.warn(msg, stacklevel=2)
+
+
+def doctor_error(msg: str) -> None:
+    """
+    Print customized error message with package and line info.
+
+    :param msg: error message to be printed
+    """
+    with CustomWarningFormat():
+        warnings.warn(f'ERROR: {msg}', stacklevel=2)

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -23,7 +23,7 @@ def format_print(report):
 
     :param report: Report object with name and items list
     """
-    print('\n ', report.name)
+    print('\n  ', report.name)
     if report.items:
         padding_num = compute_padding(report.items)
     for item_name, item_content in report.items:
@@ -52,6 +52,6 @@ def doctor_warn() -> None:
     :param msg: warning message to be printed
     """
     def custom_warning_format(message, category, filename, lineno, file=None, line=None):
-        return '%s:%s: %s: %s\n' % (filename, lineno, category.__name__, message)
+        return f'{filename}:{lineno}: {category.__name__}: {message}\n'
     warnings.formatwarning = custom_warning_format
     return warnings.warn

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -24,7 +24,8 @@ def format_print(report):
     :param report: Report object with name and items list
     """
     print('\n ', report.name)
-    padding_num = compute_padding(report.items)
+    if report.items:
+        padding_num = compute_padding(report.items)
     for item_name, item_content in report.items:
         print('{:{padding}}: {}'.format(item_name, item_content, padding=padding_num))
 
@@ -44,33 +45,13 @@ def compute_padding(report_items: List[Tuple[str, str]]) -> int:
     return padding
 
 
-def custom_warning_format(msg, cat, filename, linenum, file=None, line=None):
-    return '%s: %s: %s: %s\n' % (filename, linenum, cat.__name__, msg)
-
-
-class CustomWarningFormat:
-    """Support custom warning format without modifying default format."""
-
-    def __enter__(self):
-        self._default_format = warnings.formatwarning
-        warnings.formatwarning = custom_warning_format
-
-    def __exit__(self, t, v, trb):
-        """
-        Define exit action for context manager.
-
-        :param t: type
-        :param v: value
-        :param trb: traceback
-        """
-        warnings.formatwarning = self._default_format
-
-
-def doctor_warn(msg: str) -> None:
+def doctor_warn() -> None:
     """
-    Use CustomWarningFormat to print customized warning message.
+    Print customized warning message with package and line info.
 
     :param msg: warning message to be printed
     """
-    with CustomWarningFormat():
-        warnings.warn(msg)
+    def custom_warning_format(message, category, filename, lineno, file=None, line=None):
+        return '%s:%s: %s: %s\n' % (filename, lineno, category.__name__, message)
+    warnings.formatwarning = custom_warning_format
+    return warnings.warn

--- a/ros2doctor/ros2doctor/api/format.py
+++ b/ros2doctor/ros2doctor/api/format.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable
 from typing import List
 from typing import Tuple
 import warnings
@@ -45,7 +46,7 @@ def compute_padding(report_items: List[Tuple[str, str]]) -> int:
     return padding
 
 
-def doctor_warn() -> None:
+def doctor_warn() -> Callable:
     """
     Print customized warning message with package and line info.
 

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -20,11 +20,12 @@ from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
 from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_warn
+from ros2doctor.api.format import doctor_error
 
 try:
     import ifcfg
 except ImportError:  # check import error for windows and osx
-    doctor_warn()(
+    doctor_warn(
         'Unable to import ifcfg. '
         'Use `python3 -m pip install ifcfg` to install needed package.')
 
@@ -63,8 +64,8 @@ class NetworkCheck(DoctorCheck):
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
-            doctor_warn()(
-                'ERROR: `ifcfg` module is not imported. '
+            doctor_error(
+                '`ifcfg` module is not imported. '
                 'Unable to run network check.')
             result.add_error()
             return result
@@ -73,20 +74,20 @@ class NetworkCheck(DoctorCheck):
         if not _is_unix_like_platform():
             if not has_loopback and not has_non_loopback:
                 # no flags found, otherwise one of them should be True.
-                doctor_warn()(
-                    'ERROR: No flags found. '
+                doctor_error(
+                    'No flags found. '
                     'Run `ipconfig` on Windows or '
                     'install `ifconfig` on Unix to check network interfaces.')
                 result.add_error()
                 return result
         if not has_loopback:
-            doctor_warn()('ERROR: No loopback IP address is found.')
+            doctor_error('No loopback IP address is found.')
             result.add_error()
         if not has_non_loopback:
-            doctor_warn()('Only loopback IP address is found.')
+            doctor_warn('Only loopback IP address is found.')
             result.add_warning()
         if not has_multicast:
-            doctor_warn()('No multicast IP address is found.')
+            doctor_warn('No multicast IP address is found.')
             result.add_warning()
         return result
 
@@ -103,7 +104,7 @@ class NetworkReport(DoctorReport):
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
-            doctor_warn()('ERROR: ifcfg is not imported. Unable to generate network report.')
+            doctor_error('ifcfg is not imported. Unable to generate network report.')
             return Report('')
 
         network_report = Report('NETWORK CONFIGURATION')

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -19,8 +19,8 @@ from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
 from ros2doctor.api import Result
-from ros2doctor.api.format import doctor_warn
 from ros2doctor.api.format import doctor_error
+from ros2doctor.api.format import doctor_warn
 
 try:
     import ifcfg

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -24,7 +24,8 @@ from ros2doctor.api.format import doctor_warn
 try:
     import ifcfg
 except ImportError:  # check import error for windows and osx
-    doctor_warn()('Unable to import ifcfg. '
+    doctor_warn()(
+        'Unable to import ifcfg. '
         'Use `python3 -m pip install ifcfg` to install needed package.')
 
 
@@ -62,7 +63,8 @@ class NetworkCheck(DoctorCheck):
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
-            doctor_warn()('ERROR: `ifcfg` module is not imported. '
+            doctor_warn()(
+                'ERROR: `ifcfg` module is not imported. '
                 'Unable to run network check.')
             result.add_error()
             return result
@@ -71,7 +73,8 @@ class NetworkCheck(DoctorCheck):
         if not _is_unix_like_platform():
             if not has_loopback and not has_non_loopback:
                 # no flags found, otherwise one of them should be True.
-                doctor_warn()('ERROR: No flags found. '
+                doctor_warn()(
+                    'ERROR: No flags found. '
                     'Run `ipconfig` on Windows or '
                     'install `ifconfig` on Unix to check network interfaces.')
                 result.add_error()

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -14,6 +14,7 @@
 
 import os
 from typing import Tuple
+import warnings
 
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
@@ -24,8 +25,8 @@ from ros2doctor.api.format import doctor_warn
 try:
     import ifcfg
 except ImportError:  # check import error for windows and osx
-    doctor_warn('Failed to import ifcfg. '
-                'Use `python -m pip install ifcfg` to install needed package.')
+    doctor_warn()('Unable to import ifcfg. '
+        'Use `python -m pip install ifcfg` to install needed package.')
 
 
 def _is_unix_like_platform() -> bool:
@@ -62,22 +63,29 @@ class NetworkCheck(DoctorCheck):
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
-            result.add_error('ERROR: ifcfg is not imported. Unable to run network check.')
+            doctor_warn()('ERROR: `ifcfg` module is not imported. '
+                'Unable to run network check.')
+            result.add_error()
             return result
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
         if not _is_unix_like_platform():
             if not has_loopback and not has_non_loopback:
                 # no flags found, otherwise one of them should be True.
-                print('No flags found. \
-                    Run `ipconfig` on cmd to check network interfaces.')
+                doctor_warn()('ERROR: No flags found. '
+                    'Run `ipconfig` on Windows or '
+                    'install `ifconfig` on Unix to check network interfaces.')
+                result.add_error()
                 return result
         if not has_loopback:
-            result.add_error('ERROR: No loopback IP address is found.')
+            doctor_warn()('ERROR: No loopback IP address is found.')
+            result.add_error()
         if not has_non_loopback:
-            result.add_warning('Only loopback IP address is found.')
+            doctor_warn()('Only loopback IP address is found.')
+            result.add_warning()
         if not has_multicast:
-            result.add_warning('No multicast IP address is found.')
+            doctor_warn()('No multicast IP address is found.')
+            result.add_warning()
         return result
 
 
@@ -93,7 +101,7 @@ class NetworkReport(DoctorReport):
         try:
             ifcfg_ifaces = ifcfg.interfaces()
         except NameError:
-            doctor_warn('ifcfg is not imported. Unable to generate network report.')
+            doctor_warn()('ERROR: ifcfg is not imported. Unable to generate network report.')
             return Report('')
 
         network_report = Report('NETWORK CONFIGURATION')

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -14,7 +14,6 @@
 
 import os
 from typing import Tuple
-import warnings
 
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
@@ -26,7 +25,7 @@ try:
     import ifcfg
 except ImportError:  # check import error for windows and osx
     doctor_warn()('Unable to import ifcfg. '
-        'Use `python -m pip install ifcfg` to install needed package.')
+        'Use `python3 -m pip install ifcfg` to install needed package.')
 
 
 def _is_unix_like_platform() -> bool:

--- a/ros2doctor/ros2doctor/api/package.py
+++ b/ros2doctor/ros2doctor/api/package.py
@@ -51,9 +51,9 @@ def get_distro_package_versions() -> dict:
     if not distro_info:
         doctor_warn()(f'Distribution name {distro_name} is not found')
         return
-    distro_data = distro_info.get_data()
-    repos_info = distro_data.get('repositories')
-    if not repos_info:
+    try:
+        repos_info = distro_info.get_data().get('repositories')
+    except AttributeError:
         doctor_warn()('No repository information found.')
         return
     distro_package_vers = {}
@@ -161,11 +161,8 @@ class PackageReport(DoctorReport):
     def report(self):
         """Report packages within the directory where command is called."""
         report = Report('PACKAGE VERSIONS')
-        try:
-            distro_package_vers = get_distro_package_versions()
-        except (AttributeError, RuntimeError, URLError):
-            return report
         local_package_vers = get_local_package_versions()
+        distro_package_vers = get_distro_package_versions()
         if not local_package_vers or not distro_package_vers:
             return report
         for name, local_ver_str in local_package_vers.items():

--- a/ros2doctor/ros2doctor/api/package.py
+++ b/ros2doctor/ros2doctor/api/package.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import List
 import textwrap
-from urllib.error import URLError
 
 from ament_index_python import get_packages_with_prefixes
 from catkin_pkg.package import parse_package
@@ -43,7 +41,8 @@ def get_distro_package_versions() -> dict:
     distro_name = distro_name.lower()
     url = rosdistro.get_index_url()
     if not url:
-        doctor_warn()('ERROR: Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL. '
+        doctor_warn()(
+            'ERROR: Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL. '
             'Check network setting to make sure machine is connected to internet.')
         return
     i = rosdistro.get_index(url)
@@ -106,25 +105,30 @@ def compare_versions(result: Result, local_packages: dict, distro_packages: dict
         local_ver = version.parse(local_ver_str).base_version
         required_ver = version.parse(required_ver_str).base_version
         if local_ver < required_ver:
-            doctor_warn()(f'{name} has been updated to a new version.'
+            doctor_warn()(
+                f'{name} has been updated to a new version.'
                 f' local: {local_ver} <'
                 f' required: {required_ver}')
             result.add_warning()
     if missing_req:
         if len(missing_req) > 100:
-            doctor_warn()('Cannot find required versions of packages: ' +
+            doctor_warn()(
+                'Cannot find required versions of packages: ' +
                 textwrap.shorten(missing_req, width=100) +
                 ' Use `ros2 doctor --report` to see full list.')
         else:
-            doctor_warn()('Cannot find required versions of packages: ' +
+            doctor_warn()(
+                'Cannot find required versions of packages: ' +
                 missing_req)
     if missing_local:
         if len(missing_local) > 100:
-            doctor_warn()('Cannot find local versions of packages: ' +
+            doctor_warn()(
+                'Cannot find local versions of packages: ' +
                 textwrap.shorten(missing_local, width=100) +
                 ' Use `ros2 doctor --report` to see full list.')
         else:
-            doctor_warn()('Cannot find local versions of packages: ' +
+            doctor_warn()(
+                'Cannot find local versions of packages: ' +
                 missing_local)
 
 

--- a/ros2doctor/ros2doctor/api/package.py
+++ b/ros2doctor/ros2doctor/api/package.py
@@ -23,8 +23,8 @@ from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
 from ros2doctor.api import Result
-from ros2doctor.api.format import doctor_warn
 from ros2doctor.api.format import doctor_error
+from ros2doctor.api.format import doctor_warn
 
 import rosdistro
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -21,6 +21,7 @@ from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
 from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_warn
+from ros2doctor.api.format import doctor_error
 
 import rosdistro
 
@@ -33,19 +34,19 @@ def _check_platform_helper() -> Tuple[str, dict, dict]:
     """
     distro_name = os.environ.get('ROS_DISTRO')
     if not distro_name:
-        doctor_warn()('ERROR: ROS_DISTRO is not set.')
+        doctor_error('ROS_DISTRO is not set.')
         return
     distro_name = distro_name.lower()
     u = rosdistro.get_index_url()
     if not u:
-        doctor_warn()(
-            'ERROR: Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL. '
+        doctor_error(
+            'Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL. '
             'Check network setting to make sure machine is connected to internet.')
         return
     i = rosdistro.get_index(u)
     distro_info = i.distributions.get(distro_name)
     if not distro_info:
-        doctor_warn()(f'Distribution name {distro_name} is not found')
+        doctor_warn(f'Distribution name {distro_name} is not found')
         return
     try:
         distro_data = rosdistro.get_distribution(i, distro_name).get_data()
@@ -65,20 +66,20 @@ class PlatformCheck(DoctorCheck):
         result = Result()
         distros = _check_platform_helper()
         if not distros:
-            doctor_warn()('ERROR: Missing rosdistro info. Unable to check platform.')
+            doctor_error('Missing rosdistro info. Unable to check platform.')
             result.add_error()
             return result
         distro_name, distro_info, _ = distros
 
         # check distro status
         if distro_info.get('distribution_status') == 'prerelease':
-            doctor_warn()(
+            doctor_warn(
                 f'Distribution {distro_name} is not fully supported or tested. '
                 'To get more consistent features, download a stable version at '
                 'https://index.ros.org/doc/ros2/Installation/')
             result.add_warning()
         elif distro_info.get('distribution_status') == 'end-of-life':
-            doctor_warn()(
+            doctor_warn(
                 f'Distribution {distro_name} is no longer supported or deprecated. '
                 'To get the latest features, download the new versions at '
                 'https://index.ros.org/doc/ros2/Installation/')

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -20,8 +20,8 @@ from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
 from ros2doctor.api import Result
-from ros2doctor.api.format import doctor_warn
 from ros2doctor.api.format import doctor_error
+from ros2doctor.api.format import doctor_warn
 
 import rosdistro
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -38,7 +38,8 @@ def _check_platform_helper() -> Tuple[str, dict, dict]:
     distro_name = distro_name.lower()
     u = rosdistro.get_index_url()
     if not u:
-        doctor_warn()('ERROR: Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL. '
+        doctor_warn()(
+            'ERROR: Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL. '
             'Check network setting to make sure machine is connected to internet.')
         return
     i = rosdistro.get_index(u)
@@ -71,12 +72,14 @@ class PlatformCheck(DoctorCheck):
 
         # check distro status
         if distro_info.get('distribution_status') == 'prerelease':
-            doctor_warn()(f'Distribution {distro_name} is not fully supported or tested. '
+            doctor_warn()(
+                f'Distribution {distro_name} is not fully supported or tested. '
                 'To get more consistent features, download a stable version at '
                 'https://index.ros.org/doc/ros2/Installation/')
             result.add_warning()
         elif distro_info.get('distribution_status') == 'end-of-life':
-            doctor_warn()(f'Distribution {distro_name} is no longer supported or deprecated. '
+            doctor_warn()(
+                f'Distribution {distro_name} is no longer supported or deprecated. '
                 'To get the latest features, download the new versions at '
                 'https://index.ros.org/doc/ros2/Installation/')
             result.add_warning()

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -46,7 +46,10 @@ def _check_platform_helper() -> Tuple[str, dict, dict]:
     if not distro_info:
         doctor_warn()(f'Distribution name {distro_name} is not found')
         return
-    distro_data = rosdistro.get_distribution(i, distro_name).get_data()
+    try:
+        distro_data = rosdistro.get_distribution(i, distro_name).get_data()
+    except AttributeError:
+        distro_data = ''
     return distro_name, distro_info, distro_data
 
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -33,18 +33,18 @@ def _check_platform_helper() -> Tuple[str, dict, dict]:
     """
     distro_name = os.environ.get('ROS_DISTRO')
     if not distro_name:
-        doctor_warn('ROS_DISTRO is not set.')
+        doctor_warn()('ERROR: ROS_DISTRO is not set.')
         return
-    else:
-        distro_name = distro_name.lower()
+    distro_name = distro_name.lower()
     u = rosdistro.get_index_url()
     if not u:
-        doctor_warn('Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL.')
+        doctor_warn()('ERROR: Unable to access ROSDISTRO_INDEX_URL or DEFAULT_INDEX_URL. '
+            'Check network setting to make sure machine is connected to internet.')
         return
     i = rosdistro.get_index(u)
     distro_info = i.distributions.get(distro_name)
     if not distro_info:
-        doctor_warn(f"Distribution name {distro_name} is not found")
+        doctor_warn()(f'Distribution name {distro_name} is not found')
         return
     distro_data = rosdistro.get_distribution(i, distro_name).get_data()
     return distro_name, distro_info, distro_data
@@ -61,19 +61,22 @@ class PlatformCheck(DoctorCheck):
         result = Result()
         distros = _check_platform_helper()
         if not distros:
-            result.add_error('ERROR: Missing rosdistro info. Unable to check platform.')
+            doctor_warn()('ERROR: Missing rosdistro info. Unable to check platform.')
+            result.add_error()
             return result
         distro_name, distro_info, _ = distros
 
         # check distro status
         if distro_info.get('distribution_status') == 'prerelease':
-            result.add_warning(f'Distribution {distro_name} is not fully supported or tested. '
-                               'To get more consistent features, download a stable version at '
-                               'https://index.ros.org/doc/ros2/Installation/')
+            doctor_warn()(f'Distribution {distro_name} is not fully supported or tested. '
+                'To get more consistent features, download a stable version at '
+                'https://index.ros.org/doc/ros2/Installation/')
+            result.add_warning()
         elif distro_info.get('distribution_status') == 'end-of-life':
-            result.add_warning(f'Distribution {distro_name} is no longer supported or deprecated. '
-                               'To get the latest features, download the new versions at '
-                               'https://index.ros.org/doc/ros2/Installation/')
+            doctor_warn()(f'Distribution {distro_name} is no longer supported or deprecated. '
+                'To get the latest features, download the new versions at '
+                'https://index.ros.org/doc/ros2/Installation/')
+            result.add_warning()
         return result
 
 

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -44,7 +44,7 @@ def _check_platform_helper() -> Tuple[str, dict, dict]:
     i = rosdistro.get_index(u)
     distro_info = i.distributions.get(distro_name)
     if not distro_info:
-        doctor_warn("Distribution name '%s' is not found" % distro_name)
+        doctor_warn(f"Distribution name {distro_name} is not found")
         return
     distro_data = rosdistro.get_distribution(i, distro_name).get_data()
     return distro_name, distro_info, distro_data
@@ -67,13 +67,13 @@ class PlatformCheck(DoctorCheck):
 
         # check distro status
         if distro_info.get('distribution_status') == 'prerelease':
-            result.add_warning('Distribution %s is not fully supported or tested. '
+            result.add_warning(f'Distribution {distro_name} is not fully supported or tested. '
                                'To get more consistent features, download a stable version at '
-                               'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+                               'https://index.ros.org/doc/ros2/Installation/')
         elif distro_info.get('distribution_status') == 'end-of-life':
-            result.add_warning('Distribution %s is no longer supported or deprecated. '
+            result.add_warning(f'Distribution {distro_name} is no longer supported or deprecated. '
                                'To get the latest features, download the new versions at '
-                               'https://index.ros.org/doc/ros2/Installation/' % distro_name)
+                               'https://index.ros.org/doc/ros2/Installation/')
         return result
 
 

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -50,10 +50,10 @@ class TopicCheck(DoctorCheck):
                 pub_count = node.count_publishers(topic)
                 sub_count = node.count_subscribers(topic)
                 if pub_count > sub_count:
-                    doctor_warn()(f'Publisher without subscriber detected on {topic}.')
+                    doctor_warn(f'Publisher without subscriber detected on {topic}.')
                     result.add_warning()
                 elif pub_count < sub_count:
-                    doctor_warn()(f'Subscriber without publisher detected on {topic}.')
+                    doctor_warn(f'Subscriber without publisher detected on {topic}.')
                     result.add_warning()
         return result
 

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -22,6 +22,7 @@ from ros2doctor.api import Report
 from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_warn
 
+
 def _get_topic_names() -> List:
     """Get all topic names using rclpy API."""
     white_list = ['/parameter_events', '/rosout']

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -49,9 +49,9 @@ class TopicCheck(DoctorCheck):
                 pub_count = node.count_publishers(topic)
                 sub_count = node.count_subscribers(topic)
                 if pub_count > sub_count:
-                    result.add_warning('Publisher without subscriber detected on %s.' % topic)
+                    result.add_warning(f'Publisher without subscriber detected on {topic}.')
                 elif pub_count < sub_count:
-                    result.add_warning('Subscriber without publisher detected on %s.' % topic)
+                    result.add_warning(f'Subscriber without publisher detected on {topic}.')
         return result
 
 

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -20,7 +20,7 @@ from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
 from ros2doctor.api import Report
 from ros2doctor.api import Result
-
+from ros2doctor.api.format import doctor_warn
 
 def _get_topic_names() -> List:
     """Get all topic names using rclpy API."""
@@ -49,9 +49,11 @@ class TopicCheck(DoctorCheck):
                 pub_count = node.count_publishers(topic)
                 sub_count = node.count_subscribers(topic)
                 if pub_count > sub_count:
-                    result.add_warning(f'Publisher without subscriber detected on {topic}.')
+                    doctor_warn()(f'Publisher without subscriber detected on {topic}.')
+                    result.add_warning()
                 elif pub_count < sub_count:
-                    result.add_warning(f'Subscriber without publisher detected on {topic}.')
+                    doctor_warn()(f'Subscriber without publisher detected on {topic}.')
+                    result.add_warning()
         return result
 
 

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -46,16 +46,16 @@ class DoctorCommand(CommandExtension):
             return
 
         # `ros2 doctor
-        failed_cats, fail, total = run_checks(include_warnings=args.include_warnings)
+        fail_category, fail, total = run_checks(include_warnings=args.include_warnings)
         if fail:
-            print('\n%d/%d checks failed\n' % (fail, total))
-            print('Failed modules:', *failed_cats)
+            print(f'\n{fail}/{total} check(s) failed\n')
+            print('Failed modules:', *fail_category)
         else:
-            print('\nAll %d checks passed\n' % total)
+            print(f'\nAll {total} checks passed\n')
 
         # `ros2 doctor -rf`
         if args.report_failed and fail != 0:
-            fail_reports = generate_reports(categories=failed_cats)
+            fail_reports = generate_reports(categories=fail_category)
             for report_obj in fail_reports:
                 format_print(report_obj)
 


### PR DESCRIPTION
Updates in this PR:
* Decouple `doctor_warn()` and `Result()` to improve error/warning trace-back
    before, warning always trace back to the `format.py` file
    ```
    /home/claire/ros2_ws/build/ros2doctor/ros2doctor/api/format.py: 76: 
    UserWarning: Distribution foxy is not fully supported or tested. 
    To get more consistent features, download a stable version at https://index.ros.org/doc/ros2/Installation/
    ```
    now, warning points to the exact file where things go wrong
    ```
    /home/claire/ros2_ws/build/ros2doctor/ros2doctor/api/platform.py:76:
    UserWarning: Distribution foxy is not fully supported or tested. 
    To get more consistent features, download a stable version at https://index.ros.org/doc/ros2/Installation/
    ```
* Add `doctor_error()` in addition to `doctor_warn()`, to differentiate warning and error msgs.
* Use f-string for all print statements
* Shorten missing package names instead of printing them all out
    before
    ```
    /home/claire/ros2_ws/build/ros2doctor/ros2doctor/api/format.py: 76: 
    UserWarning: Cannot find required versions of packages: 
    rosbag2 rosbag2_compression zstd_vendor rviz_visual_testing_framework rviz2 rviz_default_plugins rviz_common ros2bag rosbag2_transport rosbag2_storage_default_plugins rosbag2_converter_default_plugins rosbag2_cpp rosbag2_storage yaml_cpp_vendor ros1_bridge interactive_markers common_interfaces visualization_msgs dummy_robot_bringup robot_state_publisher kdl_parser urdf turtlesim tracetools_launch topic_monitor tf2_tools geometry2 tf2_sensor_msgs tf2_kdl tf2_geometry_msgs tf2_eigen examples_tf2_py tf2_ros tf2_py tf2_msgs test_msgs sros2_cmake sros2 rqt_topic rqt_top rqt_srv rqt_shell rqt_service_caller rqt_reconfigure rqt_py_console rqt_publisher rqt_plot rqt_action rqt_msg rqt_console rqt rqt_py_common rqt_graph rqt_gui_py rqt_gui ros_testing ros2trace ros2topic ros2test ros2component ros2param ros2lifecycle ros2service ros2run ros2launch ros2pkg ros2node ros2multicast ros2interface ros2doctor ros2action ros2cli quality_of_service_demo_py quality_of_service_demo_cpp launch_testing_ros demo_nodes_cpp composition launch_ros examples_rclpy_minimal_subscriber examples_rclpy_minimal_service examples_rclpy_minimal_publisher examples_rclpy_minimal_client examples_rclpy_minimal_action_server
    ```
   now 
    ```
    /home/claire/ros2_ws/build/ros2doctor/ros2doctor/api/package.py:118: 
    UserWarning: Cannot find required versions of packages: 
    rosbag2 rosbag2_compression zstd_vendor rviz_visual_testing_framework rviz2 [...] Use `ros2 doctor --report` to see full list.
    ```
* Keep error/warning logic consistent everywhere.