### PR TITLE
[ros2doctor] Add QoS compatibility check and report

### DIFF
--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -141,13 +141,12 @@ def generate_reports(*, categories=None) -> List[Report]:
     return reports
 
 
-def get_topic_names() -> List:
+def get_topic_names(skip_topics: List = ()) -> List:
     """Get all topic names using rclpy API."""
-    white_list = ['/parameter_events', '/rosout']
     topics = []
     with NodeStrategy(None) as node:
         topic_names_types = node.get_topic_names_and_types()
         for t_name, _ in topic_names_types:
-            if t_name not in white_list:
+            if t_name not in skip_topics:
                 topics.append(t_name)
     return topics

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -63,10 +63,6 @@ class Report:
         """Add report content to items list (list of string tuples)."""
         self.items.append((item_name, item_info))
 
-    def add_section_to_report(self, section_name: str) -> None:
-        """Add report content to items list (list of string tuples)."""
-        self.items.append((section_name, ''))
-
 
 class Result:
     """Stores check result."""

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -21,6 +21,7 @@ try:
 except ModuleNotFoundError:
     import importlib_metadata
 
+from ros2cli.node.strategy import NodeStrategy
 from ros2doctor.api.format import doctor_warn
 
 
@@ -62,6 +63,9 @@ class Report:
         """Add report content to items list (list of string tuples)."""
         self.items.append((item_name, item_info))
 
+    def add_section_to_report(self, section_name: str) -> None:
+        """Add report content to items list (list of string tuples)."""
+        self.items.append((section_name, ''))
 
 class Result:
     """Stores check result."""
@@ -138,3 +142,15 @@ def generate_reports(*, categories=None) -> List[Report]:
         except Exception:
             doctor_warn(f'Fail to call {report_entry_pt.name} class functions.')
     return reports
+
+
+def get_topic_names() -> List:
+    """Get all topic names using rclpy API."""
+    white_list = ['/parameter_events', '/rosout']
+    topics = []
+    with NodeStrategy(None) as node:
+        topic_names_types = node.get_topic_names_and_types()
+        for t_name, _ in topic_names_types:
+            if t_name not in white_list:
+                topics.append(t_name)
+    return topics

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -67,6 +67,7 @@ class Report:
         """Add report content to items list (list of string tuples)."""
         self.items.append((section_name, ''))
 
+
 class Result:
     """Stores check result."""
 

--- a/ros2doctor/ros2doctor/api/qos_compatibility.py
+++ b/ros2doctor/ros2doctor/api/qos_compatibility.py
@@ -57,6 +57,7 @@ class QoSCompatibilityCheck(DoctorCheck):
     def _strip_leading_warning_or_error_from_string(string: str) -> str:
         """
         Remove "warning: " or "error: " (case insensitive) from the beginning of a string.
+
         If "warning: " or "error: " is not found, the original string is returned.
         """
         re_result = re.search(r'^(?i:warning|error): (.*)', string)

--- a/ros2doctor/ros2doctor/api/qos_compatibility.py
+++ b/ros2doctor/ros2doctor/api/qos_compatibility.py
@@ -1,0 +1,77 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from rclpy.qos import qos_check_compatible
+from rclpy.qos import QoSCompatibility
+from ros2cli.node.strategy import NodeStrategy
+from ros2doctor.api import DoctorCheck
+from ros2doctor.api import DoctorReport
+from ros2doctor.api import get_topic_names
+from ros2doctor.api import Report
+from ros2doctor.api import Result
+from ros2doctor.api.format import doctor_warn
+from ros2doctor.api.format import doctor_error
+
+
+class QoSCompatibilityCheck(DoctorCheck):
+    """Check for incompatible QoS profiles in each pub/sub pair."""
+
+    def category(self):
+        return 'middleware'
+
+    def check(self):
+        """Check publisher and subscriber counts."""
+        result = Result()
+        to_be_checked = get_topic_names()
+        with NodeStrategy(None) as node:
+            for topic in to_be_checked:
+                for pub in node.get_publishers_info_by_topic(topic):
+                    for sub in node.get_subscriptions_info_by_topic(topic):
+                        compatibility, reason = qos_check_compatible(pub.qos_profile, sub.qos_profile)
+                        if compatibility == QoSCompatibility.WARNING:
+                            doctor_warn(f"QOS compatibility warning found on topic '{topic}'. "
+                                        'Use `ros2 doctor --report` for more details.')
+                            result.add_warning()
+                        elif compatibility == QoSCompatibility.ERROR:
+                            doctor_error(f"QOS compatibility error found on topic '{topic}'. "
+                                         'Use `ros2 doctor --report` for more details.')
+                            result.add_error()
+        return result
+
+
+class QoSCompatibilityReport(DoctorReport):
+    """Report QoS compatibility related information."""
+
+    def category(self):
+        return 'topic'
+
+    def report(self):
+        report = Report('QOS COMPATIBILITY LIST')
+        to_be_reported = get_topic_names()
+        with NodeStrategy(None) as node:
+            for topic in to_be_reported:
+                for pub in node.get_publishers_info_by_topic(topic):
+                    for sub in node.get_subscriptions_info_by_topic(topic):
+                        compatibility, reason = qos_check_compatible(pub.qos_profile, sub.qos_profile)
+                        report.add_to_report('topic [type]', f'{topic} [{pub.topic_type}]')
+                        report.add_to_report('publisher node', pub.node_name)
+                        report.add_to_report('subscriber node', sub.node_name)
+                        if compatibility == QoSCompatibility.OK:
+                            compatibility_msg = 'OK'
+                        else:
+                            compatibility_msg = reason
+                        report.add_to_report('compatibility status', compatibility_msg)
+        return report

