### PR TITLE
[Eloquent Backport] Avoid passing None to rclpy.init (#433)

### DIFF
--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -29,7 +29,9 @@ class DirectNode:
             nonlocal timeout_reached
             timeout_reached = True
 
-        rclpy.init()
+        argv = getattr(args, 'argv', [])
+
+        rclpy.init(args=argv)
 
         node_name_suffix = getattr(
             args, 'node_name_suffix', '_%d' % os.getpid())


### PR DESCRIPTION
Backport of #433 to eloquent