### PR TITLE
Update tests to expect no launch_ros node

### DIFF
--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -139,8 +139,8 @@ class TestROS2NodeCLI(unittest.TestCase):
         assert node_command.exit_code == launch_testing.asserts.EXIT_OK
         output_lines = node_command.output.splitlines()
         assert len(output_lines) == 1
-        # Fixture nodes that are not hidden plus launch_ros node.
-        assert int(output_lines[0]) == 2
+        # Fixture nodes that are not hidden.
+        assert int(output_lines[0]) == 1
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_all_nodes_count(self):
@@ -149,8 +149,8 @@ class TestROS2NodeCLI(unittest.TestCase):
         assert node_command.exit_code == launch_testing.asserts.EXIT_OK
         output_lines = node_command.output.splitlines()
         assert len(output_lines) == 1
-        # All fixture nodes plus launch_ros and ros2cli daemon nodes.
-        assert int(output_lines[0]) == 4
+        # All fixture nodes plus ros2cli daemon node.
+        assert int(output_lines[0]) == 3
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_info_node(self):

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -192,7 +192,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
         assert service_command.exit_code == launch_testing.asserts.EXIT_OK
         output_lines = service_command.output.splitlines()
         assert len(output_lines) == 1
-        assert int(output_lines[0]) == 7 + 6  # cope with launch_ros internal node.
+        assert int(output_lines[0]) == 7
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_find(self):


### PR DESCRIPTION
This updates tests in ros2service and ros2node to expect no launch_ros node. These tests have [been failing since March 18](http://build.ros2.org/view/Fci/job/Fci__nightly-fastrtps_ubuntu_focal_amd64/61) and failed last night on [nightly release](http://build.ros2.org/view/Fci/job/Fci__nightly-release_ubuntu_focal_amd64/), [nightly debug](http://build.ros2.org/view/Fci/job/Fci__nightly-debug_ubuntu_focal_amd64/), [nightly connext](http://build.ros2.org/view/Fci/job/Fci__nightly-connext_ubuntu_focal_amd64/), [nightly cyclone](http://build.ros2.org/view/Fci/job/Fci__nightly-cyclonedds_ubuntu_focal_amd64/), [nightly fastrtps](http://build.ros2.org/view/Fci/job/Fci__nightly-fastrtps_ubuntu_focal_amd64/),  and [nightly fastrtps dynamic](http://build.ros2.org/view/Fci/job/Fci__nightly-fastrtps-dynamic_ubuntu_focal_amd64/).


I think ros2/launch_ros#128 might have removed an implicit launch_ros node. @hidmic does that explanation make sense? Is updating the test expectations here the right thing to do?