### PR TITLE
Declare missing dependency on python3-importlib-resources

### DIFF
--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -12,6 +12,7 @@
 
   <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
+  <depend>python3-importlib-resources</depend>
   <depend>ros2cli</depend>
 
   <exec_depend>ament_index_python</exec_depend>


### PR DESCRIPTION
Requires ros/rosdistro#28001.

Used here:
https://github.com/ros2/ros2cli/blob/f6c4a5b05d172f8156645b8fcf8bd2dfa23e7bb2/ros2pkg/ros2pkg/api/create.py#L20-L23

The source code supports using the `importlib_resources` package, but on all of the platforms we're running regular builds for, we have Python 3.7, which provides the package as part of Python itself.