### PR TITLE
[Foxy backport] add --keep-alive option to 'topic pub' (#544)  use transient_local and longer keep-alive for pub tests (#546) Use reliable QoS for ros2topic tests (#555)

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -84,6 +84,10 @@ class PubVerb(VerbExtension):
             '-t', '--times', type=nonnegative_int, default=0,
             help='Publish this number of times and then exit')
         parser.add_argument(
+            '--keep-alive', metavar='N', type=positive_float, default=0.1,
+            help='Keep publishing node alive for N seconds after the last msg '
+                 '(default: 0.1)')
+        parser.add_argument(
             '-n', '--node-name',
             help='Name of the created publishing node')
         add_qos_arguments_to_argument_parser(
@@ -108,7 +112,8 @@ def main(args):
             1. / args.rate,
             args.print,
             times,
-            qos_profile)
+            qos_profile,
+            args.keep_alive)
 
 
 def publisher(
@@ -120,6 +125,7 @@ def publisher(
     print_nth: int,
     times: int,
     qos_profile: QoSProfile,
+    keep_alive: float,
 ) -> Optional[str]:
     """Initialize a node with a single publisher and run its publish loop (maybe only once)."""
     msg_module = get_message(message_type)
@@ -149,7 +155,7 @@ def publisher(
     while times == 0 or count < times:
         rclpy.spin_once(node)
 
-    if times == 1:
-        time.sleep(0.1)  # make sure the message reaches the wire before exiting
+    # give some time for the messages to reach the wire before exiting
+    time.sleep(keep_alive)
 
     node.destroy_timer(timer)

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -125,7 +125,7 @@ def publisher(
     print_nth: int,
     times: int,
     qos_profile: QoSProfile,
-    keep_alive: float,
+    keep_alive: float = 0.1,
 ) -> Optional[str]:
     """Initialize a node with a single publisher and run its publish loop (maybe only once)."""
     msg_module = get_message(message_type)

--- a/ros2topic/test/fixtures/listener_node.py
+++ b/ros2topic/test/fixtures/listener_node.py
@@ -26,7 +26,8 @@ class ListenerNode(Node):
     def __init__(self):
         super().__init__('listener')
         qos_profile = qos_profile_from_short_keys(
-            'system_default', durability='transient_local')
+            'system_default', durability='transient_local',
+            reliability='reliable')
         self.sub = self.create_subscription(
             String, 'chatter', self.callback, qos_profile
         )

--- a/ros2topic/test/fixtures/listener_node.py
+++ b/ros2topic/test/fixtures/listener_node.py
@@ -16,7 +16,7 @@ import sys
 
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import qos_profile_system_default
+from ros2topic.api import qos_profile_from_short_keys
 
 from std_msgs.msg import String
 
@@ -25,8 +25,10 @@ class ListenerNode(Node):
 
     def __init__(self):
         super().__init__('listener')
+        qos_profile = qos_profile_from_short_keys(
+            'system_default', durability='transient_local')
         self.sub = self.create_subscription(
-            String, 'chatter', self.callback, qos_profile_system_default
+            String, 'chatter', self.callback, qos_profile
         )
 
     def callback(self, msg):

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -559,7 +559,14 @@ class TestROS2TopicCLI(unittest.TestCase):
 
     def test_topic_pub(self):
         with self.launch_topic_command(
-            arguments=['pub', '/chit_chatter', 'std_msgs/msg/String', '{data: foo}'],
+            arguments=[
+                'pub',
+                '--keep-alive', '3',  # seconds
+                '--qos-durability', 'transient_local',
+                '/chit_chatter',
+                'std_msgs/msg/String',
+                '{data: foo}'
+            ],
         ) as topic_command:
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
@@ -579,6 +586,8 @@ class TestROS2TopicCLI(unittest.TestCase):
         with self.launch_topic_command(
             arguments=[
                 'pub', '--once',
+                '--keep-alive', '3',  # seconds
+                '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: bar}'
@@ -604,6 +613,8 @@ class TestROS2TopicCLI(unittest.TestCase):
             arguments=[
                 'pub',
                 '-p', '2',
+                '--keep-alive', '3',  # seconds
+                '--qos-durability', 'transient_local',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: fizz}'

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -563,6 +563,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 'pub',
                 '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
+                '--qos-reliability', 'reliable',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: foo}'
@@ -588,6 +589,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 'pub', '--once',
                 '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
+                '--qos-reliability', 'reliable',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: bar}'
@@ -615,6 +617,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 '-p', '2',
                 '--keep-alive', '3',  # seconds
                 '--qos-durability', 'transient_local',
+                '--qos-reliability', 'reliable',
                 '/chit_chatter',
                 'std_msgs/msg/String',
                 '{data: fizz}'


### PR DESCRIPTION
Backports #544 which added a new `--keep-alive` flag to `ros2 topic pub`
Adds a commit that makes a new argument in #544 a keyword argument with a default value so it doesn't break API
Backports #546 which made `test_topic_pub_once` use new flag
Backports #555 which made `test_topic_pub_once` use reliable QoS

This should fix the flaky test `test_topic_pub_once` in Foxy CI http://build.ros2.org/job/Fci__nightly-fastrtps-dynamic_ubuntu_focal_amd64/181/testReport/junit/ros2topic.test/test_cli/test_cli/