### PR TITLE
Skip CLI tests on Windows until we resolve the blocking/hanging isuse.

### DIFF
--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -35,6 +35,14 @@ from rclpy.utilities import get_available_rmw_implementations
 import yaml
 
 
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
+
+
 @pytest.mark.rostest
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation):

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -15,6 +15,7 @@
 import contextlib
 import itertools
 import re
+import sys
 import unittest
 
 from launch import LaunchDescription
@@ -27,6 +28,14 @@ import launch_testing.markers
 import launch_testing.tools
 
 import pytest
+
+
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
 
 
 some_messages_from_std_msgs = [

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import sys
 import unittest
 
 from launch import LaunchDescription
@@ -29,6 +30,14 @@ import launch_testing_ros.tools
 import pytest
 
 from rclpy.utilities import get_available_rmw_implementations
+
+
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
 
 
 ALL_LIFECYCLE_NODE_TRANSITIONS = [

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -36,6 +36,14 @@ import pytest
 from rclpy.utilities import get_available_rmw_implementations
 
 
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
+
+
 @pytest.mark.rostest
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation):

--- a/ros2node/test/test_cli_duplicate_node_names.py
+++ b/ros2node/test/test_cli_duplicate_node_names.py
@@ -35,6 +35,14 @@ from rclpy.utilities import get_available_rmw_implementations
 from ros2node.api import INFO_NONUNIQUE_WARNING_TEMPLATE
 
 
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
+
+
 @pytest.mark.rostest
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation, ready_fn):

--- a/ros2pkg/test/test_cli.py
+++ b/ros2pkg/test/test_cli.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import os
+import sys
 import tempfile
 import unittest
 import xml.etree.ElementTree as ET
@@ -28,6 +29,14 @@ import launch_testing.markers
 import launch_testing.tools
 
 import pytest
+
+
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
 
 
 some_cli_packages = [

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -38,6 +38,14 @@ from rclpy.utilities import get_available_rmw_implementations
 from test_msgs.srv import BasicTypes
 
 
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
+
+
 def get_echo_call_output(**kwargs):
     request = BasicTypes.Request()
     for field_name, field_value in kwargs.items():

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -37,6 +37,14 @@ import pytest
 from rclpy.utilities import get_available_rmw_implementations
 
 
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
+
+
 @pytest.mark.rostest
 @launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
 def generate_test_description(rmw_implementation):

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import unittest
 
 from launch import LaunchDescription
@@ -34,6 +35,14 @@ from rclpy.qos import ReliabilityPolicy
 from rclpy.utilities import get_rmw_implementation_identifier
 
 from std_msgs.msg import String
+
+
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
 
 
 TEST_NODE = 'cli_echo_pub_test_node'


### PR DESCRIPTION
We've been lacking on Windows test data for months due to the blocking
or hung state that these tests can get into. I think the best thing to
do is skip these tests on windows to allow other builds to complete
while we continue investigating the problem.

I've opted for skipping entire test modules as I think the underlying issue is in the test apparatus rather than any specific test.