### PR TITLE
Ensure only one daemon can run at a time

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -16,6 +16,7 @@ import errno
 import os
 import platform
 import socket
+import struct
 import subprocess
 import sys
 import time
@@ -29,15 +30,14 @@ from ros2cli.xmlrpc.client import ServerProxy
 
 def is_daemon_running(args):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    if platform.system() != 'Windows':
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
     addr = ('localhost', get_daemon_port())
     try:
         s.bind(addr)
     except socket.error as e:
         if e.errno == errno.EADDRINUSE:
             return True
-    else:
+    finally:
         s.close()
     return False
 

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -132,5 +132,33 @@ class DaemonNode:
         self._proxy.__exit__(exc_type, exc_value, traceback)
 
 
+def shutdown_daemon(args, wait_duration=None):
+    """
+    Shuts down remote daemon node.
+
+    :param args: DaemonNode arguments namespace.
+    :param wait_duration: optional duration, in seconds, to wait
+      until the daemon node is fully shut down. Non-positive
+      durations will result in an indefinite wait.
+    :return: whether the daemon is shut down already or not.
+    """
+    with DaemonNode(args) as node:
+        node.system.shutdown()
+
+    if wait_duration is None:
+        return not is_daemon_running(args)
+
+    if wait_duration > 0.0:
+        timeout = time.time() + wait_duration
+    else:
+        timeout = None
+
+    while is_daemon_running(args):
+        time.sleep(0.1)
+        if timeout and time.time() >= timeout:
+            return False
+    return True
+
+
 def add_arguments(parser):
     pass

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -12,11 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import socket
+import struct
 from xmlrpc.server import SimpleXMLRPCRequestHandler
 from xmlrpc.server import SimpleXMLRPCServer
 
 
 class LocalXMLRPCServer(SimpleXMLRPCServer):
+
+    allow_reuse_address = False
+
+    def server_bind(self):
+        self.socket.setsockopt(
+            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
+        super(LocalXMLRPCServer, self).server_bind()
 
     def verify_request(self, request, client_address):
         if client_address[0] != '127.0.0.1':

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -23,9 +23,17 @@ class LocalXMLRPCServer(SimpleXMLRPCServer):
     allow_reuse_address = False
 
     def server_bind(self):
+        # Prevent listening socket from lingering in TIME_WAIT state after close()
         self.socket.setsockopt(
             socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
         super(LocalXMLRPCServer, self).server_bind()
+
+    def get_request(self):
+        # Prevent accepted socket from lingering in TIME_WAIT state after close()
+        sock, addr = super(LocalXMLRPCServer, self).get_request()
+        sock.setsockopt(
+            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
+        return sock, addr
 
     def verify_request(self, request, client_address):
         if client_address[0] != '127.0.0.1':

--- a/ros2cli/test/test_strategy.py
+++ b/ros2cli/test/test_strategy.py
@@ -16,8 +16,8 @@ import argparse
 
 import pytest
 
-from ros2cli.node.daemon import DaemonNode
 from ros2cli.node.daemon import is_daemon_running
+from ros2cli.node.daemon import shutdown_daemon
 from ros2cli.node.daemon import spawn_daemon
 from ros2cli.node.strategy import NodeStrategy
 
@@ -25,8 +25,7 @@ from ros2cli.node.strategy import NodeStrategy
 @pytest.fixture
 def enforce_no_daemon_is_running():
     if is_daemon_running(args=[]):
-        with DaemonNode(args=[]) as node:
-            node.system.shutdown()
+        assert shutdown_daemon(args=[], wait_duration=5.0)
     yield
 
 
@@ -53,8 +52,6 @@ def test_with_no_daemon_running(enforce_no_daemon_is_running):
 
 
 def test_enforce_no_daemon(enforce_daemon_is_running):
-    if not is_daemon_running(args=[]):
-        assert spawn_daemon(args=[], wait_until_spawned=5.0)
     args = argparse.Namespace(no_daemon=True)
     with NodeStrategy(args=args) as node:
         assert node._daemon_node is None


### PR DESCRIPTION
Improvement over #620. Flakes in `ros2cli`'s test_strategy.py such as [this one](https://ci.ros2.org/view/nightly/job/nightly_win_rep/lastCompletedBuild/testReport/ros2cli.ros2cli.test/test_strategy/test_with_no_daemon_running_3_3_/) were due to TOCTOU races between an `is_daemon_running` check and a `socket.bind` within the spawned daemon process. This patch does not resolve that race (not trivial, see discussion in #620), but ensures only one daemon can successfully bind to the same address.

CI up to `ros2cli`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14378)](http://ci.ros2.org/job/ci_linux/14378/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9153)](http://ci.ros2.org/job/ci_linux-aarch64/9153/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12054)](http://ci.ros2.org/job/ci_osx/12054/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14477)](http://ci.ros2.org/job/ci_windows/14477/)
