### PR TITLE
Add warning and annotation to `ros2 node list` when there are non-unique nodes

### DIFF
--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from collections import namedtuple
+from typing import Any
+from typing import List
 
 from rclpy.action.graph import get_action_client_names_and_types_by_node
 from rclpy.action.graph import get_action_server_names_and_types_by_node
@@ -49,6 +51,11 @@ def parse_node_name(node_name):
     if namespace == '':
         namespace = '/'
     return NodeName(node_basename, namespace, full_node_name)
+
+
+def has_duplicates(values: List[Any]) -> bool:
+    """Find out if there are any exact duplicates in a list of strings."""
+    return len(set(values)) < len(values)
 
 
 def get_node_names(*, node, include_hidden_nodes=False):

--- a/ros2node/ros2node/verb/list.py
+++ b/ros2node/ros2node/verb/list.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 from ros2cli.node.strategy import add_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2node.api import get_node_names
+from ros2node.api import has_duplicates
 from ros2node.verb import VerbExtension
 
 
@@ -37,4 +40,8 @@ class ListVerb(VerbExtension):
         if args.count_nodes:
             print(len(node_names))
         elif node_names:
-            print(*sorted(n.full_name for n in node_names), sep='\n')
+            sorted_names = sorted(n.full_name for n in node_names)
+            if has_duplicates(sorted_names):
+                print('WARNING: Be aware that are nodes in the graph that share an exact name, '
+                      'this can have unintended side effects.', file=sys.stderr)
+            print(*sorted_names, sep='\n')

--- a/ros2node/test/test_node.py
+++ b/ros2node/test/test_node.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ros2node.api import has_duplicates
 from ros2node.api import parse_node_name
 
 
@@ -34,3 +35,11 @@ def test_parse_node_name():
     assert name.full_name == '/ns/talker'
     assert name.namespace == '/ns'
     assert name.name == 'talker'
+
+
+def test_has_duplicates():
+    assert not has_duplicates([])
+    assert not has_duplicates(['ns_foo/foo', 'ns_foo/bar'])
+    assert has_duplicates(['ns_foo/foo'] * 2)
+    assert has_duplicates(['ns_foo/foo'] * 3)
+    assert has_duplicates(['ns_foo/foo', 'ns_foo/foo', 'ns_foo/bar'])


### PR DESCRIPTION
First half of https://github.com/ros2/ros2cli/issues/453 
First half of https://github.com/ros-tooling/aws-roadmap/issues/196

Add a simple warning, and annotate which nodes it applies to, when `ros2 node list` lists multiple nodes with the same exact name.  Within the "request for design" discussion https://github.com/ros2/design/issues/187, there was confusion expressed about where multiple names come from, whether they are artifacts of the printing process. This at least clears that up a little bit -it does not change the functionality at all.