### PR TITLE
Add --once and --timeout option to ros2 topic echo

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -85,6 +85,9 @@ class EchoVerb(VerbExtension):
             '--lost-messages', action='store_true', help='Report when a message is lost')
         parser.add_argument( 
             '--once', action='store_true', help="Print the first message received and then exit")
+        parser.add_argument(
+            '--timeout', metavar='N', type=unsigned_int, default=3.0,
+            help='If used with --once, the time after which the application will exit even if no message is received')
 
     def main(self, *, args):
         return main(args)

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -146,6 +146,8 @@ def subscriber(
 
     rclpy.spin_until_future_complete(node, future, timeout)
 
+    if not future.done():
+        node.get_logger().info("Timeout occured")
 
 
 def subscriber_cb(truncate_length, noarr, nostr):

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -116,7 +116,8 @@ def main(args):
             callback = subscriber_cb_once_decorator(callback, future)
 
         subscriber(
-            node, args.topic_name, message_type, callback, qos_profile, args.lost_messages, future)
+            node, args.topic_name, message_type, callback, qos_profile, args.lost_messages,
+            future, args.timeout)
 
 
 def subscriber(
@@ -126,7 +127,8 @@ def subscriber(
     callback: Callable[[MsgType], Any],
     qos_profile: QoSProfile,
     report_lost_messages: bool,
-    future = None
+    future = None,
+    timeout = None
 ) -> Optional[str]:
     """Initialize a node with a single subscription and spin."""
     event_callbacks = None
@@ -144,7 +146,7 @@ def subscriber(
     if future == None:
         rclpy.spin(node)
     else:
-        rclpy.spin_until_future_complete(node, future)
+        rclpy.spin_until_future_complete(node, future, timeout)
 
 
 

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -143,10 +143,8 @@ def subscriber(
             f"The rmw implementation '{get_rmw_implementation_identifier()}'"
             ' does not support reporting lost messages'
         )
-    if future == None:
-        rclpy.spin(node)
-    else:
-        rclpy.spin_until_future_complete(node, future, timeout)
+
+    rclpy.spin_until_future_complete(node, future, timeout)
 
 
 

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -81,8 +81,6 @@ class EchoVerb(VerbExtension):
             '--no-arr', action='store_true', help="Don't print array fields of messages")
         parser.add_argument(
             '--no-str', action='store_true', help="Don't print string fields of messages")
-        parser.add_argument(
-            '--lost-messages', action='store_true', help='Report when a message is lost')
         parser.add_argument( 
             '--once', action='store_true', help="Print the first message received and then exit")
         parser.add_argument(

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -159,7 +159,14 @@ def subscriber_cb(truncate_length, noarr, nostr):
             end='---\n')
     return cb
 
-
+def message_lost_event_callback(message_lost_status):
+    print(
+        'A message was lost!!!\n\ttotal count change:'
+        f'{message_lost_status.total_count_change}'
+        f'\n\ttotal count: {message_lost_status.total_count}',
+        end='---\n'
+    )
+    
 def subscriber_cb_csv(truncate_length, noarr, nostr):
     def cb(msg):
         nonlocal truncate_length, noarr, nostr

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -71,6 +71,8 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             '--no-str', action='store_true', help="Don't print string fields of messages")
         parser.add_argument(
+            '--lost-messages', action='store_true', help='Report when a message is lost')
+        parser.add_argument(
             '--once', action='store_true', help='Print the first message received and then exit')
         parser.add_argument(
             '--timeout', metavar='N', type=unsigned_int, default=None,

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -137,8 +137,9 @@ def subscriber(
 
     rclpy.spin_until_future_complete(node, future, timeout)
 
-    if not future.done():
-        node.get_logger().info('Timeout occured')
+    if future is not None:
+        if not future.done():
+            node.get_logger().info('Timeout occured')
 
 
 def subscriber_cb(truncate_length, noarr, nostr):

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -84,8 +84,8 @@ class EchoVerb(VerbExtension):
         parser.add_argument( 
             '--once', action='store_true', help="Print the first message received and then exit")
         parser.add_argument(
-            '--timeout', metavar='N', type=unsigned_int, default=3.0,
-            help='If used with --once, the time after which the application will exit even if no message is received')
+            '--timeout', metavar='N', type=unsigned_int, default=None,
+            help='The time after which the application will exit')
 
     def main(self, *, args):
         return main(args)

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
 from typing import Any
 from typing import Callable
 from typing import Optional
@@ -23,8 +22,8 @@ from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.qos_event import SubscriptionEventCallbacks
 from rclpy.qos_event import UnsupportedEventTypeError
-from rclpy.utilities import get_rmw_implementation_identifier
 from rclpy.task import Future
+from rclpy.utilities import get_rmw_implementation_identifier
 from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import add_qos_arguments_to_argument_parser
 from ros2topic.api import get_msg_class
@@ -38,16 +37,6 @@ from rosidl_runtime_py.utilities import get_message
 
 DEFAULT_TRUNCATE_LENGTH = 128
 MsgType = TypeVar('MsgType')
-
-
-def unsigned_int(string):
-    try:
-        value = int(string)
-    except ValueError:
-        value = -1
-    if value < 0:
-        raise ArgumentTypeError('value must be non-negative integer')
-    return value
 
 
 class EchoVerb(VerbExtension):
@@ -81,8 +70,8 @@ class EchoVerb(VerbExtension):
             '--no-arr', action='store_true', help="Don't print array fields of messages")
         parser.add_argument(
             '--no-str', action='store_true', help="Don't print string fields of messages")
