### PR TITLE
Support Python 3.8-provided importlib.metadata

### DIFF
--- a/ros2cli/ros2cli/entry_points.py
+++ b/ros2cli/ros2cli/entry_points.py
@@ -16,7 +16,10 @@
 from collections import defaultdict
 import logging
 
-import importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
 
 """
 The group name for entry points identifying extension points.

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -16,7 +16,10 @@ from typing import List
 from typing import Set
 from typing import Tuple
 
-import importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
 
 from ros2doctor.api.format import doctor_warn
 


### PR DESCRIPTION
The importlib_metadata package is a backport of the importlib.metadata module from Python 3.8. Fedora (and possibly others) no longer package importlib_metadata because they ship Python versions which have the functionality built-in.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13460)](http://ci.ros2.org/job/ci_linux/13460/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8371)](http://ci.ros2.org/job/ci_linux-aarch64/8371/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11184)](http://ci.ros2.org/job/ci_osx/11184/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13524)](http://ci.ros2.org/job/ci_windows/13524/)