### PR TITLE
Removed rmw_implementation Python dependency

### DIFF
--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -30,13 +30,15 @@ import launch_testing_ros.tools
 
 import pytest
 
-from rmw_implementation import get_available_rmw_implementations
+import ament_index_python
 
 import yaml
 
 
 @pytest.mark.rostest
-@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+@launch_testing.parametrize('rmw_implementation',
+                            {name for name in ament_index_python.get_resources('rmw_typesupport')
+                             if name != 'rmw_implementation'})
 def generate_test_description(rmw_implementation, ready_fn):
     path_to_action_server_executable = os.path.join(
         os.path.dirname(__file__), 'fixtures', 'fibonacci_action_server.py'

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -28,7 +28,7 @@ import launch_testing_ros.tools
 
 import pytest
 
-from rmw_implementation import get_available_rmw_implementations
+import ament_index_python
 
 
 ALL_LIFECYCLE_NODE_TRANSITIONS = [
@@ -111,7 +111,9 @@ ALL_LIFECYCLE_NODE_TRANSITIONS = [
 
 
 @pytest.mark.rostest
-@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+@launch_testing.parametrize('rmw_implementation',
+                            {name for name in ament_index_python.get_resources('rmw_typesupport')
+                             if name != 'rmw_implementation'})
 def generate_test_description(rmw_implementation):
     additional_env = {'RMW_IMPLEMENTATION': rmw_implementation}
     return LaunchDescription([

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -33,11 +33,13 @@ import launch_testing_ros.tools
 
 import pytest
 
-from rmw_implementation import get_available_rmw_implementations
+import ament_index_python
 
 
 @pytest.mark.rostest
-@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+@launch_testing.parametrize('rmw_implementation',
+                            {name for name in ament_index_python.get_resources('rmw_typesupport')
+                             if name != 'rmw_implementation'})
 def generate_test_description(rmw_implementation, ready_fn):
     path_to_complex_node_script = os.path.join(
         os.path.dirname(__file__), 'fixtures', 'complex_node.py'

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -33,7 +33,7 @@ import launch_testing_ros.tools
 
 import pytest
 
-from rmw_implementation import get_available_rmw_implementations
+import ament_index_python
 
 from test_msgs.srv import BasicTypes
 
@@ -55,7 +55,9 @@ def get_echo_call_output(**kwargs):
 
 
 @pytest.mark.rostest
-@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+@launch_testing.parametrize('rmw_implementation',
+                            {name for name in ament_index_python.get_resources('rmw_typesupport')
+                             if name != 'rmw_implementation'})
 def generate_test_description(rmw_implementation, ready_fn):
     path_to_echo_server_script = os.path.join(
         os.path.dirname(__file__), 'fixtures', 'echo_server.py'

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -34,11 +34,13 @@ import launch_testing_ros.tools
 
 import pytest
 
-from rmw_implementation import get_available_rmw_implementations
+import ament_index_python
 
 
 @pytest.mark.rostest
-@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+@launch_testing.parametrize('rmw_implementation',
+                            {name for name in ament_index_python.get_resources('rmw_typesupport')
+                             if name != 'rmw_implementation'})
 def generate_test_description(rmw_implementation, ready_fn):
     path_to_fixtures = os.path.join(os.path.dirname(__file__), 'fixtures')
     additional_env = {


### PR DESCRIPTION
According with this discussion https://github.com/ros2/rmw_implementation/pull/84#pullrequestreview-364451405 It makes sense to remove the Python dependency and call `ament_index_python.get_resources() where it's needed