### PR TITLE
Add /usr/lib/<pkg> and /usr/libexec/<pkg> to search paths

### DIFF
--- a/ros2pkg/ros2pkg/api/__init__.py
+++ b/ros2pkg/ros2pkg/api/__init__.py
@@ -41,17 +41,22 @@ def get_executable_paths(*, package_name):
     prefix_path = get_prefix_path(package_name)
     if prefix_path is None:
         raise PackageNotFound(package_name)
-    base_path = os.path.join(prefix_path, 'lib', package_name)
+    base_paths = [
+        os.path.join(prefix_path, 'lib', package_name),
+        os.path.join(prefix_path, 'usr', 'lib', package_name),
+        os.path.join(prefix_path, 'usr', 'libexec', package_name),
+    ]
     executable_paths = []
-    for dirpath, dirnames, filenames in os.walk(base_path):
-        # ignore folder starting with .
-        dirnames[:] = [d for d in dirnames if d[0] not in ['.']]
-        dirnames.sort()
-        # select executable files
-        for filename in sorted(filenames):
-            path = os.path.join(dirpath, filename)
-            if os.access(path, os.X_OK):
-                executable_paths.append(path)
+    for base_path in base_paths:
+        for dirpath, dirnames, filenames in os.walk(base_path):
+            # ignore folder starting with .
+            dirnames[:] = [d for d in dirnames if d[0] not in ['.']]
+            dirnames.sort()
+            # select executable files
+            for filename in sorted(filenames):
+                path = os.path.join(dirpath, filename)
+                if os.access(path, os.X_OK):
+                    executable_paths.append(path)
     return executable_paths
 
 


### PR DESCRIPTION
This is a proposal following https://github.com/ros2/ci/issues/400#issuecomment-601319086. This PR adds `<ws>/usr/lib/<pkg>` and `<ws>/usr/libexec/<pkg>` to the search paths used by `ros2 run` to comply with the [Linux Filesystem Hierarchy Standard](https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.pdf#[{%22num%22%3A242%2C%22gen%22%3A0}%2C{%22name%22%3A%22XYZ%22}%2C72%2C720%2Cnull]). It looks like the current practice of `<ws>/lib/<pkg>` doesn't match, but I left that in to make this be an enhancement rather than a disruptive change.