### PR TITLE
[ros2pkg] Use underscores in setup.cfg.em instead of dashes

### DIFF
--- a/ros2pkg/ros2pkg/resource/ament_python/setup.cfg.em
+++ b/ros2pkg/ros2pkg/resource/ament_python/setup.cfg.em
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/@(project_name)
+script_dir=$base/lib/@(project_name)
 [install]
-install-scripts=$base/lib/@(project_name)
+install_scripts=$base/lib/@(project_name)


### PR DESCRIPTION
Get rid of these warnings:

```
c:\python38\lib\site-packages\setuptools\dist.py:642: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
warnings.warn(
c:\python38\lib\site-packages\setuptools\dist.py:642: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
warnings.warn(
--- stderr: my_package
c:\python38\lib\site-packages\setuptools\dist.py:642: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
warnings.warn(
c:\python38\lib\site-packages\setuptools\dist.py:642: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
warnings.warn(
```

e.g. when running the [create your first package](https://docs.ros.org/en/rolling/Tutorials/Creating-Your-First-ROS2-Package.html) tutorial.