### PR TITLE
Avoid using ros_testing, and use launch_testing instead

### DIFF
--- a/ros2action/package.xml
+++ b/ros2action/package.xml
@@ -23,7 +23,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -35,7 +35,7 @@ from rclpy.utilities import get_available_rmw_implementations
 import yaml
 
 
-@pytest.mark.rostest
+@pytest.mark.launch_test
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation, ready_fn):
     path_to_action_server_executable = os.path.join(

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -20,7 +20,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/ros2doctor/test/test_hello.py
+++ b/ros2doctor/test/test_hello.py
@@ -26,7 +26,7 @@ from ros2doctor.verb.hello import HelloVerb
 from ros2doctor.verb.hello import SummaryTable
 
 
-@pytest.mark.rostest
+@pytest.mark.launch_test
 @launch_testing.markers.keep_alive
 def generate_test_description():
     return LaunchDescription([

--- a/ros2interface/package.xml
+++ b/ros2interface/package.xml
@@ -19,7 +19,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>test_msgs</test_depend>

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -52,7 +52,7 @@ some_interfaces = (
 )
 
 
-@pytest.mark.rostest
+@pytest.mark.launch_test
 @launch_testing.markers.keep_alive
 def generate_test_description(ready_fn):
     return LaunchDescription([OpaqueFunction(function=lambda context: ready_fn())])

--- a/ros2lifecycle/package.xml
+++ b/ros2lifecycle/package.xml
@@ -21,7 +21,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>ros2lifecycle_test_fixtures</test_depend>
 
   <export>

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -110,7 +110,7 @@ ALL_LIFECYCLE_NODE_TRANSITIONS = [
 ]
 
 
-@pytest.mark.rostest
+@pytest.mark.launch_test
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation):
     additional_env = {'RMW_IMPLEMENTATION': rmw_implementation}

--- a/ros2node/package.xml
+++ b/ros2node/package.xml
@@ -17,7 +17,7 @@
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rclpy</test_depend>
-  <test_depend>ros_testing</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -36,7 +36,7 @@ import pytest
 from rclpy.utilities import get_available_rmw_implementations
 
 
-@pytest.mark.rostest
+@pytest.mark.launch_test
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation, ready_fn):
     path_to_complex_node_script = os.path.join(

--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -21,7 +21,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
+  <test_depend>launch_testing</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2pkg/test/test_cli.py
+++ b/ros2pkg/test/test_cli.py
@@ -36,7 +36,7 @@ some_cli_packages = [
 ]
 
 
-@pytest.mark.rostest
+@pytest.mark.launch_test
 @launch_testing.markers.keep_alive
 def generate_test_description(ready_fn):
     return LaunchDescription([OpaqueFunction(function=lambda context: ready_fn())])

--- a/ros2service/package.xml
+++ b/ros2service/package.xml
@@ -20,7 +20,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -54,7 +54,7 @@ def get_echo_call_output(**kwargs):
     ]
 
 
-@pytest.mark.rostest
+@pytest.mark.launch_test
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation, ready_fn):
     path_to_echo_server_script = os.path.join(

--- a/ros2topic/package.xml
+++ b/ros2topic/package.xml
@@ -23,7 +23,7 @@
   <test_depend>ament_xmllint</test_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
 

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -37,7 +37,7 @@ import pytest
 from rclpy.utilities import get_available_rmw_implementations
 
 
-@pytest.mark.rostest
+@pytest.mark.launch_test
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation, ready_fn):
     path_to_fixtures = os.path.join(os.path.dirname(__file__), 'fixtures')


### PR DESCRIPTION
I figured out why I have some unexpected errors in https://github.com/ros2/rmw_fastrtps/pull/312.
`launch_testing_ros` default launch description, creates a node that we weren't used. That node was created without specifying an rmw implementation, so `fastrtps` was used, and created problems when running `connext` tests.

Some of the failures were because:
- Discovery works different in the mentioned PR, and were expected to fail if nodes of different vendors were running and the same time.
- Connext printing
  ```
  PRESCstReaderCollator_storeSampleData:deserialize sample error in topic 'DISCParticipant' with type 'DISCParticipantParameter'
  ```
  That was only reproducible when using `Fast-RTPS` 1.9.x, and not 1.9.3.

I will merge this PR independently of `https://github.com/ros2/rmw_fastrtps/pull/312`, as the tests should continue working in `master` too.