### PR TITLE
Composition API

### DIFF
--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -14,7 +14,6 @@
 
 from collections import namedtuple
 import subprocess
-from ament_index_python import get_resource
 from ament_index_python import get_resources
 from ament_index_python import has_resource
 
@@ -62,7 +61,7 @@ def get_package_names_with_component_types():
 
 def get_package_component_types(*, package_name=None):
     """
-    Get all component types registered in the ament index for the given package.
+    Get all component types registered for the given package.
 
     :param package_name: whose component types are to be retrieved.
     :return: a list of component type names.
@@ -77,7 +76,7 @@ def get_package_component_types(*, package_name=None):
 
 def get_registered_component_types():
     """
-    Get all component types registered in the ament index.
+    Get all registered component types.
 
     :return: a list of (package name, component type names) tuples.
     """
@@ -419,12 +418,12 @@ def add_component_arguments(parser):
     )
 
 
-def run_standalone_container(*, container_node_name):
+def run_standalone_container(*, container_node_name, component_type='rclcpp_components'):
     """Run a standalone component container."""
     try:
-        paths = get_executable_paths(package_name='rclcpp_components')
+        paths = get_executable_paths(package_name=component_type)
     except PackageNotFound:
-        raise RuntimeError("Package 'rclcpp_components' not found")
+        raise RuntimeError("Package '%s' not found" % component_type)
 
     executable_path = next((p for p in paths if 'component_container' in p), None)
     if executable_path is None:

--- a/ros2component/ros2component/api/component_searcher.py
+++ b/ros2component/ros2component/api/component_searcher.py
@@ -1,13 +1,32 @@
-
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 class ComponentSearcher:
+    """An abstract class providing interfaces to get component types"""
 
-    def __init__(self, component_resource_type='rclcpp'):
+    def __init__(self, component_resource_type):
         self.component_resource_type = component_resource_type
 
     def get_component_types(self):
+        """Get the registered component types
+        :return: a list of component types in the tuple(res type/package name, component name)
+        """
         pass
 
     def get_package_component_types(self, package_name):
+        """Get the registered component types in a package
+        :param package_name: whose component types are to be retrieved.
+        :return: a list of component types in the tuple(res type/package name, component name)
+        """
         pass
-

--- a/ros2component/ros2component/api/component_searcher.py
+++ b/ros2component/ros2component/api/component_searcher.py
@@ -1,0 +1,13 @@
+
+
+class ComponentSearcher:
+
+    def __init__(self, component_resource_type='rclcpp'):
+        self.component_resource_type = component_resource_type
+
+    def get_component_types(self):
+        pass
+
+    def get_package_component_types(self, package_name):
+        pass
+

--- a/ros2component/ros2component/verb/standalone.py
+++ b/ros2component/ros2component/verb/standalone.py
@@ -36,9 +36,15 @@ class StandaloneVerb(VerbExtension):
             default='standalone_container_' + uuid.uuid4().hex[:12],
             help='Name of the standalone container node to be run'
         )
+        parser.add_argument(
+            '-t', '--component-type',
+            default='rclcpp_components',
+            help='Component resource types, typically in the format rcl<language>_components'
+        )
 
     def main(self, *, args):
-        container = run_standalone_container(container_node_name=args.container_node_name)
+        container = run_standalone_container(container_node_name=args.container_node_name,
+                                             component_type=args.component_type)
 
         with DirectNode(args) as node:
             try:


### PR DESCRIPTION
Make ros2cli able to handle Python components. The changes:

- Add type `rclpy_components`
- Get the components' metadata by py entry points, related repo: [rcl_component_searchers](https://github.com/crystaldust/rcl_component_searchers). 
- For rclpy_components, use Python's entry_points API to get the metadata, while for rclcpp_components, use a general ament resource searcher, which can also be applied to other programming language implementations(just add an entry point item in the above project's setup.py)
- When calling `ros2 component list`, add the component resource types(rclpy_components or rclcpp_components) to the output