### PR TITLE
[ros2topic bw] Monotonic clock, units, fstring

### DIFF
--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -90,7 +90,7 @@ class ROSTopicBandwidth(object):
         """Execute ros sub callback."""
         with self.lock:
             try:
-                t = time.time()
+                t = time.monotonic()
                 self.times.append(t)
                 # TODO(yechun1): Subscribing to the msgs and calculate the length may be
                 # inefficiency. To optimize here if found better solution.
@@ -109,7 +109,7 @@ class ROSTopicBandwidth(object):
             return
         with self.lock:
             n = len(self.times)
-            tn = time.time()
+            tn = time.monotonic()
             t0 = self.times[0]
 
             total = sum(self.sizes)

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -81,8 +81,8 @@ class BwVerb(VerbExtension):
             include_hidden_topics_key='include_hidden_topics')
         parser.add_argument(
             '--window', '-w', type=positive_int, default=DEFAULT_WINDOW_SIZE,
-            help='window size, in # of messages, for calculating rate '
-                 '(default: %d)' % DEFAULT_WINDOW_SIZE, metavar='WINDOW')
+            help='maximum window size, in # of messages, for calculating rate '
+                 f'(default: {DEFAULT_WINDOW_SIZE})', metavar='WINDOW')
 
     def main(self, *, args):
         with DirectNode(args) as node:
@@ -164,7 +164,7 @@ def _rostopic_bw(node, topic, window_size=DEFAULT_WINDOW_SIZE):
         raw=True
     )
 
-    print('Subscribed to [%s]' % topic)
+    print(f'Subscribed to {topic}')
     timer = node.create_timer(1, rt.print_bw)
     while rclpy.ok():
         rclpy.spin_once(node)

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -144,7 +144,7 @@ class ROSTopicBandwidth(object):
         # Bandwidth is per second
         bw += '/s'
 
-        print('average: %s\n\tmean: %s min: %s max: %s window: %s' % (bw, mean, min_s, max_s, n))
+        print(f'{bw} from {n} messages\n\tMessage size mean: {mean} min: {min_s} max: {max_s}')
 
 
 def _rostopic_bw(node, topic, window_size=DEFAULT_WINDOW_SIZE):

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -58,6 +58,18 @@ def positive_int(string):
     return value
 
 
+def str_bytes(num_bytes):
+    return f'{num_bytes:.0f} B'
+
+
+def str_kilobytes(num_bytes):
+    return f'{num_bytes/1000:.2f} KB'
+
+
+def str_megabytes(num_bytes):
+    return f'{num_bytes/1000/1000:.2f} MB'
+
+
 class BwVerb(VerbExtension):
     """Display bandwidth used by topic."""
 
@@ -123,13 +135,14 @@ class ROSTopicBandwidth(object):
         # min/max and even mean are likely to be much smaller,
         # but for now I prefer unit consistency
         if bytes_per_s < 1000:
-            bw, mean, min_s, max_s = ['%.2fB/s' % v for v in [bytes_per_s, mean, min_s, max_s]]
+            bw, mean, min_s, max_s = map(str_bytes, (bytes_per_s, mean, min_s, max_s))
         elif bytes_per_s < 1000000:
-            bw, mean, min_s, max_s = \
-                ['%.2fKB/s' % (v / 1000) for v in [bytes_per_s, mean, min_s, max_s]]
+            bw, mean, min_s, max_s = map(str_kilobytes, (bytes_per_s, mean, min_s, max_s))
         else:
-            bw, mean, min_s, max_s = \
-                ['%.2fMB/s' % (v / 1000000) for v in [bytes_per_s, mean, min_s, max_s]]
+            bw, mean, min_s, max_s = map(str_megabytes, (bytes_per_s, mean, min_s, max_s))
+
+        # Bandwidth is per second
+        bw += '/s'
 
         print('average: %s\n\tmean: %s min: %s max: %s window: %s' % (bw, mean, min_s, max_s, n))
 

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -164,7 +164,7 @@ def _rostopic_bw(node, topic, window_size=DEFAULT_WINDOW_SIZE):
         raw=True
     )
 
-    print(f'Subscribed to {topic}')
+    print(f'Subscribed to [{topic}]')
     timer = node.create_timer(1, rt.print_bw)
     while rclpy.ok():
         rclpy.spin_once(node)

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -678,11 +678,8 @@ class TestROS2TopicCLI(unittest.TestCase):
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
                     'Subscribed to [/defaults]',
-                    re.compile(r'average: \d{2}\.\d{2}B/s'),
-                    re.compile(
-                        r'\s*mean: \d{2}\.\d{2}B/s min: \d{2}\.\d{2}B/s'
-                        r' max: \d{2}\.\d{2}B/s window: \d+'
-                    )
+                    re.compile(r'\d{2} B/s from \d+ messages'),
+                    re.compile(r'\s*Message size mean: \d{2} B min: \d{2} B max: \d{2} B')
                 ], strict=True
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)


### PR DESCRIPTION
This PR fixes a few issues I noticed while using `ros2topic bw`.

* Use `time.monotonic()` so time measurements aren't affected by system clock time jumps
* Fix units on printed message sizes - they're sizes not size per second
* Don't use any decimal places when printing bytes, continue using 2 decimal places with KB and MB
* Make the periodic print easier to understand (subjective)
  * It wasn't clear to me what `window:` was, so output now says it's a measurement considering that many messages
  * mean/min/max are sizes not bandwidth so output now includes word "size"
* Use `f` strings

What the current output in `eloquent` looks like:

```
$ ros2 topic bw /topic
Subscribed to [/topic]
average: 61.08B/s
	mean: 28.00B/s min: 28.00B/s max: 28.00B/s window: 2
average: 58.43B/s
	mean: 28.00B/s min: 28.00B/s max: 28.00B/s window: 4
average: 57.60B/s
	mean: 28.00B/s min: 28.00B/s max: 28.00B/s window: 6
average: 57.19B/s
	mean: 28.00B/s min: 28.00B/s max: 28.00B/s window: 8
```


What the new output looks like:
```
$ ros2 topic bw /topic
Subscribed to [/topic]
63 B/s from 2 messages
	Message size mean: 24 B min: 24 B max: 24 B
55 B/s from 4 messages
	Message size mean: 24 B min: 24 B max: 24 B
52 B/s from 6 messages
	Message size mean: 24 B min: 24 B max: 24 B
51 B/s from 8 messages
	Message size mean: 24 B min: 24 B max: 24 B
```