### PR TITLE
ros2 param dump/load should use fully qualified node names

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -139,19 +139,17 @@ def load_parameter_dict(*, node, node_name, parameter_dict):
 
 def load_parameter_file(*, node, node_name, parameter_file):
     # Remove leading slash and namespaces
-    internal_node_name = node_name.split('/')[-1]
     with open(parameter_file, 'r') as f:
         param_file = yaml.safe_load(f)
-        if internal_node_name not in param_file:
+        if node_name not in param_file:
             raise RuntimeError('Param file does not contain parameters for {}, '
-                               ' only for namespaces: {}' .format(internal_node_name,
-                                                                  param_file.keys()))
+                               ' only for nodes: {}' .format(node_name, param_file.keys()))
 
-        value = param_file[internal_node_name]
+        value = param_file[node_name]
         if type(value) != dict or 'ros__parameters' not in value:
-            raise RuntimeError('Invalid structure of parameter file in namespace {}'
+            raise RuntimeError('Invalid structure of parameter file for node {}'
                                'expected same format as provided by ros2 param dump'
-                               .format(internal_node_name))
+                               .format(node_name))
         load_parameter_dict(node=node, node_name=node_name,
                             parameter_dict=value['ros__parameters'])
 

--- a/ros2param/ros2param/verb/dump.py
+++ b/ros2param/ros2param/verb/dump.py
@@ -108,7 +108,7 @@ class DumpVerb(VerbExtension):
             # wait for response
             rclpy.spin_until_future_complete(node, future)
 
-            yaml_output = {node_name.name: {'ros__parameters': {}}}
+            yaml_output = {node_name.full_name: {'ros__parameters': {}}}
 
             # retrieve values
             if future.result() is not None:
@@ -116,7 +116,7 @@ class DumpVerb(VerbExtension):
                 for param_name in sorted(response.result.names):
                     pval = self.get_parameter_value(node, absolute_node_name, param_name)
                     self.insert_dict(
-                        yaml_output[node_name.name]['ros__parameters'], param_name, pval)
+                        yaml_output[node_name.full_name]['ros__parameters'], param_name, pval)
             else:
                 e = future.exception()
                 raise RuntimeError(

--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -43,7 +43,7 @@ TEST_NAMESPACE = '/foo'
 TEST_TIMEOUT = 20.0
 
 EXPECTED_PARAMETER_FILE = (
-    f'{TEST_NODE}:\n'
+    f'{TEST_NAMESPACE}/{TEST_NODE}:\n'
     '  ros__parameters:\n'
     '    bool_array_param:\n'
     '    - false\n'

--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -43,7 +43,7 @@ TEST_NAMESPACE = '/foo'
 TEST_TIMEOUT = 20.0
 
 INPUT_PARAMETER_FILE = (
-    f'{TEST_NODE}:\n'
+    f'{TEST_NAMESPACE}/{TEST_NODE}:\n'
     '  ros__parameters:\n'
     '    bool_array_param:\n'
     '    - true\n'


### PR DESCRIPTION
Make `ros2 param dump` consistent with how `rclcpp` and `rclpy` load parameters.

See for example https://github.com/ros2/rclcpp/blob/ab743392e4daf546eb0de704936b5f14ef6e0417/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp#L97.