### PR TITLE
Add delay when retrying tests involving the CLI daemon

### DIFF
--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -135,7 +135,7 @@ class TestROS2ActionCLI(unittest.TestCase):
             strict=False
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_fibonacci_info(self):
         with self.launch_action_command(arguments=['info', '/fibonacci']) as action_command:
             assert action_command.wait_for_shutdown(timeout=10)
@@ -151,7 +151,7 @@ class TestROS2ActionCLI(unittest.TestCase):
             strict=False
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_fibonacci_info_with_types(self):
         with self.launch_action_command(arguments=['info', '-t', '/fibonacci']) as action_command:
             assert action_command.wait_for_shutdown(timeout=10)
@@ -167,7 +167,7 @@ class TestROS2ActionCLI(unittest.TestCase):
             strict=False
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_fibonacci_info_count(self):
         with self.launch_action_command(arguments=['info', '-c', '/fibonacci']) as action_command:
             assert action_command.wait_for_shutdown(timeout=10)
@@ -182,7 +182,7 @@ class TestROS2ActionCLI(unittest.TestCase):
             strict=False
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list(self):
         with self.launch_action_command(arguments=['list']) as action_command:
             assert action_command.wait_for_shutdown(timeout=10)
@@ -193,7 +193,7 @@ class TestROS2ActionCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_with_types(self):
         with self.launch_action_command(arguments=['list', '-t']) as action_command:
             assert action_command.wait_for_shutdown(timeout=10)
@@ -203,7 +203,7 @@ class TestROS2ActionCLI(unittest.TestCase):
             text=action_command.output, strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_count(self):
         with self.launch_action_command(arguments=['list', '-c']) as action_command:
             assert action_command.wait_for_shutdown(timeout=10)