--- a/ros2doctor/ros2doctor/api/qos_compatibility.py
+++ b/ros2doctor/ros2doctor/api/qos_compatibility.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2021 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
 from rclpy.qos import qos_check_compatible
 from rclpy.qos import QoSCompatibility
 from ros2cli.node.strategy import NodeStrategy
@@ -22,8 +20,8 @@ from ros2doctor.api import DoctorReport
 from ros2doctor.api import get_topic_names
 from ros2doctor.api import Report
 from ros2doctor.api import Result
-from ros2doctor.api.format import doctor_warn
 from ros2doctor.api.format import doctor_error
+from ros2doctor.api.format import doctor_warn
 
 
 class QoSCompatibilityCheck(DoctorCheck):
@@ -40,7 +38,8 @@ class QoSCompatibilityCheck(DoctorCheck):
             for topic in to_be_checked:
                 for pub in node.get_publishers_info_by_topic(topic):
                     for sub in node.get_subscriptions_info_by_topic(topic):
-                        compatibility, reason = qos_check_compatible(pub.qos_profile, sub.qos_profile)
+                        compatibility, reason = qos_check_compatible(
+                            pub.qos_profile, sub.qos_profile)
                         if compatibility == QoSCompatibility.WARNING:
                             doctor_warn(f"QOS compatibility warning found on topic '{topic}'. "
                                         'Use `ros2 doctor --report` for more details.')
@@ -65,7 +64,8 @@ class QoSCompatibilityReport(DoctorReport):
             for topic in to_be_reported:
                 for pub in node.get_publishers_info_by_topic(topic):
                     for sub in node.get_subscriptions_info_by_topic(topic):
-                        compatibility, reason = qos_check_compatible(pub.qos_profile, sub.qos_profile)
+                        compatibility, reason = qos_check_compatible(
+                            pub.qos_profile, sub.qos_profile)
                         report.add_to_report('topic [type]', f'{topic} [{pub.topic_type}]')
                         report.add_to_report('publisher node', pub.node_name)
                         report.add_to_report('subscriber node', sub.node_name)

--- a/ros2doctor/ros2doctor/api/qos_compatibility.py
+++ b/ros2doctor/ros2doctor/api/qos_compatibility.py
@@ -74,4 +74,10 @@ class QoSCompatibilityReport(DoctorReport):
                         else:
                             compatibility_msg = reason
                         report.add_to_report('compatibility status', compatibility_msg)
+        if self._is_report_empty(report):
+            report.add_to_report('compatibility status', "No publisher/subscriber pairs found")
         return report
+
+    @staticmethod
+    def _is_report_empty(report: Report) -> bool:
+        return len(report.items) == 0

--- a/ros2doctor/ros2doctor/api/qos_compatibility.py
+++ b/ros2doctor/ros2doctor/api/qos_compatibility.py
@@ -71,7 +71,7 @@ class QoSCompatibilityReport(DoctorReport):
     """Report QoS compatibility related information."""
 
     def category(self):
