### PR TITLE
[ros2interface] Allow input from stdin for `show`

### DIFF
--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -37,15 +37,15 @@ class ShowVerb(VerbExtension):
                 return str("stdin is empty")
 
             # The regex pattern is permissive so that
-            # `get_interface_path` can handle errors
-            regex_pattern = "([a-zA-Z0-9_\/]+)"
+            # `get_interface_path` handles errors
+            pattern = "^[a-zA-Z0-9_\/]+$"
             stdin_str = "".join(sys.stdin.readlines())
-            matches = re.findall(regex_pattern, stdin_str)
+            match = re.match(pattern, stdin_str)
 
-            if len(matches) != 1:
+            if not match:
                 return str("Could not determine message type from stdin")
 
-            args.type = matches[0]
+            args.type = match.string.strip()
         try:
             file_path = get_interface_path(args.type)
         except LookupError as e:

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -388,3 +388,18 @@ class TestROS2InterfaceCLI(unittest.TestCase):
             text=interface_command.output,
             strict=True
         )
+
+    def test_show_from_stdin_no_valid_interface(self):
+        with self.launch_stdin_interface_command(
+                stdin_arguments=['echo', '"not an interface"'],
+                interface_arguments=['show', '-']
+        ) as interface_command:
+            assert interface_command.wait_for_shutdown(timeout=2)
+        assert interface_command.exit_code == 1
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                "Could not determine message type from stdin"
+            ],
+            text=interface_command.output,
+            strict=True
+        )


### PR DESCRIPTION
Fixes #349, allowing `ros2 interface show` to read from stdin.
```console
$ echo std_msgs/msg/String | ros2 interface show -
# This was originally provided as an example message.
# It is deprecated as of Foxy
# It is recommended to create your own semantically meaningful message.
# However if you would like to continue using this please use the equivalent in example_msgs.

string data
```

# Design decisions

Unlike `rosmsg`, this solution uses a dash (`-`) to denote that the program should look to stdin, which is a common convention in many programs ([see here](https://unix.stackexchange.com/a/16364)).

There are two main reasons for using a dash rather than automatically looking for stdin:
1. It allows for the argparse help message to be shown in the event the user enters `ros2 interface show` (with no stdin piped in).
2. It required changing only the `show` verb of `ros2interface`.  

# Error handling

No stdin supplied:
```console
$ ros2 interface show -
stdin is empty
```

stdin is not exclusively an interface type:
```console
$ echo "Not in the right form" | ros2 interface show -
Could not determine message type from stdin
``` 

No dash shows help:
```console
$ ros2 interface show
usage: ros2 interface show [-h] type
ros2 interface show: error: the following arguments are required: type
```



Package related errors are differed to `rosidl_runtime_py`'s `get_interface_path`:
```console
$ echo "not/a/message/type" | ros2 interface show -
Unknown package 'not'
```
```console
$ echo "std_msgs/msg/Foo" | ros2 interface show -
Could not find the interface '/root/ros2_foxy/install/std_msgs/share/std_msgs/msg/Foo.idl'
```
```console
$ echo "not/a/message/type/" | ros2 interface show -
[...]
ValueError: Invalid name 'not/a/message/type/'. Must not contain empty parts
```
```console
$ echo "not_a_message_type" | ros2 interface show -
[...]
ValueError: Invalid name 'not_a_message_type'. Expected at least two parts separated by '/'
```