@@ -212,7 +212,7 @@ class TestROS2ActionCLI(unittest.TestCase):
         assert len(command_output_lines) == 1
         assert int(command_output_lines[0]) == 1
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_send_fibonacci_goal(self):
         with self.launch_action_command(
             arguments=[
@@ -229,7 +229,7 @@ class TestROS2ActionCLI(unittest.TestCase):
             text=action_command.output, strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_send_fibonacci_goal_with_feedback(self):
         with self.launch_action_command(
             arguments=[

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -178,7 +178,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
                 yield lifecycle_command
         cls.launch_lifecycle_command = launch_lifecycle_command
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_lifecycle_node_transitions(self):
         with self.launch_lifecycle_command(
             arguments=['list', 'test_lifecycle_node']
@@ -198,7 +198,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_all_lifecycle_node_transitions(self):
         with self.launch_lifecycle_command(
             arguments=['list', 'test_lifecycle_node', '-a']
@@ -211,7 +211,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_all_lifecycle_hidden_node_transitions_without_hidden_flag(self):
         with self.launch_lifecycle_command(
             arguments=['list', '_hidden_test_lifecycle_node', '-a']
@@ -224,7 +224,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_all_lifecycle_hidden_node_transitions_with_hidden_flag(self):
         with self.launch_lifecycle_command(
             arguments=['list', '--include-hidden-nodes', '_hidden_test_lifecycle_node', '-a']
@@ -237,7 +237,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_lifecycle_nodes(self):
         with self.launch_lifecycle_command(arguments=['nodes']) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
@@ -248,7 +248,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_all_lifecycle_nodes(self):
         with self.launch_lifecycle_command(arguments=['nodes', '-a']) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
@@ -262,7 +262,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_count_lifecycle_nodes(self):
         with self.launch_lifecycle_command(arguments=['nodes', '-c']) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
@@ -271,7 +271,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert len(output_lines) == 1
         assert int(output_lines[0]) == 1
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_count_all_lifecycle_nodes(self):
         with self.launch_lifecycle_command(arguments=['nodes', '-a', '-c']) as lifecycle_command:
             assert lifecycle_command.wait_for_shutdown(timeout=20)
@@ -280,7 +280,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert len(output_lines) == 1
         assert int(output_lines[0]) == 2
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_set_lifecycle_node_invalid_transition(self):
         with self.launch_lifecycle_command(
             arguments=['set', '/test_lifecycle_node', 'noop']
@@ -297,7 +297,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_set_nonexistent_lifecycle_node_state(self):
         with self.launch_lifecycle_command(
             arguments=['set', '/nonexistent_test_lifecycle_node', 'configure']
@@ -310,7 +310,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_set_hidden_lifecycle_node_transition(self):
         with self.launch_lifecycle_command(
             arguments=['set', '/_hidden_test_lifecycle_node', 'configure']
@@ -323,7 +323,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_get_nonexistent_lifecycle_node_state(self):
         with self.launch_lifecycle_command(
             arguments=['get', '/nonexistent_test_lifecycle_node']
@@ -336,7 +336,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_get_hidden_lifecycle_node_state(self):
         with self.launch_lifecycle_command(
             arguments=['get', '/_hidden_test_lifecycle_node']
@@ -360,7 +360,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_get_lifecycle_node_state(self):
         with self.launch_lifecycle_command(
             arguments=['get', '/test_lifecycle_node']
@@ -373,7 +373,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_node_lifecycle(self):
         lifecycle = [
             ('unconfigured [1]', 'configure'),

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -107,7 +107,7 @@ class TestROS2NodeCLI(unittest.TestCase):
                 yield node_command
         cls.launch_node_command = launch_node_command
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_nodes(self):
         with self.launch_node_command(arguments=['list']) as node_command:
             assert node_command.wait_for_shutdown(timeout=10)
@@ -118,7 +118,7 @@ class TestROS2NodeCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_all_nodes(self):
         with self.launch_node_command(arguments=['list', '-a']) as node_command:
             assert node_command.wait_for_shutdown(timeout=10)
@@ -132,7 +132,7 @@ class TestROS2NodeCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_node_count(self):
         with self.launch_node_command(arguments=['list', '-c']) as node_command:
             assert node_command.wait_for_shutdown(timeout=10)
@@ -142,7 +142,7 @@ class TestROS2NodeCLI(unittest.TestCase):
         # Fixture nodes that are not hidden plus launch_ros node.
         assert int(output_lines[0]) == 2
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_all_nodes_count(self):
         with self.launch_node_command(arguments=['list', '-c', '-a']) as node_command:
             assert node_command.wait_for_shutdown(timeout=10)
@@ -152,7 +152,7 @@ class TestROS2NodeCLI(unittest.TestCase):
         # All fixture nodes plus launch_ros and ros2cli daemon nodes.
         assert int(output_lines[0]) == 4
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_info_node(self):
         with self.launch_node_command(arguments=['info', '/complex_node']) as node_command:
             assert node_command.wait_for_shutdown(timeout=10)
@@ -182,7 +182,7 @@ class TestROS2NodeCLI(unittest.TestCase):
             text=node_command.output, strict=False
         ), 'Output does not match:\n' + node_command.output
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_info_hidden_node_no_hidden_flag(self):
         with self.launch_node_command(arguments=['info', '/_hidden_complex_node']) as node_command:
             assert node_command.wait_for_shutdown(timeout=10)
@@ -192,7 +192,7 @@ class TestROS2NodeCLI(unittest.TestCase):
             text=node_command.output, strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_info_hidden_node_hidden_flag(self):
         with self.launch_node_command(
             arguments=['info', '/_hidden_complex_node', '--include-hidden']

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -130,7 +130,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
                 yield service_command
         cls.launch_service_command = launch_service_command
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_services(self):
         with self.launch_service_command(arguments=['list']) as service_command:
             assert service_command.wait_for_shutdown(timeout=10)
@@ -146,7 +146,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_hidden(self):
         with self.launch_service_command(
             arguments=['--include-hidden-services', 'list']
@@ -168,7 +168,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_with_types(self):
         with self.launch_service_command(arguments=['list', '-t']) as service_command:
             assert service_command.wait_for_shutdown(timeout=10)
@@ -185,7 +185,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_count(self):
         with self.launch_service_command(arguments=['list', '-c']) as service_command:
             assert service_command.wait_for_shutdown(timeout=10)
@@ -194,7 +194,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
         assert len(output_lines) == 1
         assert int(output_lines[0]) == 7 + 6  # cope with launch_ros internal node.
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_find(self):
         with self.launch_service_command(
             arguments=['find', 'test_msgs/srv/BasicTypes']
@@ -207,7 +207,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_find_hidden(self):
         with self.launch_service_command(
             arguments=['find', '--include-hidden-services', 'test_msgs/srv/BasicTypes']
@@ -220,7 +220,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_find_count(self):
         with self.launch_service_command(
             arguments=['find', '-c', 'test_msgs/srv/BasicTypes']
@@ -259,7 +259,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
         assert service_command.exit_code == 1
         assert service_command.output == ''
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_call_no_args(self):
         with self.launch_service_command(
             arguments=['call', '/my_ns/echo', 'test_msgs/srv/BasicTypes']
@@ -272,7 +272,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_call(self):
         with self.launch_service_command(
             arguments=[
@@ -295,7 +295,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_repeated_call(self):
         with self.launch_service_command(
             arguments=[

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -180,7 +180,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             output_filter=rmw_implementation_filter
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_topics(self):
         with self.launch_topic_command(arguments=['list']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
@@ -201,7 +201,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_all_topics(self):
         with self.launch_topic_command(
             arguments=['list', '--include-hidden-topics']
@@ -225,7 +225,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_with_types(self):
         with self.launch_topic_command(arguments=['list', '-t']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
@@ -246,7 +246,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_count(self):
         with self.launch_topic_command(arguments=['list', '-c']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
@@ -255,7 +255,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert len(output_lines) == 1
         assert int(output_lines[0]) == 9
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_endpoint_info(self):
         with self.launch_topic_command(arguments=['info', '/chatter']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
@@ -311,7 +311,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_type(self):
         with self.launch_topic_command(arguments=['type', '/chatter']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
@@ -322,7 +322,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             strict=True
         )
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_hidden_topic_type(self):
         with self.launch_topic_command(
             arguments=['type', '/_hidden_chatter']
@@ -331,7 +331,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.exit_code == 1
         assert topic_command.output == ''
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_find_topic_type(self):
         with self.launch_topic_command(
             arguments=['find', 'rcl_interfaces/msg/Log']
@@ -350,7 +350,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
         assert not topic_command.output
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_echo(self):
         with self.launch_topic_command(
             arguments=['echo', '/chatter']
@@ -363,7 +363,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_no_str_topic_echo(self):
         with self.launch_topic_command(
             arguments=['echo', '--no-str', '/chatter']
@@ -376,7 +376,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_csv_topic_echo(self):
         with self.launch_topic_command(
             arguments=['echo', '--csv', '/defaults']
@@ -388,7 +388,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_no_arr_topic_echo_on_array_message(self):
         with self.launch_topic_command(
             arguments=['echo', '--no-arr', '/arrays'],
@@ -432,7 +432,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10), 'Output does not match: ' + topic_command.output
         assert topic_command.wait_for_shutdown(timeout=10)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_no_arr_topic_echo_on_seq_message(self):
         with self.launch_topic_command(
             arguments=['echo', '--no-arr', '/unbounded_sequences'],
@@ -476,7 +476,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_no_arr_topic_echo_on_bounded_seq_message(self):
         with self.launch_topic_command(
             arguments=['echo', '--no-arr', '/bounded_sequences'],
@@ -521,7 +521,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_truncate_length_topic_echo(self):
         with self.launch_topic_command(
             arguments=['echo', '--truncate-length', '5', '/chatter'],
@@ -602,7 +602,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_delay(self):
         average_delay_line_pattern = re.compile(r'average delay: (\d+.\d{3})')
         stats_line_pattern = re.compile(
@@ -620,7 +620,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         average_delay = float(average_delay_line_pattern.match(head_line).group(1))
         assert math.isclose(average_delay, 0.0, abs_tol=10e-3)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_hz(self):
         average_rate_line_pattern = re.compile(r'average rate: (\d+.\d{3})')
         stats_line_pattern = re.compile(
@@ -638,7 +638,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         average_rate = float(average_rate_line_pattern.match(head_line).group(1))
         assert math.isclose(average_rate, 1., rel_tol=1e-3)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_filtered_topic_hz(self):
         average_rate_line_pattern = re.compile(r'average rate: (\d+.\d{3})')
         stats_line_pattern = re.compile(
@@ -663,7 +663,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         average_rate = float(average_rate_line_pattern.match(head_line).group(1))
         assert math.isclose(average_rate, 0.5, rel_tol=1e-3)
 
-    @launch_testing.markers.retry_on_failure(times=5)
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_bw(self):
         with self.launch_topic_command(arguments=['bw', '/defaults']) as topic_command:
             assert topic_command.wait_for_output(functools.partial(


### PR DESCRIPTION
This is to give time for discovery to happen between the daemon node and the test fixture nodes.

Alternative to https://github.com/ros2/ros2cli/pull/454

Depends on https://github.com/ros2/launch/pull/390