### PR TITLE
Extend CLI daemon's API

### DIFF
--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -17,6 +17,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>test_msgs</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -17,8 +17,8 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
-  <test_depend>test_msgs</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>test_msgs</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -25,7 +25,8 @@ import rclpy.action
 
 from ros2cli.node.direct import DirectNode
 
-import ros2cli.xmlrpc
+from ros2cli.xmlrpc.local_server import LocalXMLRPCServer
+from ros2cli.xmlrpc.local_server import RequestHandler
 
 
 def main(*, script_name='_ros2_daemon', argv=None):
@@ -55,9 +56,9 @@ def main(*, script_name='_ros2_daemon', argv=None):
         node_name_suffix='_daemon_%d' % args.ros_domain_id,
         start_parameter_services=False)
     with NetworkAwareNode(node_args) as node:
-        server = ros2cli.xmlrpc.local_server.LocalXMLRPCServer(
+        server = LocalXMLRPCServer(
             addr, logRequests=False,
-            requestHandler=ros2cli.xmlrpc.local_server.RequestHandler,
+            requestHandler=RequestHandler,
             allow_none=True)
 
         try:

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -24,7 +24,8 @@ import rclpy
 from ros2cli.daemon import get_daemon_port
 from ros2cli.node.direct import DirectNode
 
-import ros2cli.xmlrpc
+from ros2cli.xmlrpc.client import ProtocolError
+from ros2cli.xmlrpc.client import ServerProxy
 
 
 def is_daemon_running(args):
@@ -100,7 +101,7 @@ class DaemonNode:
 
     def __init__(self, args):
         self._args = args
-        self._proxy = ros2cli.xmlrpc.client.ServerProxy(
+        self._proxy = ServerProxy(
             'http://localhost:%d/ros2cli/' % get_daemon_port(),
             allow_none=True)
         self._methods = []
@@ -110,7 +111,7 @@ class DaemonNode:
 
         try:
             methods = self._proxy.system.listMethods()
-        except ros2cli.xmlrpc.client.ProtocolError as e:
+        except ProtocolError as e:
             if e.errcode != 404:
                 raise
             # remote daemon returned 404, likely using different rmw impl.

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -19,12 +19,12 @@ import socket
 import subprocess
 import sys
 import time
-from xmlrpc.client import ProtocolError
-from xmlrpc.client import ServerProxy
 
 import rclpy
 from ros2cli.daemon import get_daemon_port
 from ros2cli.node.direct import DirectNode
+
+import ros2cli.xmlrpc
 
 
 def is_daemon_running(args):
@@ -100,7 +100,7 @@ class DaemonNode:
 
     def __init__(self, args):
         self._args = args
-        self._proxy = ServerProxy(
+        self._proxy = ros2cli.xmlrpc.client.ServerProxy(
             'http://localhost:%d/ros2cli/' % get_daemon_port(),
             allow_none=True)
         self._methods = []
@@ -110,7 +110,7 @@ class DaemonNode:
 
         try:
             methods = self._proxy.system.listMethods()
-        except ProtocolError as e:
+        except ros2cli.xmlrpc.client.ProtocolError as e:
             if e.errcode != 404:
                 raise
             # remote daemon returned 404, likely using different rmw impl.

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -15,6 +15,7 @@
 import os
 
 import rclpy
+import rclpy.action
 
 from ros2cli.node import NODE_NAME_PREFIX
 DEFAULT_TIMEOUT = 0.5
@@ -54,6 +55,20 @@ class DirectNode:
 
     def __enter__(self):
         return self
+
+    # TODO(hidmic): generalize/standardize rclpy graph API
+    #               to not have to make a special case for
+    #               rclpy.action
+    def get_action_names_and_types(self):
+        return rclpy.action.get_action_names_and_types(self.node)
+
+    def get_action_client_names_and_types_by_node(self, remote_node_name, remote_node_namespace):
+        return rclpy.action.get_action_client_names_and_types_by_node(
+            self.node, remote_node_name, remote_node_namespace)
+
+    def get_action_server_names_and_types_by_node(self, remote_node_name, remote_node_namespace):
+        return rclpy.action.get_action_server_names_and_types_by_node(
+            self.node, remote_node_name, remote_node_namespace)
 
     def __getattr__(self, name):
         if not rclpy.ok():

--- a/ros2cli/ros2cli/node/strategy.py
+++ b/ros2cli/ros2cli/node/strategy.py
@@ -36,7 +36,7 @@ class NodeStrategy:
         return self
 
     def __getattr__(self, name):
-        return self.node.__getattr__(name)
+        return getattr(self.node, name)
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.node.__exit__(exc_type, exc_value, traceback)

--- a/ros2cli/ros2cli/xmlrpc/__init__.py
+++ b/ros2cli/ros2cli/xmlrpc/__init__.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import xmlrpc.client as client
-
+# Ensure client code uses ros2cli.xmlrpc only
+from . import client
 from . import local_server
+
+# Force custom xmlrpc (un)marshalling logic importation.
 from . import marshal
 
 

--- a/ros2cli/ros2cli/xmlrpc/__init__.py
+++ b/ros2cli/ros2cli/xmlrpc/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import xmlrpc.client as client
+
+from . import local_server
+from . import marshal
+
+
+__all__ = [
+    'client',
+    'local_server',
+    'marshal'
+]

--- a/ros2cli/ros2cli/xmlrpc/__init__.py
+++ b/ros2cli/ros2cli/xmlrpc/__init__.py
@@ -12,16 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Ensure client code uses ros2cli.xmlrpc only
-from . import client
-from . import local_server
-
 # Force custom xmlrpc (un)marshalling logic importation.
-from . import marshal
-
-
-__all__ = [
-    'client',
-    'local_server',
-    'marshal'
-]
+from . import marshal  # noqa: F401

--- a/ros2cli/ros2cli/xmlrpc/client.py
+++ b/ros2cli/ros2cli/xmlrpc/client.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Force custom xmlrpc (un)marshalling logic importation.
-from . import generic
-from . import rclpy
+# Alias xmlrpc.client module objects to ensure client code uses ros2cli.xmlrpc
+from xmlrpc.client import ProtocolError
+from xmlrpc.client import ServerProxy
 
 
 __all__ = [
-    'generic',
-    'rclpy'
+    'ProtocolError',
+    'ServerProxy'
 ]

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -1,0 +1,28 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from xmlrpc.server import SimpleXMLRPCRequestHandler
+from xmlrpc.server import SimpleXMLRPCServer
+
+
+class LocalXMLRPCServer(SimpleXMLRPCServer):
+
+    def verify_request(self, request, client_address):
+        if client_address[0] != '127.0.0.1':
+            return False
+        return super(LocalXMLRPCServer, self).verify_request(request, client_address)
+
+
+class RequestHandler(SimpleXMLRPCRequestHandler):
+    rpc_paths = ('/ros2cli/',)

--- a/ros2cli/ros2cli/xmlrpc/marshal/__init__.py
+++ b/ros2cli/ros2cli/xmlrpc/marshal/__init__.py
@@ -12,12 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Force custom xmlrpc (un)marshalling logic importation.
-from . import generic
-from . import rclpy
-
-
-__all__ = [
-    'generic',
-    'rclpy'
-]
+# Force rclpy specific xmlrpc (un)marshalling logic importation.
+from . import rclpy  # noqa: F401

--- a/ros2cli/ros2cli/xmlrpc/marshal/__init__.py
+++ b/ros2cli/ros2cli/xmlrpc/marshal/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import generic
+from . import rclpy
+
+
+__all__ = [
+    'generic',
+    'rclpy'
+]

--- a/ros2cli/ros2cli/xmlrpc/marshal/generic.py
+++ b/ros2cli/ros2cli/xmlrpc/marshal/generic.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def fullname(klass):
+    return f'{klass.__module__}.{klass.__name__}'
+
+
+def end_any_with_slots(unmarshaller, data, type_):
+    unmarshaller._stack[-1] = type_(**unmarshaller._stack[-1])
+    unmarshaller._value = 0
+
+
+def dump_any_with_slots(marshaller, value, write, transform=None):
+    write(f'<value><{fullname(type(value))}>')
+    slots = value.__slots__
+    if transform is not None:
+        slots = map(transform, slots)
+    marshaller.dump_struct({name: getattr(value, name) for name in slots}, write)
+    write(f'</{fullname(type(value))}></value>')
+
+
+def end_any_enum(unmarshaller, data, enum_):
+    unmarshaller.append(enum_(int(data)))
+    unmarshaller._value = 0
+
+
+def dump_any_enum(marshaller, value, write):
+    write(f'<value><{fullname(type(value))}>')
+    write(str(value.value))
+    write(f'</{fullname(type(value))}></value>')

--- a/ros2cli/ros2cli/xmlrpc/marshal/rclpy.py
+++ b/ros2cli/ros2cli/xmlrpc/marshal/rclpy.py
@@ -1,0 +1,77 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from xmlrpc.client import Marshaller
+from xmlrpc.client import Unmarshaller
+
+import rclpy.duration
+import rclpy.qos
+import rclpy.topic_endpoint_info
+
+from .generic import dump_any_enum
+from .generic import dump_any_with_slots
+from .generic import end_any_enum
+from .generic import end_any_with_slots
+from .generic import fullname
+
+
+def end_duration(unmarshaller, data):
+    unmarshaller.append(
+        rclpy.duration.Duration(nanoseconds=int(data))
+    )
+    unmarshaller._value = 0
+
+
+def dump_duration(marshaller, value, write):
+    write(f'<value><{fullname(type(value))}>')
+    write(str(value.nanoseconds))
+    write(f'</{fullname(type(value))}></value>')
+
+
+Unmarshaller.dispatch[fullname(rclpy.duration.Duration)] = end_duration
+Marshaller.dispatch[rclpy.duration.Duration] = dump_duration
+
+
+Unmarshaller.dispatch[fullname(rclpy.qos.QoSProfile)] = functools.partial(
+    end_any_with_slots, type_=rclpy.qos.QoSProfile
+)
+Marshaller.dispatch[rclpy.qos.QoSProfile] = functools.partial(
+    dump_any_with_slots, transform=lambda slot: slot.lstrip('_')
+)
+
+policy_types = (
+    rclpy.qos.HistoryPolicy,
+    rclpy.qos.ReliabilityPolicy,
+    rclpy.qos.DurabilityPolicy,
+    rclpy.qos.LivelinessPolicy
+)
+
+for enum_type in policy_types:
+    Unmarshaller.dispatch[fullname(enum_type)] = \
+        functools.partial(end_any_enum, enum_=enum_type)
+
+    Marshaller.dispatch[enum_type] = dump_any_enum
+
+
+Unmarshaller.dispatch[fullname(rclpy.topic_endpoint_info.TopicEndpointInfo)] = \
+    functools.partial(end_any_with_slots, type_=rclpy.topic_endpoint_info.TopicEndpointInfo)
+
+Marshaller.dispatch[rclpy.topic_endpoint_info.TopicEndpointInfo] = \
+    functools.partial(dump_any_with_slots, transform=lambda slot: slot.lstrip('_'))
+
+Unmarshaller.dispatch[fullname(rclpy.topic_endpoint_info.TopicEndpointTypeEnum)] = \
+    functools.partial(end_any_enum, enum_=rclpy.topic_endpoint_info.TopicEndpointTypeEnum)
+
+Marshaller.dispatch[rclpy.topic_endpoint_info.TopicEndpointTypeEnum] = dump_any_enum

--- a/ros2cli/test/test_daemon.py
+++ b/ros2cli/test/test_daemon.py
@@ -1,0 +1,215 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import rclpy
+import rclpy.action
+
+from ros2cli.node.daemon import DaemonNode
+from ros2cli.node.daemon import is_daemon_running
+from ros2cli.node.daemon import spawn_daemon
+
+import test_msgs.action
+import test_msgs.msg
+import test_msgs.srv
+
+
+TEST_NODE_NAME = 'test_node'
+TEST_NODE_NAMESPACE = '/test'
+TEST_TOPIC_NAME = '/test/topic'
+TEST_TOPIC_TYPE = 'test_msgs/msg/Empty'
+TEST_TOPIC_PUBLISHER_QOS = rclpy.qos.QoSProfile(
+    reliability=rclpy.qos.ReliabilityPolicy.RELIABLE,
+    durability=rclpy.qos.DurabilityPolicy.VOLATILE,
+    depth=1
+)
+TEST_TOPIC_SUBSCRIPTION_QOS = rclpy.qos.QoSProfile(
+    reliability=rclpy.qos.ReliabilityPolicy.BEST_EFFORT,
+    durability=rclpy.qos.DurabilityPolicy.VOLATILE,
+    depth=1
+)
+TEST_SERVICE_NAME = '/test/service'
+TEST_SERVICE_TYPE = 'test_msgs/srv/Empty'
+TEST_ACTION_NAME = '/test/action'
+TEST_ACTION_TYPE = 'test_msgs/action/Fibonacci'
+
+
+@pytest.fixture(autouse=True, scope='module')
+def local_node():
+    rclpy.init()
+    node = rclpy.create_node(
+        node_name=TEST_NODE_NAME, namespace=TEST_NODE_NAMESPACE
+    )
+    publisher = node.create_publisher(
+        msg_type=test_msgs.msg.Empty,
+        topic=TEST_TOPIC_NAME,
+        qos_profile=TEST_TOPIC_PUBLISHER_QOS
+    )
+    subscription = node.create_subscription(
+        msg_type=test_msgs.msg.Empty,
+        topic=TEST_TOPIC_NAME,
+        callback=(lambda msg: None),
+        qos_profile=TEST_TOPIC_SUBSCRIPTION_QOS
+    )
+    service = node.create_service(
+        srv_type=test_msgs.srv.Empty,
+        srv_name=TEST_SERVICE_NAME,
+        callback=(lambda req, res: res)
+    )
+    client = node.create_client(
+        srv_type=test_msgs.srv.Empty,
+        srv_name=TEST_SERVICE_NAME
+    )
+
+    def noop_execute_callback(goal_handle):
+        goal_handle.succeed()
+        return test_msgs.action.Fibonacci.Result()
+
+    action_server = rclpy.action.ActionServer(
+        node=node,
+        action_type=test_msgs.action.Fibonacci,
+        action_name=TEST_ACTION_NAME,
+        execute_callback=noop_execute_callback
+    )
+    action_client = rclpy.action.ActionClient(
+        node=node,
+        action_type=test_msgs.action.Fibonacci,
+        action_name=TEST_ACTION_NAME
+    )
+    try:
+        yield node
+    finally:
+        action_client.destroy()
+        action_server.destroy()
+        node.destroy_client(client)
+        node.destroy_service(service)
+        node.destroy_subscription(subscription)
+        node.destroy_publisher(publisher)
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+@pytest.fixture(scope='module')
+def daemon_node():
+    if is_daemon_running(args=[]):
+        with DaemonNode(args=[]) as node:
+            node.system.shutdown()
+    assert spawn_daemon(args=[], wait_until_spawned=5.0)
+    with DaemonNode(args=[]) as node:
+        yield node
+
+
+def test_get_name(daemon_node):
+    assert 'daemon' in daemon_node.get_name()
+
+
+def test_get_namespace(daemon_node):
+    assert '/' == daemon_node.get_namespace()
+
+
+def test_get_node_names_and_namespaces(daemon_node):
+    node_names_and_namespaces = daemon_node.get_node_names_and_namespaces()
+    assert [TEST_NODE_NAME, TEST_NODE_NAMESPACE] in node_names_and_namespaces
+
+
+def test_get_topic_names_and_types(daemon_node):
+    topic_names_and_types = daemon_node.get_topic_names_and_types()
+    assert [TEST_TOPIC_NAME, [TEST_TOPIC_TYPE]] in topic_names_and_types
+
+
+def test_get_service_names_and_types(daemon_node):
+    service_names_and_types = daemon_node.get_service_names_and_types()
+    assert [TEST_SERVICE_NAME, [TEST_SERVICE_TYPE]] in service_names_and_types
+
+
+def test_get_action_names_and_types(daemon_node):
+    action_names_and_types = daemon_node.get_action_names_and_types()
+    assert [TEST_ACTION_NAME, [TEST_ACTION_TYPE]] in action_names_and_types
+
+
+def test_get_publisher_names_and_types_by_node(daemon_node):
+    topic_names_and_types = daemon_node.get_publisher_names_and_types_by_node(
+        TEST_NODE_NAME, TEST_NODE_NAMESPACE
+    )
+    assert [TEST_TOPIC_NAME, [TEST_TOPIC_TYPE]] in topic_names_and_types
+
+
+def test_get_subscriber_names_and_types_by_node(daemon_node):
+    topic_names_and_types = daemon_node.get_subscriber_names_and_types_by_node(
+        TEST_NODE_NAME, TEST_NODE_NAMESPACE
+    )
+    assert [TEST_TOPIC_NAME, [TEST_TOPIC_TYPE]] in topic_names_and_types
+
+
+def test_get_service_names_and_types_by_node(daemon_node):
+    service_names_and_types = daemon_node.get_service_names_and_types_by_node(
+        TEST_NODE_NAME, TEST_NODE_NAMESPACE
+    )
+    assert [TEST_SERVICE_NAME, [TEST_SERVICE_TYPE]] in service_names_and_types
+
+
+def test_get_client_names_and_types_by_node(daemon_node):
+    service_names_and_types = daemon_node.get_client_names_and_types_by_node(
+        TEST_NODE_NAME, TEST_NODE_NAMESPACE
+    )
+    assert [TEST_SERVICE_NAME, [TEST_SERVICE_TYPE]] in service_names_and_types
+
+
+def test_get_action_server_names_and_types_by_node(daemon_node):
+    action_names_and_types = daemon_node.get_action_server_names_and_types_by_node(
+        TEST_NODE_NAME, TEST_NODE_NAMESPACE
+    )
+    assert [TEST_ACTION_NAME, [TEST_ACTION_TYPE]] in action_names_and_types
+
+
+def test_get_action_client_names_and_types_by_node(daemon_node):
+    action_names_and_types = daemon_node.get_action_client_names_and_types_by_node(
+        TEST_NODE_NAME, TEST_NODE_NAMESPACE
+    )
+    assert [TEST_ACTION_NAME, [TEST_ACTION_TYPE]] in action_names_and_types
+
+
+def test_get_publishers_info_by_topic(daemon_node):
+    publishers_info = daemon_node.get_publishers_info_by_topic(TEST_TOPIC_NAME)
+    assert len(publishers_info) == 1
+    test_publisher_info = publishers_info[0]
+    assert test_publisher_info.node_name == TEST_NODE_NAME
+    assert test_publisher_info.node_namespace == TEST_NODE_NAMESPACE
+    assert test_publisher_info.topic_type == TEST_TOPIC_TYPE
+    assert test_publisher_info.qos_profile.durability == \
+        TEST_TOPIC_PUBLISHER_QOS.durability
+    assert test_publisher_info.qos_profile.reliability == \
+        TEST_TOPIC_PUBLISHER_QOS.reliability
+
+
+def test_get_subscriptions_info_by_topic(daemon_node):
+    subscriptions_info = daemon_node.get_subscriptions_info_by_topic(TEST_TOPIC_NAME)
+    assert len(subscriptions_info) == 1
+    test_subscription_info = subscriptions_info[0]
+    assert test_subscription_info.node_name == TEST_NODE_NAME
+    assert test_subscription_info.node_namespace == TEST_NODE_NAMESPACE
+    assert test_subscription_info.topic_type == TEST_TOPIC_TYPE
+    assert test_subscription_info.qos_profile.durability == \
+        TEST_TOPIC_SUBSCRIPTION_QOS.durability
+    assert test_subscription_info.qos_profile.reliability == \
+        TEST_TOPIC_SUBSCRIPTION_QOS.reliability
+
+
+def test_count_publishers(daemon_node):
+    assert 1 == daemon_node.count_publishers(TEST_TOPIC_NAME)
+
+
+def test_count_subscribers(daemon_node):
+    assert 1 == daemon_node.count_subscribers(TEST_TOPIC_NAME)


### PR DESCRIPTION
Split from #421. This pull request extends the CLI daemon API to better match that of a regular `rclpy.node.Node`.