-        parser.add_argument( 
-            '--once', action='store_true', help="Print the first message received and then exit")
+        parser.add_argument(
+            '--once', action='store_true', help='Print the first message received and then exit')
         parser.add_argument(
             '--timeout', metavar='N', type=unsigned_int, default=None,
             help='The time after which the application will exit')
@@ -127,8 +116,8 @@ def subscriber(
     callback: Callable[[MsgType], Any],
     qos_profile: QoSProfile,
     report_lost_messages: bool,
-    future = None,
-    timeout = None
+    future=None,
+    timeout=None
 ) -> Optional[str]:
     """Initialize a node with a single subscription and spin."""
     event_callbacks = None
@@ -147,7 +136,7 @@ def subscriber(
     rclpy.spin_until_future_complete(node, future, timeout)
 
     if not future.done():
-        node.get_logger().info("Timeout occured")
+        node.get_logger().info('Timeout occured')
 
 
 def subscriber_cb(truncate_length, noarr, nostr):
@@ -159,6 +148,7 @@ def subscriber_cb(truncate_length, noarr, nostr):
             end='---\n')
     return cb
 
+
 def message_lost_event_callback(message_lost_status):
     print(
         'A message was lost!!!\n\ttotal count change:'
@@ -166,14 +156,16 @@ def message_lost_event_callback(message_lost_status):
         f'\n\ttotal count: {message_lost_status.total_count}',
         end='---\n'
     )
-    
+
+
 def subscriber_cb_csv(truncate_length, noarr, nostr):
     def cb(msg):
         nonlocal truncate_length, noarr, nostr
         print(message_to_csv(msg, truncate_length=truncate_length, no_arr=noarr, no_str=nostr))
     return cb
 
-def subscriber_cb_once_decorator(callback : Callable, future : Future) -> Callable:
+
+def subscriber_cb_once_decorator(callback: Callable, future: Future) -> Callable:
     def cb(msg):
         if not future.done():
             callback(msg)

--- a/ros2topic/test/fixtures/listener_node.py
+++ b/ros2topic/test/fixtures/listener_node.py
@@ -16,7 +16,7 @@ import sys
 
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import qos_profile_system_default
+from ros2topic.api import qos_profile_from_short_keys
 
 from std_msgs.msg import String
 
@@ -25,8 +25,10 @@ class ListenerNode(Node):
 
     def __init__(self):
         super().__init__('listener')
+        qos_profile = qos_profile_from_short_keys(
+            'system_default', durability='transient_local')
         self.sub = self.create_subscription(
-            String, 'chatter', self.callback, qos_profile_system_default
+            String, 'chatter', self.callback, qos_profile
         )
 
     def callback(self, msg):

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -575,6 +575,26 @@ class TestROS2TopicCLI(unittest.TestCase):
             strict=True
         )
 
