### PR TITLE
[ros2param] Wait for discovery before running tests

### DIFF
--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -85,6 +85,7 @@ class TestVerbDump(unittest.TestCase):
     def setUp(self):
         # Ensure the daemon node is running and discovers the test node
         start_time = time.time()
+        timed_out = True
         with NodeStrategy(None) as node:
             while (time.time() - start_time) < TEST_TIMEOUT:
                 # TODO(jacobperron): Create a generic 'CliNodeError' so we can treat errors
@@ -103,10 +104,9 @@ class TestVerbDump(unittest.TestCase):
                     len(service_names) > 0
                     and f'{TEST_NAMESPACE}/{TEST_NODE}/get_parameters' in service_names
                 ):
-                    break
-        delta = time.time() - start_time
-        if delta >= TEST_TIMEOUT:
-            self.fail(f'CLI daemon failed to find test node after {delta} seconds')
+                    timed_out = False
+        if timed_out:
+            self.fail(f'CLI daemon failed to find test node after {TEST_TIMEOUT} seconds')
 
     def _output_file(self):
 


### PR DESCRIPTION
Fixes #480.

Catch expected exceptions from rclpy (or transitively as xmlrpc.client.Fault) while we wait for discovery in the test setup.