### PR TITLE
[ros2topic] Make info format for subscriptions consistent with publishers

### DIFF
--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -61,7 +61,7 @@ class InfoVerb(VerbExtension):
                 except NotImplementedError as e:
                     return str(e)
 
-            print('Subscription count: %d' % node.count_subscribers(topic_name))
+            print('Subscription count: %d' % node.count_subscribers(topic_name), end=line_end)
             if args.verbose:
                 try:
                     for info in node.get_subscriptions_info_by_topic(topic_name):


### PR DESCRIPTION
Example of output before:

```
$ ros2 topic info /mycamera/left/image_filtered --verbose
Type: sensor_msgs/msg/Image

Publisher count: 1

Node name: image_filter_left
Node namespace: /mycamera/left
Topic type: sensor_msgs/msg/Image
Endpoint type: PUBLISHER
GID: 01.0f.35.00.57.7f.00.00.01.00.00.00.00.00.10.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RMW_QOS_POLICY_RELIABILITY_RELIABLE
  Durability: RMW_QOS_POLICY_DURABILITY_VOLATILE
  Lifespan: 2147483651294967295 nanoseconds
  Deadline: 2147483651294967295 nanoseconds
  Liveliness: RMW_QOS_POLICY_LIVELINESS_AUTOMATIC
  Liveliness lease duration: 2147483651294967295 nanoseconds

Subscription count: 1
Node name: disparity_node
Node namespace: /mycamera
Topic type: sensor_msgs/msg/Image
Endpoint type: SUBSCRIPTION
GID: 01.0f.35.00.59.7f.00.00.02.00.00.00.00.00.11.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RMW_QOS_POLICY_RELIABILITY_RELIABLE
  Durability: RMW_QOS_POLICY_DURABILITY_VOLATILE
  Lifespan: 2147483651294967295 nanoseconds
  Deadline: 2147483651294967295 nanoseconds
  Liveliness: RMW_QOS_POLICY_LIVELINESS_AUTOMATIC
  Liveliness lease duration: 2147483651294967295 nanoseconds
```

This change adds an extra line break after "Subscription count: X".

```diff
- Subscription count: 1
- Node name: disparity_node
+ Subscription count: 1
+
+ Node name: disparity_node
```