### PR TITLE
Wait for daemon shutdown before testing NodeStrategy

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -132,5 +132,24 @@ class DaemonNode:
         self._proxy.__exit__(exc_type, exc_value, traceback)
 
 
+def shutdown_daemon(args, wait_until_shutdown=None):
+    with DaemonNode(args) as node:
+        node.system.shutdown()
+
+    if wait_until_shutdown is None:
+        return True
+
+    if wait_until_shutdown > 0.0:
+        timeout = time.time() + wait_until_shutdown
+    else:
+        timeout = None
+
+    while is_daemon_running(args):
+        time.sleep(0.1)
+        if timeout and time.time() >= timeout:
+            return False
+    return True
+
+
 def add_arguments(parser):
     pass

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -132,15 +132,24 @@ class DaemonNode:
         self._proxy.__exit__(exc_type, exc_value, traceback)
 
 
-def shutdown_daemon(args, wait_until_shutdown=None):
+def shutdown_daemon(args, wait_duration=None):
+    """
+    Shuts down remote daemon node.
+
+    :param args: DaemonNode arguments namespace.
+    :param wait_duration: optional duration, in seconds, to wait
+      until the daemon node is fully shut down. Non-positive
+      durations will result in an indefinite wait.
+    :return: whether the daemon is shut down already or not.
+    """
     with DaemonNode(args) as node:
         node.system.shutdown()
 
-    if wait_until_shutdown is None:
-        return True
+    if wait_duration is None:
+        return not is_daemon_running(args)
 
-    if wait_until_shutdown > 0.0:
-        timeout = time.time() + wait_until_shutdown
+    if wait_duration > 0.0:
+        timeout = time.time() + wait_duration
     else:
         timeout = None
 

--- a/ros2cli/test/test_strategy.py
+++ b/ros2cli/test/test_strategy.py
@@ -25,7 +25,7 @@ from ros2cli.node.strategy import NodeStrategy
 @pytest.fixture
 def enforce_no_daemon_is_running():
     if is_daemon_running(args=[]):
-        assert shutdown_daemon(args=[], wait_until_shutdown=5.0)
+        assert shutdown_daemon(args=[], wait_duration=5.0)
     yield
 
 

--- a/ros2cli/test/test_strategy.py
+++ b/ros2cli/test/test_strategy.py
@@ -16,8 +16,8 @@ import argparse
 
 import pytest
 
-from ros2cli.node.daemon import DaemonNode
 from ros2cli.node.daemon import is_daemon_running
+from ros2cli.node.daemon import shutdown_daemon
 from ros2cli.node.daemon import spawn_daemon
 from ros2cli.node.strategy import NodeStrategy
 
@@ -25,8 +25,7 @@ from ros2cli.node.strategy import NodeStrategy
 @pytest.fixture
 def enforce_no_daemon_is_running():
     if is_daemon_running(args=[]):
-        with DaemonNode(args=[]) as node:
-            node.system.shutdown()
+        assert shutdown_daemon(args=[], wait_until_shutdown=5.0)
     yield
 
 
@@ -53,8 +52,6 @@ def test_with_no_daemon_running(enforce_no_daemon_is_running):
 
 
 def test_enforce_no_daemon(enforce_daemon_is_running):
-    if not is_daemon_running(args=[]):
-        assert spawn_daemon(args=[], wait_until_spawned=5.0)
     args = argparse.Namespace(no_daemon=True)
     with NodeStrategy(args=args) as node:
         assert node._daemon_node is None


### PR DESCRIPTION
Hopefully this solves the sporadic flakes on Windows (e.g. https://ci.ros2.org/view/nightly/job/nightly_win_rep/lastCompletedBuild/testReport/ros2cli.ros2cli.test/test_strategy/test_with_no_daemon_running_3_3_/)

CI up to `ros2cli`: 

* Repeated Windows CI [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14429)](https://ci.ros2.org/job/ci_windows/14429/)