### PR TITLE
continue to next iteration after exceptions in generate_reports and

### DIFF
--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -95,10 +95,12 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
             check_class = check_entry_pt.load()
         except ImportError:
             doctor_warn(f'Check entry point {check_entry_pt.name} fails to load.')
+            continue
         try:
             check_instance = check_class()
         except Exception:
             doctor_warn(f'Unable to instantiate check object from {check_entry_pt.name}.')
+            continue
         try:
             check_category = check_instance.category()
             result = check_instance.check()
@@ -123,10 +125,12 @@ def generate_reports(*, categories=None) -> List[Report]:
             report_class = report_entry_pt.load()
         except ImportError:
             doctor_warn(f'Report entry point {report_entry_pt.name} fails to load.')
+            continue
         try:
             report_instance = report_class()
         except Exception:
             doctor_warn(f'Unable to instantiate report object from {report_entry_pt.name}.')
+            continue
         try:
             report_category = report_instance.category()
             report = report_instance.report()


### PR DESCRIPTION
This PR fixes a bug in the `ros2 doctor` utility.

Both the `run_checks` and the `generate_reports` functions contain a for loop that iterates over all the specified entry points.
If there are issues with one of the entry points, the exception is catched and a warning is printed.

However, after printing the warning, the loop continues executing.
This causes a problem as variables such as `check_class`, `report_class`, `check_instance` and `report_instance` may still hold the value assigned during the previous iteration of the loop.

Let's assume that we have 2 reports: A and B, with B raising an `ImportError` during `report_entry_pt.load()`.
This will result in printing twice the report from A.

This PR adds a `continue` after the warnings.


Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>