### PR TITLE
Ensure ros2doctor ROS nodes have valid names.

### DIFF
--- a/ros2doctor/ros2doctor/verb/hello.py
+++ b/ros2doctor/ros2doctor/verb/hello.py
@@ -14,6 +14,7 @@
 
 from argparse import ArgumentTypeError
 import os
+import re
 import socket
 import struct
 import threading
@@ -28,6 +29,9 @@ from std_msgs.msg import String
 
 DEFAULT_GROUP = '225.0.0.1'
 DEFAULT_PORT = 49150
+
+NODE_NAME_PREFIX = \
+    f"ros2doctor_{re.sub(r'[^0-9a-zA-Z_]', '_', socket.gethostname())}_{os.getpid()}"
 
 
 def positive_int(string: str) -> int:
@@ -109,7 +113,7 @@ class Talker(Node):
     """Initialize talker node."""
 
     def __init__(self, topic, time_period, *, qos=10):
-        node_name = 'ros2doctor_' + socket.gethostname() + str(os.getpid()) + '_talker'
+        node_name = NODE_NAME_PREFIX + '_talker'
         super().__init__(node_name)
         self._i = 0
         self._pub = self.create_publisher(String, topic, qos)
@@ -128,7 +132,7 @@ class Listener(Node):
     """Initialize listener node."""
 
     def __init__(self, topic, *, qos=10):
-        node_name = 'ros2doctor_' + socket.gethostname() + str(os.getpid()) + '_listener'
+        node_name = NODE_NAME_PREFIX + '_listener'
         super().__init__(node_name)
         self._sub = self.create_subscription(
             String,

--- a/ros2doctor/test/test_api.py
+++ b/ros2doctor/test/test_api.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
@@ -29,7 +31,6 @@ from ros2doctor.api.topic import TopicReport
 @launch_testing.markers.keep_alive
 def generate_test_description():
     return LaunchDescription([
-        # Always restart daemon to isolate tests.
         ExecuteProcess(
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
@@ -46,14 +47,6 @@ def generate_test_description():
     ])
 
 
-def test_topic_check():
-    """Assume no topics are publishing or subscribing other than whitelisted ones."""
-    topic_check = TopicCheck()
-    check_result = topic_check.check()
-    assert check_result.error == 0
-    assert check_result.warning == 0
-
-
 def _generate_expected_report(topic, pub_count, sub_count):
     expected_report = Report('TOPIC LIST')
     expected_report.add_to_report('topic', topic)
@@ -62,9 +55,18 @@ def _generate_expected_report(topic, pub_count, sub_count):
     return expected_report
 
 
-def test_topic_report():
-    """Assume no topics are publishing or subscribing other than whitelisted ones."""
-    report = TopicReport().report()
-    expected_report = _generate_expected_report('none', 0, 0)
-    assert report.name == expected_report.name
-    assert report.items == expected_report.items
+class TestROS2DoctorAPI(unittest.TestCase):
+
+    def test_topic_check(self):
+        """Assume no topics are publishing or subscribing other than whitelisted ones."""
+        topic_check = TopicCheck()
+        check_result = topic_check.check()
+        self.assertEqual(check_result.error, 0)
+        self.assertEqual(check_result.warning, 0)
+
+    def test_topic_report(self):
+        """Assume no topics are publishing or subscribing other than whitelisted ones."""
+        report = TopicReport().report()
+        expected_report = _generate_expected_report('none', 0, 0)
+        self.assertEqual(report.name, expected_report.name)
+        self.assertEqual(report.items, expected_report.items)

--- a/ros2doctor/test/test_cli.py
+++ b/ros2doctor/test/test_cli.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from argparse import Namespace
+import unittest
+import unittest.mock as mock
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
@@ -30,18 +32,11 @@ from ros2doctor.verb.hello import SummaryTable
 @launch_testing.markers.keep_alive
 def generate_test_description():
     return LaunchDescription([
-        # Always restart daemon to isolate tests.
         ExecuteProcess(
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                ExecuteProcess(
-                    cmd=['ros2', 'daemon', 'start'],
-                    name='daemon-start',
-                    on_exit=[
-                        launch_testing.actions.ReadyToTest()
-                    ]
-                )
+                launch_testing.actions.ReadyToTest()
             ]
         )
     ])
@@ -56,18 +51,21 @@ def _generate_expected_summary_table():
     return expected_summary
 
 
-def test_hello_single_host():
-    """Run HelloVerb for one emit period on a single host."""
-    args = Namespace()
-    args.topic = '/canyouhearme'
-    args.emit_period = 0.1
-    args.print_period = 1.0
-    args.ttl = None
-    args.once = True
-    hello_verb = HelloVerb()
-    summary = hello_verb.main(args=args)
-    expected_summary = _generate_expected_summary_table()
-    assert summary._pub == expected_summary._pub
-    assert summary._sub == expected_summary._sub
-    assert summary._send == expected_summary._send
-    assert summary._receive == expected_summary._receive
+class TestROS2DoctorCLI(unittest.TestCase):
+
+    def test_hello_single_host(self):
+        """Run HelloVerb for one emit period on a single host."""
+        args = Namespace()
+        args.topic = '/canyouhearme'
+        args.emit_period = 0.1
+        args.print_period = 1.0
+        args.ttl = None
+        args.once = True
+        with mock.patch('socket.gethostname', return_value='!nv@lid-n*de-n4me'):
+            hello_verb = HelloVerb()
+            summary = hello_verb.main(args=args)
+            expected_summary = _generate_expected_summary_table()
+            self.assertEqual(summary._pub, expected_summary._pub)
+            self.assertEqual(summary._sub, expected_summary._sub)
+            self.assertEqual(summary._send, expected_summary._send)
+            self.assertEqual(summary._receive, expected_summary._receive)


### PR DESCRIPTION
Precisely what the title says. Came across this while testing `ros2 doctor hello` on a VM that had dashes in its hostname. It's tricky one to test for regression, so I'm open to ideas.

