### PR TITLE
Use local git config instead of global for email

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -94,7 +94,7 @@ class CreateVerb(VerbExtension):
             git = shutil.which('git')
             if git is not None:
                 p = subprocess.Popen(
-                    [git, 'config', '--global', 'user.email'],
+                    [git, 'config', 'user.email'],
                     stdout=subprocess.PIPE)
                 resp = p.communicate()
                 email = resp[0].decode().rstrip()


### PR DESCRIPTION
Use the local git configuration when querying the `user.email` key instead of
the global configuration. Fixes #477

Signed-off-by: Thibaud Chupin <thibaud.chupin@spaceapplications.com>