### PR TITLE
[ros2doctor] Only report topic warnings if publisher or subscription count is zero

### DIFF
--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -49,10 +49,10 @@ class TopicCheck(DoctorCheck):
             for topic in to_be_checked:
                 pub_count = node.count_publishers(topic)
                 sub_count = node.count_subscribers(topic)
-                if pub_count > sub_count:
+                if pub_count > 0 and sub_count == 0:
                     doctor_warn(f'Publisher without subscriber detected on {topic}.')
                     result.add_warning()
-                elif pub_count < sub_count:
+                elif sub_count > 0 and pub_count == 0:
                     doctor_warn(f'Subscriber without publisher detected on {topic}.')
                     result.add_warning()
         return result


### PR DESCRIPTION
Before the tool was generating many false positives as it is a valid configuration
to have an unequal number of publishers and subscriptions on a given topic.

This change makes it so we only provide a warning if one of the counts is zero and the
other is not. Although this is still a legitimate configuration, it seems more likely to be
a problem and worth reporting.