-        return 'topic'
+        return 'middleware'
 
     def report(self):
         report = Report('QOS COMPATIBILITY LIST')

--- a/ros2doctor/ros2doctor/api/qos_compatibility.py
+++ b/ros2doctor/ros2doctor/api/qos_compatibility.py
@@ -45,11 +45,11 @@ class QoSCompatibilityCheck(DoctorCheck):
                         reason_message = self._strip_leading_warning_or_error_from_string(reason)
                         if compatibility == QoSCompatibility.WARNING:
                             doctor_warn(f"QoS compatibility warning found on topic '{topic}': "
-                                        f"{reason_message}")
+                                        f'{reason_message}')
                             result.add_warning()
                         elif compatibility == QoSCompatibility.ERROR:
                             doctor_error(f"QoS compatibility error found on topic '{topic}': "
-                                         f"{reason_message}")
+                                         f'{reason_message}')
                             result.add_error()
         return result
 
@@ -92,7 +92,7 @@ class QoSCompatibilityReport(DoctorReport):
                             compatibility_msg = reason
                         report.add_to_report('compatibility status', compatibility_msg)
         if self._is_report_empty(report):
-            report.add_to_report('compatibility status', "No publisher/subscriber pairs found")
+            report.add_to_report('compatibility status', 'No publisher/subscriber pairs found')
         return report
 
     @staticmethod

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -15,24 +15,12 @@
 from typing import List
 
 from ros2cli.node.direct import DirectNode
-from ros2cli.node.strategy import NodeStrategy
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
+from ros2doctor.api import get_topic_names
 from ros2doctor.api import Report
 from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_warn
-
-
-def _get_topic_names() -> List:
-    """Get all topic names using rclpy API."""
-    white_list = ['/parameter_events', '/rosout']
-    topics = []
-    with NodeStrategy(None) as node:
-        topic_names_types = node.get_topic_names_and_types()
-        for t_name, _ in topic_names_types:
-            if t_name not in white_list:
-                topics.append(t_name)
-    return topics
 
 
 class TopicCheck(DoctorCheck):
@@ -44,7 +32,7 @@ class TopicCheck(DoctorCheck):
     def check(self):
         """Check publisher and subscriber counts."""
         result = Result()
-        to_be_checked = _get_topic_names()
+        to_be_checked = get_topic_names()
         with DirectNode(None) as node:
             for topic in to_be_checked:
                 pub_count = node.count_publishers(topic)
@@ -66,7 +54,7 @@ class TopicReport(DoctorReport):
 
     def report(self):
         report = Report('TOPIC LIST')
-        to_be_reported = _get_topic_names()
+        to_be_reported = get_topic_names()
         if not to_be_reported:
             report.add_to_report('topic', 'none')
             report.add_to_report('publisher count', 0)

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -21,6 +21,9 @@ from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_warn
 
 
+SKIP_TOPICS = ['/parameter_events', '/rosout']
+
+
 class TopicCheck(DoctorCheck):
     """Check for pub without sub or sub without pub."""
 
@@ -30,7 +33,7 @@ class TopicCheck(DoctorCheck):
     def check(self):
         """Check publisher and subscriber counts."""
         result = Result()
-        to_be_checked = get_topic_names()
+        to_be_checked = get_topic_names(skip_topics=SKIP_TOPICS)
         with DirectNode(None) as node:
             for topic in to_be_checked:
                 pub_count = node.count_publishers(topic)
@@ -52,7 +55,7 @@ class TopicReport(DoctorReport):
 
     def report(self):
         report = Report('TOPIC LIST')
-        to_be_reported = get_topic_names()
+        to_be_reported = get_topic_names(skip_topics=SKIP_TOPICS)
         if not to_be_reported:
             report.add_to_report('topic', 'none')
             report.add_to_report('publisher count', 0)

