### PR TITLE
Fix race in ros2action test_cli

### DIFF
--- a/ros2action/test/fixtures/fibonacci_action_server.py
+++ b/ros2action/test/fixtures/fibonacci_action_server.py
@@ -56,6 +56,12 @@ def main(args=None):
 
     node = FibonacciActionServer()
     try:
+        # Spend up to 2 seconds doing all the work we need to have the fibonacci
+        # action server actually talking over DDS before signaling to the test it's
+        # OK to start
+        for _ in range(20):
+            rclpy.spin_once(node, timeout_sec=0.1)
+        print('fibonacci_action_server has started')
         rclpy.spin(node)
     except KeyboardInterrupt:
         print('server stopped cleanly')


### PR DESCRIPTION
This test was trying to talk to the fibonacci action server before it
was ready to be talked to.

Fix the test by having the fibonacci action server write to stdout when
it's ready and having the test wait for the stdout to start

I believe this was the cause of the test failures in https://github.com/ros2/ros2cli/pull/376 but I've found the ros2cli tests are very fragile, so I'd like to try to merge this separately so there aren't confounding factors if the tests continue to fail.

## How to reproduce the original race/failure:
If you delay the Fibonacci action server program's startup by adding
```
import time
time.sleep(5)
```
right before `main` is called [here](https://github.com/ros2/ros2cli/blob/master/ros2action/test/fixtures/fibonacci_action_server.py#L71)

. . . and also remove the retry_on_failure [here](https://github.com/ros2/ros2cli/blob/master/ros2action/test/test_cli.py#L138) you could make `test_fibonacci_info` fail every time.

Signed-off-by: Pete Baughman <peter.c.baughman@gmail.com>