### PR TITLE
also provide --include-hidden-services for `ros2 service list` verb

### DIFF
--- a/ros2service/ros2service/verb/list.py
+++ b/ros2service/ros2service/verb/list.py
@@ -29,6 +29,9 @@ class ListVerb(VerbExtension):
         parser.add_argument(
             '-c', '--count-services', action='store_true',
             help='Only display the number of services discovered')
+        parser.add_argument(
+            '--include-hidden-services', action='store_true',
+            help='Consider hidden services as well')
 
     def main(self, *, args):
         with NodeStrategy(args) as node:

--- a/ros2service/ros2service/verb/list.py
+++ b/ros2service/ros2service/verb/list.py
@@ -29,6 +29,7 @@ class ListVerb(VerbExtension):
         parser.add_argument(
             '-c', '--count-services', action='store_true',
             help='Only display the number of services discovered')
+        # duplicate the following argument from the command for visibility
         parser.add_argument(
             '--include-hidden-services', action='store_true',
             help='Consider hidden services as well')

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -157,7 +157,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list_hidden(self):
         with self.launch_service_command(
-            arguments=['--include-hidden-services', 'list']
+            arguments=['list', '--include-hidden-services']
         ) as service_command:
             assert service_command.wait_for_shutdown(timeout=10)
         assert service_command.exit_code == launch_testing.asserts.EXIT_OK


### PR DESCRIPTION
There's currently API in place for listing hidden services, however the command line option was never exposed.