### PR TITLE
[ros2param] Do not wait for entire timeout in test_verb_dump setUp

### DIFF
--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -105,6 +105,7 @@ class TestVerbDump(unittest.TestCase):
                     and f'{TEST_NAMESPACE}/{TEST_NODE}/get_parameters' in service_names
                 ):
                     timed_out = False
+                    break
         if timed_out:
             self.fail(f'CLI daemon failed to find test node after {TEST_TIMEOUT} seconds')
 


### PR DESCRIPTION
Follow-up to #481

This makes the tests faster.