### PR TITLE
Use reliable QoS for ros2topic tests

### DIFF
--- a/ros2topic/test/fixtures/listener_node.py
+++ b/ros2topic/test/fixtures/listener_node.py
@@ -26,7 +26,8 @@ class ListenerNode(Node):
     def __init__(self):
         super().__init__('listener')
         qos_profile = qos_profile_from_short_keys(
-            'system_default', durability='transient_local')
+            'system_default', durability='transient_local',
+            reliability='reliable')
         self.sub = self.create_subscription(
             String, 'chatter', self.callback, qos_profile
         )

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -563,6 +563,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 'pub',
                 '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
+                '--qos-reliability', 'reliable',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: foo}'
@@ -588,6 +589,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 'pub', '--once',
                 '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
+                '--qos-reliability', 'reliable',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: bar}'
@@ -615,6 +617,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 '-p', '2',
                 '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
+                '--qos-reliability', 'reliable',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: fizz}'


### PR DESCRIPTION
The `TestROS2TopicCLI` tests perform feature testing of the ros2topic command line interface. If the system is under stress during these tests, messages may be lost (by design). If that happens, there is a fairly high likelihood that the `test_topic_pub_once` test will fail because there is only one opportunity for the message to be successfully transported. We're likely dropping other messages in this suite, but the other tests continuously publish until one of the messages is received (or a timeout occurs), making them significantly less likely to fail.

Using the 'reliable' setting for QoS reliability seems to make the tests consistently pass, even when the system is placed under additional stress.

Closes #552

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11709)](http://ci.ros2.org/job/ci_linux/11709/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6802)](http://ci.ros2.org/job/ci_linux-aarch64/6802/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9556)](http://ci.ros2.org/job/ci_osx/9556/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11655)](http://ci.ros2.org/job/ci_windows/11655/)
* Linux-repeated [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11708)](http://ci.ros2.org/job/ci_linux/11708/)