### PR TITLE
Make sure to add ros2doctor verbs to the extension points.

### DIFF
--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -51,6 +51,9 @@ setup(
             'TopicReport = ros2doctor.api.topic:TopicReport',
             'PackageReport = ros2doctor.api.package:PackageReport',
         ],
+        'ros2cli.extension_point': [
+            'ros2doctor.verb = ros2doctor.verb:VerbExtension',
+        ],
         'ros2doctor.verb': [
             'hello = ros2doctor.verb.hello:HelloVerb'
         ]


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Without this, `ros2 extensions` doesn't list `ros2doctor.hello` as one of the sub-verbs.  I think this was just an oversight.