### PR TITLE
Implement times for ros2 topic pub

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -40,7 +40,7 @@ def nonnegative_int(inval):
     ret = int(inval)
     if ret < 0:
         # The error message here gets completely swallowed by argparse
-        raise ValueError('Value must be positive')
+        raise ValueError('Value must be positive or zero')
     return ret
 
 

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -93,9 +93,6 @@ class PubVerb(VerbExtension):
             parser, is_publisher=True, default_preset='system_default')
 
     def main(self, *, args):
-        if args.once and args.times > 0:
-            raise RuntimeError('Cannot pass both -1 and -t <times>')
-
         return main(args)
 
 

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -36,6 +36,22 @@ import yaml
 MsgType = TypeVar('MsgType')
 
 
+def positive_int(inval):
+    ret = int(inval)
+    if ret < 0:
+        # The error message here gets completely swallowed by argparse
+        raise ValueError('Value must be positive')
+    return ret
+
+
+def positive_float(inval):
+    ret = float(inval)
+    if ret <= 0.0:
+        # The error message here gets completely swallowed by argparse
+        raise ValueError('Value must be positive')
+    return ret
+
+
 class PubVerb(VerbExtension):
     """Publish a message to a topic."""
 
@@ -58,7 +74,7 @@ class PubVerb(VerbExtension):
         arg.completer = TopicMessagePrototypeCompleter(
             topic_type_key='message_type')
         parser.add_argument(
-            '-r', '--rate', metavar='N', type=float, default=1.0,
+            '-r', '--rate', metavar='N', type=positive_float, default=1.0,
             help='Publishing rate in Hz (default: 1)')
         parser.add_argument(
             '-p', '--print', metavar='N', type=int, default=1,
@@ -70,15 +86,12 @@ class PubVerb(VerbExtension):
             '-n', '--node-name',
             help='Name of the created publishing node')
         parser.add_argument(
-            '-t', '--times', type=int, default=0,
+            '-t', '--times', type=positive_int, default=0,
             help='Publish this number of times and then exit')
         add_qos_arguments_to_argument_parser(
             parser, is_publisher=True, default_preset='system_default')
 
     def main(self, *, args):
-        if args.rate <= 0:
-            raise RuntimeError('rate must be greater than zero')
-
         if args.once and args.times > 0:
             raise RuntimeError('Cannot pass both -1 and -t <times>')
 

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -36,7 +36,7 @@ import yaml
 MsgType = TypeVar('MsgType')
 
 
-def positive_int(inval):
+def nonnegative_int(inval):
     ret = int(inval)
     if ret < 0:
         # The error message here gets completely swallowed by argparse
@@ -79,15 +79,16 @@ class PubVerb(VerbExtension):
         parser.add_argument(
             '-p', '--print', metavar='N', type=int, default=1,
             help='Only print every N-th published message (default: 1)')
-        parser.add_argument(
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
             '-1', '--once', action='store_true',
             help='Publish one message and exit')
+        group.add_argument(
+            '-t', '--times', type=nonnegative_int, default=0,
+            help='Publish this number of times and then exit')
         parser.add_argument(
             '-n', '--node-name',
             help='Name of the created publishing node')
-        parser.add_argument(
-            '-t', '--times', type=positive_int, default=0,
-            help='Publish this number of times and then exit')
         add_qos_arguments_to_argument_parser(
             parser, is_publisher=True, default_preset='system_default')
 


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

While doing some testing, it turned out to be useful to tell `ros2 topic pub` exactly how many times to publish a message.  This is basically a generic version of the `-1` flag that already exists, though that flag is left for backwards-compatibility.

I should point out that this is *not* the same as doing `for i in seq 1 10 ; do ros2 topic pub ... ; done`.  The difference is that with the bash loop, a new node and publisher is created every time.  This can be problematic for discovery, since it can happen that we bring up the node, publish, and destroy the node before connections are properly made.  Doing it inside of `ros2 topic pub` itself neatly avoids this issue.

The one potentially flaky part of this is the test, which expects *exactly* 5 messages to be published.  Depending on the platform and load, that may not be a reasonable assumption.  Thoughts on how to improve that, while still testing that we are publishing a fixed number of times, are appreciated.