### PR TITLE
Add filter option to ros2topic 

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
-from typing import Callable
 from typing import Optional
 from typing import TypeVar
 
@@ -78,98 +76,96 @@ class EchoVerb(VerbExtension):
             '--raw', action='store_true', help='Echo the raw binary representation')
 
     def main(self, *, args):
-        return main(args)
+        # Select print function
+        self.print_func = _print_yaml
+        if args.csv:
+            self.print_func = _print_csv
 
+        self.truncate_length = args.truncate_length if not args.full_length else None
+        self.no_arr = args.no_arr
+        self.no_str = args.no_str
 
-def main(args):
-    if not args.csv:
-        truncate_length = args.truncate_length if not args.full_length else None
-        callback = subscriber_cb(truncate_length, args.no_arr, args.no_str)
-    else:
-        truncate_length = args.truncate_length if not args.full_length else None
-        callback = subscriber_cb_csv(truncate_length, args.no_arr, args.no_str)
-    qos_profile = qos_profile_from_short_keys(
-        args.qos_profile, reliability=args.qos_reliability, durability=args.qos_durability,
-        depth=args.qos_depth, history=args.qos_history)
-    with NodeStrategy(args) as node:
-        if args.message_type is None:
-            message_type = get_msg_class(
-                node, args.topic_name, include_hidden_topics=True)
-        else:
-            try:
-                message_type = get_message(args.message_type)
-            except (AttributeError, ModuleNotFoundError, ValueError):
-                raise RuntimeError('The passed message type is invalid')
+        qos_profile = qos_profile_from_short_keys(
+            args.qos_profile,
+            reliability=args.qos_reliability,
+            durability=args.qos_durability,
+            depth=args.qos_depth,
+            history=args.qos_history)
 
-        if message_type is None:
-            raise RuntimeError(
-                'Could not determine the type for the passed topic')
+        with NodeStrategy(args) as node:
+            if args.message_type is None:
+                message_type = get_msg_class(
+                    node, args.topic_name, include_hidden_topics=True)
+            else:
+                try:
+                    message_type = get_message(args.message_type)
+                except (AttributeError, ModuleNotFoundError, ValueError):
+                    raise RuntimeError('The passed message type is invalid')
 
-        subscriber(
-            node,
-            args.topic_name,
-            message_type,
-            callback,
-            qos_profile,
-            args.lost_messages,
-            args.raw)
+            if message_type is None:
+                raise RuntimeError(
+                    'Could not determine the type for the passed topic')
 
+            self.subscribe_and_spin(
+                node,
+                args.topic_name,
+                message_type,
+                qos_profile,
+                args.lost_messages,
+                args.raw)
 
