### PR TITLE
add --keep-alive option to 'topic pub'

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -84,6 +84,10 @@ class PubVerb(VerbExtension):
             '-t', '--times', type=nonnegative_int, default=0,
             help='Publish this number of times and then exit')
         parser.add_argument(
+            '--keep-alive', metavar='N', type=positive_float, default=0.1,
+            help='Keep publishing node alive for N seconds after the last msg '
+                 '(default: 0.1)')
+        parser.add_argument(
             '-n', '--node-name',
             help='Name of the created publishing node')
         add_qos_arguments_to_argument_parser(
@@ -109,7 +113,8 @@ def main(args):
             1. / args.rate,
             args.print,
             times,
-            qos_profile)
+            qos_profile,
+            args.keep_alive)
 
 
 def publisher(
@@ -121,6 +126,7 @@ def publisher(
     print_nth: int,
     times: int,
     qos_profile: QoSProfile,
+    keep_alive: float,
 ) -> Optional[str]:
     """Initialize a node with a single publisher and run its publish loop (maybe only once)."""
     msg_module = get_message(message_type)
@@ -150,7 +156,7 @@ def publisher(
     while times == 0 or count < times:
         rclpy.spin_once(node)
 
-    if times == 1:
-        time.sleep(0.1)  # make sure the message reaches the wire before exiting
+    # give some time for the messages to reach the wire before exiting
+    time.sleep(keep_alive)
 
     node.destroy_timer(timer)


### PR DESCRIPTION
The new option allows to make the currently hard coded sleep before exiting configurable. It also change the logic to apply that sleep for `times != 1` since even when publishing multiple messages it makes sense to wait after the last one to ensure it is published to the wire.

CI builds testing `ros2topic`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11339)](http://ci.ros2.org/job/ci_linux/11339/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6576)](http://ci.ros2.org/job/ci_linux-aarch64/6576/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9302)](http://ci.ros2.org/job/ci_osx/9302/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11236)](http://ci.ros2.org/job/ci_windows/11236/)