### PR TITLE
Feature/timeout config

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -44,6 +44,7 @@ def is_daemon_running(args):
 
 def spawn_daemon(args, wait_until_spawned=None, debug=False):
     ros_domain_id = int(os.environ.get('ROS_DOMAIN_ID', 0))
+    timeout_duration = int(args.timeout)
     kwargs = {}
     if platform.system() != 'Windows':
         cmd = ['_ros2_daemon']
@@ -75,7 +76,8 @@ def spawn_daemon(args, wait_until_spawned=None, debug=False):
     cmd.extend([
         # the arguments are only passed for visibility in e.g. the process list
         '--rmw-implementation', rmw_implementation_identifier,
-        '--ros-domain-id', str(ros_domain_id)])
+        '--ros-domain-id', str(ros_domain_id),
+        '--timeout', str(timeout_duration)])
     if not debug:
         kwargs['stdout'] = subprocess.DEVNULL
         kwargs['stderr'] = subprocess.DEVNULL

--- a/ros2cli/ros2cli/verb/daemon/start.py
+++ b/ros2cli/ros2cli/verb/daemon/start.py
@@ -26,6 +26,9 @@ class StartVerb(VerbExtension):
         parser.add_argument(
             '--debug', '-d', action='store_true',
             help='Print debug messages')
+        parser.add_argument(
+            '--timeout', '-t', action='store_const', const=2 * 60 * 60,
+            help='Terminate daemon after t seconds of inactivity. Default of 7200 seconds ( 2 hours )')
 
     def main(self, *, args):
         running = is_daemon_running(args)

--- a/ros2cli/ros2cli/verb/daemon/start.py
+++ b/ros2cli/ros2cli/verb/daemon/start.py
@@ -27,8 +27,8 @@ class StartVerb(VerbExtension):
             '--debug', '-d', action='store_true',
             help='Print debug messages')
         parser.add_argument(
-            '--timeout', '-t', action='store_const', const=2 * 60 * 60,
-            help='Terminate daemon after t seconds of inactivity. Default of 7200 seconds ( 2 hours )')
+            '--timeout', '-t', default=2 * 60 * 60,
+            help='Terminate daemon after integer t seconds of inactivity. Default of 7200 seconds ( 2 hours )')
 
     def main(self, *, args):
         running = is_daemon_running(args)

--- a/ros2cli/ros2cli/verb/daemon/start.py
+++ b/ros2cli/ros2cli/verb/daemon/start.py
@@ -28,7 +28,8 @@ class StartVerb(VerbExtension):
             help='Print debug messages')
         parser.add_argument(
             '--timeout', '-t', default=2 * 60 * 60,
-            help='Terminate daemon after integer t seconds of inactivity. Default of 7200 seconds ( 2 hours )')
+            help='Terminate daemon after integer t seconds of inactivity. \
+            Default of 7200 seconds(2 hours)')
 
     def main(self, *, args):
         running = is_daemon_running(args)


### PR DESCRIPTION
Configurable daemon timeout option targeted at https://github.com/ros2/ros2cli/issues/502. 

There is no option for disabling timeout entirely yet, save for setting an astronomically large value.
This could be further handled, for example by following @codebot's suggestion of using negative values, but I might defer to the maintainers on design choice.