### PR TITLE
Replace deprecated launch_ros usage

### DIFF
--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -127,14 +127,14 @@ def generate_test_description(rmw_implementation):
                         # Add test fixture actions.
                         Node(
                             package='ros2lifecycle_test_fixtures',
-                            node_executable='simple_lifecycle_node',
+                            executable='simple_lifecycle_node',
                             node_name='test_lifecycle_node',
                             output='screen',
                             additional_env=additional_env
                         ),
                         Node(
                             package='ros2lifecycle_test_fixtures',
-                            node_executable='simple_lifecycle_node',
+                            executable='simple_lifecycle_node',
                             node_name='_hidden_test_lifecycle_node',
                             output='screen',
                             additional_env=additional_env

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -55,13 +55,13 @@ def generate_test_description(rmw_implementation):
                     on_exit=[
                         # Add test fixture actions.
                         Node(
-                            node_executable=sys.executable,
+                            executable=sys.executable,
                             arguments=[path_to_complex_node_script],
                             node_name='complex_node',
                             additional_env=additional_env
                         ),
                         Node(
-                            node_executable=sys.executable,
+                            executable=sys.executable,
                             arguments=[path_to_complex_node_script],
                             node_name='_hidden_complex_node',
                             additional_env=additional_env

--- a/ros2node/test/test_cli_duplicate_node_names.py
+++ b/ros2node/test/test_cli_duplicate_node_names.py
@@ -54,19 +54,19 @@ def generate_test_description(rmw_implementation, ready_fn):
                     on_exit=[
                         # Add test fixture actions.
                         Node(
-                            node_executable=sys.executable,
+                            executable=sys.executable,
                             arguments=[path_to_complex_node_script],
                             node_name='complex_node',
                             additional_env=additional_env,
                         ),
                         Node(
-                            node_executable=sys.executable,
+                            executable=sys.executable,
                             arguments=[path_to_complex_node_script],
                             node_name='complex_node',
                             additional_env=additional_env,
                         ),
                         Node(
-                            node_executable=sys.executable,
+                            executable=sys.executable,
                             arguments=[path_to_complex_node_script],
                             node_name='complex_node_2',
                             additional_env=additional_env,

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -73,14 +73,14 @@ def generate_test_description(rmw_implementation):
                     on_exit=[
                         # Add test fixture actions.
                         Node(
-                            node_executable=sys.executable,
+                            executable=sys.executable,
                             arguments=[path_to_echo_server_script],
                             node_name='echo_server',
                             node_namespace='my_ns',
                             additional_env=additional_env,
                         ),
                         Node(
-                            node_executable=sys.executable,
+                            executable=sys.executable,
                             arguments=[path_to_echo_server_script],
                             node_name='_hidden_echo_server',
                             node_namespace='my_ns',

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -49,18 +49,18 @@ def generate_test_description(rmw_implementation):
     path_to_listener_node_script = os.path.join(path_to_fixtures, 'listener_node.py')
 
     hidden_talker_node_action = Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[path_to_talker_node_script],
         remappings=[('chatter', '_hidden_chatter')],
         additional_env=additional_env
     )
     talker_node_action = Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[path_to_talker_node_script],
         additional_env=additional_env
     )
     listener_node_action = Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[path_to_listener_node_script],
         remappings=[('chatter', 'chit_chatter')],
         additional_env=additional_env
@@ -69,7 +69,7 @@ def generate_test_description(rmw_implementation):
     path_to_repeater_node_script = os.path.join(path_to_fixtures, 'repeater_node.py')
 
     array_repeater_node_action = Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[path_to_repeater_node_script, 'test_msgs/msg/Arrays'],
         node_name='array_repeater',
         remappings=[('/array_repeater/output', '/arrays')],
@@ -77,14 +77,14 @@ def generate_test_description(rmw_implementation):
         additional_env=additional_env
     )
     defaults_repeater_node_action = Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[path_to_repeater_node_script, 'test_msgs/msg/Defaults'],
         node_name='defaults_repeater',
         remappings=[('/defaults_repeater/output', '/defaults')],
         additional_env=additional_env,
     )
     bounded_sequences_repeater_node_action = Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[
             path_to_repeater_node_script, 'test_msgs/msg/BoundedSequences'
         ],
@@ -93,7 +93,7 @@ def generate_test_description(rmw_implementation):
         additional_env=additional_env
     )
     unbounded_sequences_repeater_node_action = Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[
             path_to_repeater_node_script, 'test_msgs/msg/UnboundedSequences'
         ],
@@ -105,7 +105,7 @@ def generate_test_description(rmw_implementation):
     path_to_controller_node_script = os.path.join(path_to_fixtures, 'controller_node.py')
 
     cmd_vel_controller_node_action = Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[path_to_controller_node_script],
         additional_env=additional_env
     )


### PR DESCRIPTION
The Node parameter 'node_executable' has been deprecated and replaced
with the parameter 'executable'.

Depends on https://github.com/ros2/launch_ros/pull/140