--- a/ros2doctor/ros2doctor/api/topic.py
+++ b/ros2doctor/ros2doctor/api/topic.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
 from ros2cli.node.direct import DirectNode
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -41,6 +41,7 @@ setup(
             'PlatformCheck = ros2doctor.api.platform:PlatformCheck',
             'NetworkCheck = ros2doctor.api.network:NetworkCheck',
             'TopicCheck = ros2doctor.api.topic:TopicCheck',
+            'QoSCompatibilityCheck = ros2doctor.api.qos_compatibility:QoSCompatibilityCheck',
             'PackageCheck = ros2doctor.api.package:PackageCheck',
         ],
         'ros2doctor.report': [
@@ -49,6 +50,7 @@ setup(
             'NetworkReport = ros2doctor.api.network:NetworkReport',
             'RMWReport = ros2doctor.api.rmw:RMWReport',
             'TopicReport = ros2doctor.api.topic:TopicReport',
+            'QoSCompatibilityReport = ros2doctor.api.qos_compatibility:QoSCompatibilityReport',
             'PackageReport = ros2doctor.api.package:PackageReport',
         ],
         'ros2cli.extension_point': [

--- a/ros2doctor/test/fixtures/listener_node_with_reliable_qos.py
+++ b/ros2doctor/test/fixtures/listener_node_with_reliable_qos.py
@@ -1,0 +1,59 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
+
+from std_msgs.msg import String
+
+
+class ListenerNode(Node):
+
+    def __init__(self):
+        super().__init__('listener')
+        qos_profile = QoSProfile(
+            depth=1,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+        )
+        self.sub = self.create_subscription(
+            String, 'chatter', self.callback, qos_profile
+        )
+
+    def callback(self, msg):
+        self.get_logger().info('I heard: [%s]' % msg.data)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    node = ListenerNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        print('listener stopped cleanly')
+    except BaseException:
+        print('exception in listener:', file=sys.stderr)
+        raise
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2doctor/test/fixtures/listener_node_with_reliable_qos.py
+++ b/ros2doctor/test/fixtures/listener_node_with_reliable_qos.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2021 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ros2doctor/test/fixtures/talker_node_with_best_effort_qos.py
+++ b/ros2doctor/test/fixtures/talker_node_with_best_effort_qos.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2021 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ros2doctor/test/fixtures/talker_node_with_best_effort_qos.py
+++ b/ros2doctor/test/fixtures/talker_node_with_best_effort_qos.py
@@ -1,0 +1,60 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
+
+from std_msgs.msg import String
+
+
+class TalkerNode(Node):
+
+    def __init__(self):
+        super().__init__('talker_node')
+        qos_profile = QoSProfile(
+            depth=1,
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+        )
+        self.count = 1
+        self.pub = self.create_publisher(String, 'chatter', qos_profile=qos_profile)
+        self.tmr = self.create_timer(1.0, self.callback)
+
+    def callback(self):
+        self.pub.publish(String(data='Hello World: {0}'.format(self.count)))
+        self.count += 1
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    node = TalkerNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        print('talker stopped cleanly')
+    except BaseException:
+        print('exception in talker:', file=sys.stderr)
+        raise
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2doctor/test/fixtures/talker_node_with_reliable_qos.py
+++ b/ros2doctor/test/fixtures/talker_node_with_reliable_qos.py
@@ -1,0 +1,60 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
+
+from std_msgs.msg import String
+
+
+class TalkerNode(Node):
+
+    def __init__(self):
+        super().__init__('talker_node')
+        qos_profile = QoSProfile(
+            depth=1,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+        )
+        self.count = 1
+        self.pub = self.create_publisher(String, 'chatter', qos_profile=qos_profile)
+        self.tmr = self.create_timer(1.0, self.callback)
+
+    def callback(self):
+        self.pub.publish(String(data='Hello World: {0}'.format(self.count)))
+        self.count += 1
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    node = TalkerNode()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        print('talker stopped cleanly')
+    except BaseException:
+        print('exception in talker:', file=sys.stderr)
+        raise
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2doctor/test/fixtures/talker_node_with_reliable_qos.py
+++ b/ros2doctor/test/fixtures/talker_node_with_reliable_qos.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2021 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ros2doctor/test/test_qos_compatibility.py
+++ b/ros2doctor/test/test_qos_compatibility.py
@@ -1,0 +1,172 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import os
+import re
+import sys
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+
+from launch_ros.actions import Node
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+import launch_testing_ros.tools
+
+import pytest
+
+from rclpy.utilities import get_available_rmw_implementations
+
+
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+        'CLI tests can block for a pathological amount of time on Windows.',
+        allow_module_level=True)
+
+
+@pytest.mark.rostest
+@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+def generate_test_description(rmw_implementation):
+    path_to_fixtures = os.path.join(os.path.dirname(__file__), 'fixtures')
+    additional_env = {
+        'RMW_IMPLEMENTATION': rmw_implementation, 'PYTHONUNBUFFERED': '1'
+    }
+
+    path_to_incompatible_talker_node_script = os.path.join(
+        path_to_fixtures, 'talker_node_with_best_effort_qos.py')
+    path_to_compatible_talker_node_script = os.path.join(
+        path_to_fixtures, 'talker_node_with_reliable_qos.py')
+
+    path_to_listener_node_script = os.path.join(
+        path_to_fixtures, 'listener_node_with_reliable_qos.py')
+
+    talker_node_compatible = Node(
+        executable=sys.executable,
+        arguments=[path_to_compatible_talker_node_script],
+        remappings=[('chatter', 'compatible_chatter')],
+        additional_env=additional_env
+    )
+    listener_node_compatible = Node(
+        executable=sys.executable,
+        arguments=[path_to_listener_node_script],
+        remappings=[('chatter', 'compatible_chatter')],
+        additional_env=additional_env
+    )
+    talker_node_incompatible = Node(
+        executable=sys.executable,
+        arguments=[path_to_incompatible_talker_node_script],
+        remappings=[('chatter', 'incompatible_chatter')],
+        additional_env=additional_env
+    )
+    listener_node_incompatible = Node(
+        executable=sys.executable,
+        arguments=[path_to_listener_node_script],
+        remappings=[('chatter', 'incompatible_chatter')],
+        additional_env=additional_env
+    )
+
+    return LaunchDescription([
+        # Always restart daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                ExecuteProcess(
+                    cmd=['ros2', 'daemon', 'start'],
+                    name='daemon-start',
+                    on_exit=[
+                        # Add incompatible talker/listener pair.
+                        talker_node_incompatible,
+                        listener_node_incompatible,
+                        talker_node_compatible,
+                        listener_node_compatible,
+                        launch_testing.actions.ReadyToTest()
+                    ],
+                    additional_env=additional_env
+                )
+            ]
+        ),
+    ]), locals()
+
+
+class TestROS2DoctorQoSCompatibility(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(
+            cls,
+            launch_service,
+            proc_info,
+            proc_output,
+            rmw_implementation,
+    ):
+        rmw_implementation_filter = launch_testing_ros.tools.basic_output_filter(
+            filtered_patterns=['WARNING: topic .* does not appear to be published yet'],
+            filtered_rmw_implementation=rmw_implementation
+        )
+
+        @contextlib.contextmanager
+        def launch_doctor_command(self, arguments):
+            doctor_command_action = ExecuteProcess(
+                cmd=['ros2', 'doctor', *arguments],
+                additional_env={
+                    'RMW_IMPLEMENTATION': rmw_implementation,
+                    'PYTHONUNBUFFERED': '1'
+                },
+                name='ros2doctor-cli',
+                output='screen'
+            )
+            with launch_testing.tools.launch_process(
+                    launch_service, doctor_command_action, proc_info, proc_output,
+                    output_filter=rmw_implementation_filter
+            ) as doctor_command:
+                yield doctor_command
+        cls.launch_doctor_command = launch_doctor_command
+
+    def test_check(self):
+        with self.launch_doctor_command(
+                arguments=[]
+        ) as doctor_command:
+            assert doctor_command.wait_for_shutdown(timeout=10)
+        assert doctor_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert doctor_command.output
+
+        lines_list = [line for line in doctor_command.output.splitlines() if line]
+        assert lines_list[-1] == 'Failed modules: middleware'
+        assert re.search(r'^1/\d+ check\(s\) failed$', lines_list[-2])
+
+    def test_report(self):
+        for argument in ['-r', '--report']:
+            with self.launch_doctor_command(
+                    arguments=[argument]
+            ) as doctor_command:
+                assert doctor_command.wait_for_shutdown(timeout=10)
+            assert doctor_command.exit_code == launch_testing.asserts.EXIT_OK
+            assert ("topic [type]            : /compatible_chatter [std_msgs/msg/String]\n"
+                    "publisher node          : talker_node\n"
+                    "subscriber node         : listener\n"
+                    "compatibility status    : OK") in doctor_command.output
+            assert ("topic [type]            : /incompatible_chatter [std_msgs/msg/String]\n"
+                    "publisher node          : talker_node\n"
+                    "subscriber node         : listener\n"
+                    "compatibility status    : "
+                    "ERROR: Best effort publisher and reliable subscription;") \
+                in doctor_command.output

--- a/ros2doctor/test/test_qos_compatibility.py
+++ b/ros2doctor/test/test_qos_compatibility.py
@@ -14,7 +14,6 @@
 
 import contextlib
 import os
-import re
 import sys
 import unittest
 

--- a/ros2doctor/test/test_qos_compatibility.py
+++ b/ros2doctor/test/test_qos_compatibility.py
@@ -160,13 +160,13 @@ class TestROS2DoctorQoSCompatibility(unittest.TestCase):
             ) as doctor_command:
                 assert doctor_command.wait_for_shutdown(timeout=10)
             assert doctor_command.exit_code == launch_testing.asserts.EXIT_OK
