### PR TITLE
* catch additional exception in get_parameter_value()

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -56,7 +56,7 @@ def get_parameter_value(*, string_value):
     value = ParameterValue()
     try:
         yaml_value = yaml.safe_load(string_value)
-    except yaml.parser.ParserError:
+    except (yaml.parser.ParserError, yaml.scanner.ScannerError):
         value.type = ParameterType.PARAMETER_STRING
         value.string_value = string_value
         return value


### PR DESCRIPTION
If `string_value` contains a leading `%` sign, this is interpreted as a YAML directive, which would throw a ParserError as expected. However, if an additional `%` exists elsewhere in `string_value`, then `PyYAML` throws a `ScannerError`.

Without catching this exception, `get_parameter_value()` will fail under these circumstances. With this fix, the intended behaviour is maintained.

Example: `ros2 param set /my_node my_param "%string"` succeeds, but  `ros2 param set /my_node my_param "%string%"` throws an uncaught `yaml.scanner.ScannerError`.

This commit should resolve the issue.