### PR TITLE
Update ros2topic test to expect additional endpoint info

### DIFF
--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -295,7 +295,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 re.compile(r'Endpoint type: (INVALID|PUBLISHER|SUBSCRIPTION)'),
                 re.compile(r'GID: [\w\.]+'),
                 'QoS profile:',
-                re.compile(r'  History: (KEEP_LAST|KEEP_ALL)'),
+                re.compile(r'  History: (KEEP_LAST|KEEP_ALL|UNKNOWN)'),
                 re.compile(r'  Depth: \d+'),
                 re.compile(r'  Reliability: (RELIABLE|BEST_EFFORT|SYSTEM_DEFAULT|UNKNOWN)'),
                 re.compile(r'  Durability: (VOLATILE|TRANSIENT_LOCAL|SYSTEM_DEFAULT|UNKNOWN)'),

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -295,6 +295,8 @@ class TestROS2TopicCLI(unittest.TestCase):
                 re.compile(r'Endpoint type: (INVALID|PUBLISHER|SUBSCRIPTION)'),
                 re.compile(r'GID: [\w\.]+'),
                 'QoS profile:',
+                re.compile(r'  History: (KEEP_LAST|KEEP_ALL)'),
+                re.compile(r'  Depth: \d+'),
                 re.compile(r'  Reliability: (RELIABLE|BEST_EFFORT|SYSTEM_DEFAULT|UNKNOWN)'),
                 re.compile(r'  Durability: (VOLATILE|TRANSIENT_LOCAL|SYSTEM_DEFAULT|UNKNOWN)'),
                 re.compile(r'  Lifespan: \d+ nanoseconds'),


### PR DESCRIPTION
The verbose option will now output history and depth policies.

Connected to https://github.com/ros2/rclpy/pull/686