-            assert ("topic [type]            : /compatible_chatter [std_msgs/msg/String]\n"
-                    "publisher node          : talker_node\n"
-                    "subscriber node         : listener\n"
-                    "compatibility status    : OK") in doctor_command.output
-            assert ("topic [type]            : /incompatible_chatter [std_msgs/msg/String]\n"
-                    "publisher node          : talker_node\n"
-                    "subscriber node         : listener\n"
-                    "compatibility status    : "
-                    "ERROR: Best effort publisher and reliable subscription;") \
+            assert ('topic [type]            : /compatible_chatter [std_msgs/msg/String]\n'
+                    'publisher node          : talker_node\n'
+                    'subscriber node         : listener\n'
+                    'compatibility status    : OK') in doctor_command.output
+            assert ('topic [type]            : /incompatible_chatter [std_msgs/msg/String]\n'
+                    'publisher node          : talker_node\n'
+                    'subscriber node         : listener\n'
+                    'compatibility status    : '
+                    'ERROR: Best effort publisher and reliable subscription;') \
                 in doctor_command.output

--- a/ros2doctor/test/test_qos_compatibility.py
+++ b/ros2doctor/test/test_qos_compatibility.py
@@ -141,6 +141,7 @@ class TestROS2DoctorQoSCompatibility(unittest.TestCase):
                 yield doctor_command
         cls.launch_doctor_command = launch_doctor_command
 
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_check(self):
         with self.launch_doctor_command(
                 arguments=[]
@@ -153,6 +154,7 @@ class TestROS2DoctorQoSCompatibility(unittest.TestCase):
         assert lines_list[-1] == 'Failed modules: middleware'
         assert re.search(r'^1/\d+ check\(s\) failed$', lines_list[-2])
 
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_report(self):
         for argument in ['-r', '--report']:
             with self.launch_doctor_command(

--- a/ros2doctor/test/test_qos_compatibility.py
+++ b/ros2doctor/test/test_qos_compatibility.py
@@ -151,8 +151,8 @@ class TestROS2DoctorQoSCompatibility(unittest.TestCase):
         assert doctor_command.output
 
         lines_list = [line for line in doctor_command.output.splitlines() if line]
-        assert lines_list[-1] == 'Failed modules: middleware'
-        assert re.search(r'^1/\d+ check\(s\) failed$', lines_list[-2])
+        assert 'Failed modules' in lines_list[-1]
+        assert 'middleware' in lines_list[-1]
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_report(self):


### PR DESCRIPTION
Here is an example of what the check looks like if an incompatibility error is detected;
```
/root/ros2_ws/build/ros2doctor/ros2doctor/api/qos_compatibility.py: 49: UserWarning: ERROR: QOS compatibility error found on topic '/my_chatter'. Use `ros2 doctor --report` for more details.
```

Here is what a report looks like with two pub/sub pairs, one compatible and one incompatible:
```
   QOS COMPATIBILITY LIST
topic [type]            : /chatter [std_msgs/msg/String]
publisher node          : talker
subscriber node         : listener
compatibility status    : OK
topic [type]            : /my_chatter [std_msgs/msg/String]
publisher node          : mynode
subscriber node         : mynode
compatibility status    : ERROR: Best effort publisher and reliable subscription;
```

The messages for warnings are similar.

Here is the report if there are no publisher/subscription pairs:
```
   QOS COMPATIBILITY LIST
compatibility status    : No publisher/subscriber pairs found
```

I haven't written any tests for this yet and would be happy for suggestions on how to do so.