### PR TITLE
[ros2interface] Add option to include/remove whitespace and comments

### DIFF
--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -260,6 +260,36 @@ class TestROS2InterfaceCLI(unittest.TestCase):
             strict=True
         )
 
+    def test_show_raw_message(self):
+        with self.launch_interface_command(
+                arguments=['show', 'test_msgs/msg/Builtins', '--raw']
+        ) as interface_command:
+            assert interface_command.wait_for_shutdown(timeout=2)
+        assert interface_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                'builtin_interfaces/Duration duration_value',
+                '\t# Duration defines a period between two time points. It is comprised of a',
+                '\t# seconds component and a nanoseconds component.',
+                '',
+                '\t# Seconds component, range is valid over any possible int32 value.',
+                '\tint32 sec',
+                '',
+                '\t# Nanoseconds component in the range of [0, 10e9).',
+                '\tuint32 nanosec',
+                'builtin_interfaces/Time time_value',
+                "\t# Time indicates a specific point in time, relative to a clock's 0 point.",
+                '',
+                '\t# The seconds component, valid over all int32 values.',
+                '\tint32 sec',
+                '',
+                '\t# The nanoseconds component, valid in the range [0, 10e9).',
+                '\tuint32 nanosec',
+            ],
+            text=interface_command.output,
+            strict=True
+        )
+
     def test_show_service(self):
         with self.launch_interface_command(
             arguments=['show', 'test_msgs/srv/BasicTypes']
@@ -310,13 +340,10 @@ class TestROS2InterfaceCLI(unittest.TestCase):
         assert interface_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                '#goal definition',
                 'int32 order',
                 '---',
-                '#result definition',
                 'int32[] sequence',
                 '---',
-                '#feedback',
                 'int32[] sequence',
             ],
             text=interface_command.output,
@@ -353,6 +380,93 @@ class TestROS2InterfaceCLI(unittest.TestCase):
     def test_show_nested_action(self):
         with self.launch_interface_command(
                 arguments=['show', 'test_msgs/action/NestedMessage']
+        ) as interface_command:
+            assert interface_command.wait_for_shutdown(timeout=2)
+        assert interface_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                'Builtins nested_field_no_pkg',
+                '\tbuiltin_interfaces/Duration duration_value',
+                '\t\tint32 sec',
+                '\t\tuint32 nanosec',
+                '\tbuiltin_interfaces/Time time_value',
+                '\t\tint32 sec',
+                '\t\tuint32 nanosec',
+                'test_msgs/BasicTypes nested_field',
+                '\tbool bool_value',
+                '\tbyte byte_value',
+                '\tchar char_value',
+                '\tfloat32 float32_value',
+                '\tfloat64 float64_value',
+                '\tint8 int8_value',
+                '\tuint8 uint8_value',
+                '\tint16 int16_value',
+                '\tuint16 uint16_value',
+                '\tint32 int32_value',
+                '\tuint32 uint32_value',
+                '\tint64 int64_value',
+                '\tuint64 uint64_value',
+                'builtin_interfaces/Time nested_different_pkg',
+                '\tint32 sec',
+                '\tuint32 nanosec',
+                '---',
+                'Builtins nested_field_no_pkg',
+                '\tbuiltin_interfaces/Duration duration_value',
+                '\t\tint32 sec',
+                '\t\tuint32 nanosec',
+                '\tbuiltin_interfaces/Time time_value',
+                '\t\tint32 sec',
+                '\t\tuint32 nanosec',
+                'test_msgs/BasicTypes nested_field',
+                '\tbool bool_value',
+                '\tbyte byte_value',
+                '\tchar char_value',
+                '\tfloat32 float32_value',
+                '\tfloat64 float64_value',
+                '\tint8 int8_value',
+                '\tuint8 uint8_value',
+                '\tint16 int16_value',
+                '\tuint16 uint16_value',
+                '\tint32 int32_value',
+                '\tuint32 uint32_value',
+                '\tint64 int64_value',
+                '\tuint64 uint64_value',
+                'builtin_interfaces/Time nested_different_pkg',
+                '\tint32 sec',
+                '\tuint32 nanosec',
+                '---',
+                'Builtins nested_field_no_pkg',
+                '\tbuiltin_interfaces/Duration duration_value',
+                '\t\tint32 sec',
+                '\t\tuint32 nanosec',
+                '\tbuiltin_interfaces/Time time_value',
+                '\t\tint32 sec',
+                '\t\tuint32 nanosec',
+                'test_msgs/BasicTypes nested_field',
+                '\tbool bool_value',
+                '\tbyte byte_value',
+                '\tchar char_value',
+                '\tfloat32 float32_value',
+                '\tfloat64 float64_value',
+                '\tint8 int8_value',
+                '\tuint8 uint8_value',
+                '\tint16 int16_value',
+                '\tuint16 uint16_value',
+                '\tint32 int32_value',
+                '\tuint32 uint32_value',
+                '\tint64 int64_value',
+                '\tuint64 uint64_value',
+                'builtin_interfaces/Time nested_different_pkg',
+                '\tint32 sec',
+                '\tuint32 nanosec',
+            ],
+            text=interface_command.output,
+            strict=True
+        )
+
+    def test_show_raw_nested_action(self):
+        with self.launch_interface_command(
+                arguments=['show', 'test_msgs/action/NestedMessage', '--raw']
         ) as interface_command:
             assert interface_command.wait_for_shutdown(timeout=2)
         assert interface_command.exit_code == launch_testing.asserts.EXIT_OK


### PR DESCRIPTION
Adds the ability to show an interface's whitespace and comments with the argument `--raw` or `-r`, like in ROS1's [`rosmsg`](https://github.com/ros/ros_comm/blob/9162b32a42b5569ae42a94aa6426aafcb63021ae/tools/rosmsg/src/rosmsg/__init__.py#L585-L587).