### PR TITLE
Added dependency to python3-argcomplete to ros2cli

### DIFF
--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -9,11 +9,11 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
+  <exec_depend>python3-argcomplete</exec_depend>
   <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-netifaces</exec_depend>
   <exec_depend>python3-packaging</exec_depend>
   <exec_depend>python3-pkg-resources</exec_depend>
-  <exec_depend>python3-argcomplete</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>python3-netifaces</exec_depend>
   <exec_depend>python3-packaging</exec_depend>
   <exec_depend>python3-pkg-resources</exec_depend>
+  <exec_depend>python3-argcomplete</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Following https://github.com/ros2/ros2_documentation/pull/841#issuecomment-682203981 here's a proposal so that all ros2cli commands no longer require a manual install of python3-argcomplete

TODO: to be updated in https://github.com/ros2/ros2_documentation also 