+    def test_topic_echo_once(self):
+        with self.launch_topic_command(
+            arguments=[
+                'echo', '--once',
+                '/chit_chatter',
+                'std_msgs/msg/String',
+                '{data: bar}'
+            ]
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[],
+                strict=True
+            ), timeout=10)
+            assert topic_command.wait_for_shutdown(timeout=10)
+            assert self.listener_node.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[],
+                strict=False
+            ), timeout=10)
+        assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
+
     def test_topic_pub(self):
         with self.launch_topic_command(
             arguments=[

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -375,11 +375,11 @@ class TestROS2TopicCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_echo_once(self):
         with self.launch_topic_command(
-        arguments=[
-            'echo', '--once',
-            '/chatter',
-            'std_msgs/msg/String'
-        ]
+            arguments=[
+                'echo', '--once',
+                '/chatter',
+                'std_msgs/msg/String'
+            ]
         ) as topic_command:
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
@@ -574,26 +574,6 @@ class TestROS2TopicCLI(unittest.TestCase):
             text=topic_command.output,
             strict=True
         )
-
-    def test_topic_echo_once(self):
-        with self.launch_topic_command(
-            arguments=[
-                'echo', '--once',
-                '/chit_chatter',
-                'std_msgs/msg/String',
-                '{data: bar}'
-            ]
-        ) as topic_command:
-            assert topic_command.wait_for_output(functools.partial(
-                launch_testing.tools.expect_output, expected_lines=[],
-                strict=True
-            ), timeout=10)
-            assert topic_command.wait_for_shutdown(timeout=10)
-            assert self.listener_node.wait_for_output(functools.partial(
-                launch_testing.tools.expect_output, expected_lines=[],
-                strict=False
-            ), timeout=10)
-        assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
 
     def test_topic_pub(self):
         with self.launch_topic_command(

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -373,6 +373,25 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.wait_for_shutdown(timeout=10)
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_once(self):
+        with self.launch_topic_command(
+        arguments=[
+            'echo', '--once',
+            '/chatter',
+            'std_msgs/msg/String',
+            '{data: bar}'
+        ]
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    re.compile(r"data: 'Hello World: \d+'"),
+                    '---'
+                ], strict=True
+            ), timeout=10)
+            assert topic_command.wait_for_shutdown(timeout=10)
+        assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_no_str_topic_echo(self):
         with self.launch_topic_command(
             arguments=['echo', '--no-str', '/chatter']
@@ -556,26 +575,6 @@ class TestROS2TopicCLI(unittest.TestCase):
             text=topic_command.output,
             strict=True
         )
-
-    def test_topic_echo_once(self):
-        with self.launch_topic_command(
-            arguments=[
-                'echo', '--once',
-                '/chit_chatter',
-                'std_msgs/msg/String',
-                '{data: bar}'
-            ]
-        ) as topic_command:
-            assert topic_command.wait_for_output(functools.partial(
-                launch_testing.tools.expect_output, expected_lines=[],
-                strict=True
-            ), timeout=10)
-            assert topic_command.wait_for_shutdown(timeout=10)
-            assert self.listener_node.wait_for_output(functools.partial(
-                launch_testing.tools.expect_output, expected_lines=[],
-                strict=False
-            ), timeout=10)
-        assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
 
     def test_topic_pub(self):
         with self.launch_topic_command(

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -559,7 +559,14 @@ class TestROS2TopicCLI(unittest.TestCase):
 
     def test_topic_pub(self):
         with self.launch_topic_command(
-            arguments=['pub', '/chit_chatter', 'std_msgs/msg/String', '{data: foo}'],
+            arguments=[
+                'pub',
+                '--keep-alive', '3',  # seconds
+                '--qos-durability', 'transient_local',
+                '/chit_chatter',
+                'std_msgs/msg/String',
+                '{data: foo}'
+            ],
         ) as topic_command:
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
@@ -579,6 +586,8 @@ class TestROS2TopicCLI(unittest.TestCase):
         with self.launch_topic_command(
             arguments=[
                 'pub', '--once',
+                '--keep-alive', '3',  # seconds
+                '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: bar}'
@@ -604,6 +613,8 @@ class TestROS2TopicCLI(unittest.TestCase):
             arguments=[
                 'pub',
                 '-p', '2',
+                '--keep-alive', '3',  # seconds
+                '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: fizz}'

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -378,8 +378,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         arguments=[
             'echo', '--once',
             '/chatter',
-            'std_msgs/msg/String',
-            '{data: bar}'
+            'std_msgs/msg/String'
         ]
         ) as topic_command:
             assert topic_command.wait_for_output(functools.partial(

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -557,6 +557,26 @@ class TestROS2TopicCLI(unittest.TestCase):
             strict=True
         )
 
+    def test_topic_echo_once(self):
+        with self.launch_topic_command(
+            arguments=[
+                'echo', '--once',
+                '/chit_chatter',
+                'std_msgs/msg/String',
+                '{data: bar}'
+            ]
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[],
+                strict=True
+            ), timeout=10)
+            assert topic_command.wait_for_shutdown(timeout=10)
+            assert self.listener_node.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[],
+                strict=False
+            ), timeout=10)
+        assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
+
     def test_topic_pub(self):
         with self.launch_topic_command(
             arguments=[


### PR DESCRIPTION
Closes https://github.com/ros2/ros2cli/issues/529

As mentioned in the issue, this is very usefull when combned with the `--qos-durability=transient_local` as it acts as a "get" command, getting the last message published on a topic (even if the message was published in the past) and then self terminating.

I use this extensivley to query the current state of the system. E.g "tell me the current possition of the robot".

As it is self terminating it can be used in automated tests.