-def subscriber(
-    node: Node,
-    topic_name: str,
-    message_type: MsgType,
-    callback: Callable[[MsgType], Any],
-    qos_profile: QoSProfile,
-    report_lost_messages: bool,
-    raw: bool
-) -> Optional[str]:
-    """Initialize a node with a single subscription and spin."""
-    event_callbacks = None
-    if report_lost_messages:
-        event_callbacks = SubscriptionEventCallbacks(
-            message_lost=message_lost_event_callback)
-    try:
-        node.create_subscription(
-            message_type,
-            topic_name,
-            callback,
-            qos_profile,
-            event_callbacks=event_callbacks,
-            raw=raw)
-    except UnsupportedEventTypeError:
-        assert report_lost_messages
-        print(
-            f"The rmw implementation '{get_rmw_implementation_identifier()}'"
-            ' does not support reporting lost messages'
-        )
-    rclpy.spin(node)
-
-
-def subscriber_cb(truncate_length, noarr, nostr):
-    def cb(msg):
-        nonlocal truncate_length, noarr, nostr
-        if isinstance(msg, bytes):
-            print(msg, end='\n---\n')
-        else:
+    def subscribe_and_spin(
+        self,
+        node: Node,
+        topic_name: str,
+        message_type: MsgType,
+        qos_profile: QoSProfile,
+        report_lost_messages: bool,
+        raw: bool
+    ) -> Optional[str]:
+        """Initialize a node with a single subscription and spin."""
+        event_callbacks = None
+        if report_lost_messages:
+            event_callbacks = SubscriptionEventCallbacks(
+                message_lost=_message_lost_event_callback)
+        try:
+            node.create_subscription(
+                message_type,
+                topic_name,
+                self._subscriber_callback,
+                qos_profile,
+                event_callbacks=event_callbacks,
+                raw=raw)
+        except UnsupportedEventTypeError:
+            assert report_lost_messages
             print(
-                message_to_yaml(
-                    msg, truncate_length=truncate_length, no_arr=noarr, no_str=nostr),
-                end='---\n')
-    return cb
+                f"The rmw implementation '{get_rmw_implementation_identifier()}'"
+                ' does not support reporting lost messages'
+            )
+        rclpy.spin(node)
+
+    def _subscriber_callback(self, msg):
+        self.print_func(msg, self.truncate_length, self.no_arr, self.no_str)
 
 
-def subscriber_cb_csv(truncate_length, noarr, nostr):
-    def cb(msg):
-        nonlocal truncate_length, noarr, nostr
-        if isinstance(msg, bytes):
-            print(msg)
-        else:
-            print(message_to_csv(msg, truncate_length=truncate_length, no_arr=noarr, no_str=nostr))
-    return cb
+def _print_yaml(msg, truncate_length, noarr, nostr):
+    if isinstance(msg, bytes):
+        print(msg, end='\n---\n')
+    else:
+        print(
+            message_to_yaml(
+                msg, truncate_length=truncate_length, no_arr=noarr, no_str=nostr),
+            end='---\n')
 
 
-def message_lost_event_callback(message_lost_status):
+def _print_csv(msg, truncate_length, noarr, nostr):
+    if isinstance(msg, bytes):
+        print(msg)
+    else:
+        print(message_to_csv(msg, truncate_length=truncate_length, no_arr=noarr, no_str=nostr))
+
+
+def _message_lost_event_callback(message_lost_status):
     print(
         'A message was lost!!!\n\ttotal count change:'
         f'{message_lost_status.total_count_change}'

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -543,6 +543,42 @@ class TestROS2TopicCLI(unittest.TestCase):
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
 
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_filter(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--filter', 'alignment_check'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    '0',
+                    '---',
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_filter_not_a_member(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--filter', 'not_member'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    "Invalid filter 'not_member': 'Arrays' object has no attribute 'not_member'",
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    def test_topic_echo_filter_invalid(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--filter', '/'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    "Invalid filter value '/'",
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
     def test_topic_echo_no_publisher(self):
         with self.launch_topic_command(
             arguments=['echo', '/this_topic_has_no_pub'],

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -544,9 +544,9 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.wait_for_shutdown(timeout=10)
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
-    def test_topic_echo_filter(self):
+    def test_topic_echo_field(self):
         with self.launch_topic_command(
-            arguments=['echo', '/arrays', '--filter', 'alignment_check'],
+            arguments=['echo', '/arrays', '--field', 'alignment_check'],
         ) as topic_command:
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
@@ -557,24 +557,49 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.wait_for_shutdown(timeout=10)
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
-    def test_topic_echo_filter_not_a_member(self):
+    def test_topic_echo_field_nested(self):
         with self.launch_topic_command(
-            arguments=['echo', '/arrays', '--filter', 'not_member'],
+            arguments=['echo', '/cmd_vel', '--field', 'twist.angular'],
         ) as topic_command:
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
-                    "Invalid filter 'not_member': 'Arrays' object has no attribute 'not_member'",
+                    'x: 0.0',
+                    'y: 0.0',
+                    'z: 0.0',
+                    '---',
                 ], strict=True
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
 
-    def test_topic_echo_filter_invalid(self):
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_field_not_a_member(self):
         with self.launch_topic_command(
-            arguments=['echo', '/arrays', '--filter', '/'],
+            arguments=['echo', '/arrays', '--field', 'not_member'],
         ) as topic_command:
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
-                    "Invalid filter value '/'",
+                    "Invalid field 'not_member': 'Arrays' object has no attribute 'not_member'",
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    def test_topic_echo_field_invalid(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--field', '/'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    "Invalid field '/': 'Arrays' object has no attribute '/'",
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--field', '.'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    "Invalid field value '.'",
                 ], strict=True
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)


### PR DESCRIPTION
A new '--filter' option makes it easy to echo only part of a message.
For example, to only echo the position part of an odometry message:

    ros2 topic echo /odom --filter pose/pose/position

The filter option takes one value that must not be empty (or only forward slashes '/').

--- 

I found that this feature was a bit easier to add after refactoring the code a little bit. I did the refactor in a separate commit to make the review easier (ae07bd5):

* Move subscription functions into class for easier reuse arguments.
* Prefix functions with an underscore to indicate they are private.