### PR TITLE
Use consistent quotes in help messages

### DIFF
--- a/ros2interface/ros2interface/verb/proto.py
+++ b/ros2interface/ros2interface/verb/proto.py
@@ -23,7 +23,7 @@ class ProtoVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
                 'type',
-                help='Show an interface definition (e.g. "std_msgs/msg/String")')
+                help="Show an interface definition (e.g. 'std_msgs/msg/String')")
         arg.completer = type_completer
         parser.add_argument(
             '--no-quotes', action='store_true',

--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -23,7 +23,7 @@ class ShowVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
                 'type',
-                help='Show an interface definition (e.g. "std_msgs/msg/String")')
+                help="Show an interface definition (e.g. 'std_msgs/msg/String')")
         arg.completer = type_completer
 
     def main(self, *, args):

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -42,7 +42,7 @@ class CallVerb(VerbExtension):
         arg = parser.add_argument(
             'values', nargs='?', default='{}',
             help='Values to fill the service request with in YAML format ' +
-                 '(e.g. "{a: 1, b: 2}"), ' +
+                 "(e.g. '{a: 1, b: 2}'), " +
                  'otherwise the service request will be published with default values')
         arg.completer = ServicePrototypeCompleter(
             service_type_key='service_type')

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -66,7 +66,7 @@ class PubVerb(VerbExtension):
         arg = parser.add_argument(
             'values', nargs='?', default='{}',
             help='Values to fill the message with in YAML format '
-                 '(e.g. "data: Hello World"), '
+                 "(e.g. 'data: Hello World'), "
                  'otherwise the message will be published with default values')
         arg.completer = TopicMessagePrototypeCompleter(
             topic_type_key='message_type')


### PR DESCRIPTION
Using single quotes inside double quotes is consistent with the other CLI help messages.