### PR TITLE
Fix formatting of "ros2 topic info -v" output

### DIFF
--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -61,7 +61,7 @@ class InfoVerb(VerbExtension):
                 except NotImplementedError as e:
                     return str(e)
 
-            print('Subscription count: %d' % node.count_subscribers(topic_name))
+            print('Subscription count: %d' % node.count_subscribers(topic_name), end=line_end)
             if args.verbose:
                 try:
                     for info in node.get_subscriptions_info_by_topic(topic_name):

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -294,7 +294,8 @@ class TestROS2TopicCLI(unittest.TestCase):
                 re.compile(r'  Liveliness: RMW_QOS_POLICY_LIVELINESS_\w+'),
                 re.compile(r'  Liveliness lease duration: \d+ nanoseconds'),
                 '',
-                'Subscription count: 0'
+                'Subscription count: 0',
+                ''
             ],
             text=topic_command.output,
             strict=True


### PR DESCRIPTION
Currently when `ros2 topic info` is used in verbose mode, there is a vertical space between the "Publisher count: x" heading and the list of publishers below it. That vertical space is missing for the "Subscription count: x" heading and the list of subscriptions below it.

This pull request adds that vertical spacing to the subscriptions listing, so that it is consistent with the publishers listing.