### PR TITLE
use transient_local and longer keep-alive for pub tests

### DIFF
--- a/ros2topic/test/fixtures/listener_node.py
+++ b/ros2topic/test/fixtures/listener_node.py
@@ -16,7 +16,7 @@ import sys
 
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import qos_profile_system_default
+from ros2topic.api import qos_profile_from_short_keys
 
 from std_msgs.msg import String
 
@@ -25,8 +25,10 @@ class ListenerNode(Node):
 
     def __init__(self):
         super().__init__('listener')
+        qos_profile = qos_profile_from_short_keys(
+            'system_default', durability='transient_local')
         self.sub = self.create_subscription(
-            String, 'chatter', self.callback, qos_profile_system_default
+            String, 'chatter', self.callback, qos_profile
         )
 
     def callback(self, msg):

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -561,7 +561,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         with self.launch_topic_command(
             arguments=[
                 'pub',
-                '--keep-alive', '3',
+                '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',
@@ -586,7 +586,7 @@ class TestROS2TopicCLI(unittest.TestCase):
         with self.launch_topic_command(
             arguments=[
                 'pub', '--once',
-                '--keep-alive', '3',
+                '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',
@@ -613,7 +613,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             arguments=[
                 'pub',
                 '-p', '2',
-                '--keep-alive', '3',
+                '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -559,7 +559,14 @@ class TestROS2TopicCLI(unittest.TestCase):
 
     def test_topic_pub(self):
         with self.launch_topic_command(
-            arguments=['pub', '/chit_chatter', 'std_msgs/msg/String', '{data: foo}'],
+            arguments=[
+                'pub',
+                '--keep-alive', '3',
+                '--qos-durability', 'transient_local',
+                '/chit_chatter',
+                'std_msgs/msg/String',
+                '{data: foo}'
+            ],
         ) as topic_command:
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
@@ -579,6 +586,8 @@ class TestROS2TopicCLI(unittest.TestCase):
         with self.launch_topic_command(
             arguments=[
                 'pub', '--once',
+                '--keep-alive', '3',
+                '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: bar}'
@@ -604,6 +613,8 @@ class TestROS2TopicCLI(unittest.TestCase):
             arguments=[
                 'pub',
                 '-p', '2',
+                '--keep-alive', '3',
+                '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: fizz}'


### PR DESCRIPTION
Follow up of #544. Fix flakiness of `pub_once` test added in #304.

E.g. https://ci.ros2.org/view/nightly/job/nightly_linux-centos_extra_rmw_release/459/testReport/ros2topic.ros2topic.test/test_cli/test_cli/

CI build testing `ros2topic`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11341)](http://ci.ros2.org/job/ci_linux/11341/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6578)](http://ci.ros2.org/job/ci_linux-aarch64/6578/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9304)](http://ci.ros2.org/job/ci_osx/9304/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11238)](http://ci.ros2.org/job/ci_windows/11238/)