### PR TITLE
Make ros2doctor depend on ros_environment and fix platform.py bug on error.

### DIFF
--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -14,7 +14,8 @@
   <exec_depend>python3-ifcfg</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  
+  <exec_depend>ros_environment</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -114,11 +114,11 @@ class RosdistroReport(DoctorReport):
         return 'platform'
 
     def report(self):
+        ros_report = Report('ROS 2 INFORMATION')
         distros = _check_platform_helper()
         if not distros:
-            return
+            return ros_report
         distro_name, distro_info, distro_data = distros
-        ros_report = Report('ROS 2 INFORMATION')
         ros_report.add_to_report('distribution name', distro_name)
         ros_report.add_to_report('distribution type', distro_info.get('distribution_type'))
         ros_report.add_to_report('distribution status', distro_info.get('distribution_status'))

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -65,7 +65,8 @@ class DoctorCommand(CommandExtension):
         if args.report_failed and fail != 0:
             fail_reports = generate_reports(categories=fail_category)
             for report_obj in fail_reports:
-                format_print(report_obj)
+                if report_obj is not None:
+                    format_print(report_obj)
 
 
 class WtfCommand(DoctorCommand):

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -65,8 +65,7 @@ class DoctorCommand(CommandExtension):
         if args.report_failed and fail != 0:
             fail_reports = generate_reports(categories=fail_category)
             for report_obj in fail_reports:
-                if report_obj is not None:
-                    format_print(report_obj)
+                format_print(report_obj)
 
 
 class WtfCommand(DoctorCommand):


### PR DESCRIPTION
The ros2doctor [package check](https://github.com/ros2/ros2cli/blob/d109a695b0630b139f30c979ec9133836ae77fb0/ros2doctor/ros2doctor/api/package.py#L38) requires ROS_DISTRO to be defined in the environment.  If it is not, you get warnings like:

```
UserWarning: ERROR: ROS_DISTRO is not set
```

Since that environment variable comes from the `ros_environment` package, that means this package has an `exec_depend` on `ros_environment`.  Add that here.

While we are in here, also notice that platform.py returns a "None" value if `_check_platform_helper` fails.  However, it's contract states:

```
:return: Report object storing report content.
```

Thus, make sure to return an empty report on error, which fixes possible crashes and also conforms to what other reports do.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>