### PR TITLE
Pass package exports to template in pkg create api (#619)

### DIFF
--- a/ros2pkg/ros2pkg/api/create.py
+++ b/ros2pkg/ros2pkg/api/create.py
@@ -94,7 +94,7 @@ def create_package_environment(package, destination_directory):
         'buildtool_dependencies': package.buildtool_depends,
         'dependencies': package.build_depends,
         'test_dependencies': package.test_depends,
-        'build_type': package.get_build_type(),
+        'exports': package.exports,
     }
     _create_template_file(
         'package_environment',

--- a/ros2pkg/ros2pkg/resource/package_environment/package.xml.em
+++ b/ros2pkg/ros2pkg/resource/package_environment/package.xml.em
@@ -26,6 +26,10 @@
 
 @[end if]@
   <export>
-    <build_type>@build_type</build_type>
+@[if exports]@
+@[  for export in exports]@
+    <@export.tagname>@export.content</@export.tagname>
+@[  end for]@
+@[end if]@
   </export>
 </package>


### PR DESCRIPTION
Hi @audrow, here's my fix for #619.

I tested it with ` pytest ros2pkg/test/test_cli.py`, which checks that the build type is being written to `package.xml` successfully [(here)](https://github.com/ros2/ros2cli/blob/master/ros2pkg/test/test_cli.py#L205) .

I also confirmed manually that `package.xml` looked correct (indentation, spacing between lines looked good).

Let me know if any further changes or tests are needed.