### PR TITLE
improve the error message for invalid message types

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -141,7 +141,10 @@ def _get_msg_class(node, topic, include_hidden_topics):
         # Could not determine the type for the passed topic
         return None
 
-    return get_message(message_type)
+    try:
+        return get_message(message_type)
+    except (AttributeError, ModuleNotFoundError, ValueError):
+        raise RuntimeError("The message type '%s' is invalid" % message_type)
 
 
 class TopicMessagePrototypeCompleter:

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -96,7 +96,10 @@ def main(args):
             message_type = get_msg_class(
                 node, args.topic_name, include_hidden_topics=True)
         else:
-            message_type = get_message(args.message_type)
+            try:
+                message_type = get_message(args.message_type)
+            except (AttributeError, ModuleNotFoundError, ValueError):
+                raise RuntimeError('The passed message type is invalid')
 
         if message_type is None:
             raise RuntimeError(

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -129,7 +129,10 @@ def publisher(
     keep_alive: float,
 ) -> Optional[str]:
     """Initialize a node with a single publisher and run its publish loop (maybe only once)."""
-    msg_module = get_message(message_type)
+    try:
+        msg_module = get_message(message_type)
+    except (AttributeError, ModuleNotFoundError, ValueError):
+        raise RuntimeError('The passed message type is invalid')
     values_dictionary = yaml.safe_load(values)
     if not isinstance(values_dictionary, dict):
         return 'The passed value needs to be a dictionary in YAML format'


### PR DESCRIPTION
Closes #557.

CI builds testing only `ros2topic` with Fast DDS:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11725)](http://ci.ros2.org/job/ci_linux/11725/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6809)](http://ci.ros2.org/job/ci_linux-aarch64/6809/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9564)](http://ci.ros2.org/job/ci_osx/9564/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11663)](http://ci.ros2.org/job/ci_windows/11663/)