### PR TITLE
Improve ros2 doctor on Windows

### DIFF
--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -93,8 +93,8 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
     for check_entry_pt in importlib_metadata.entry_points().get('ros2doctor.checks', []):
         try:
             check_class = check_entry_pt.load()
-        except ImportError:
-            doctor_warn(f'Check entry point {check_entry_pt.name} fails to load.')
+        except ImportError as e:
+            doctor_warn(f'Check entry point {check_entry_pt.name} fails to load: {e}')
             continue
         try:
             check_instance = check_class()
@@ -123,8 +123,8 @@ def generate_reports(*, categories=None) -> List[Report]:
     for report_entry_pt in importlib_metadata.entry_points().get('ros2doctor.report', []):
         try:
             report_class = report_entry_pt.load()
-        except ImportError:
-            doctor_warn(f'Report entry point {report_entry_pt.name} fails to load.')
+        except ImportError as e:
+            doctor_warn(f'Report entry point {report_entry_pt.name} fails to load: {e}')
             continue
         try:
             report_instance = report_class()

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import os
+from pathlib import Path
+import sys
 from typing import Tuple
 
 from ros2doctor.api import DoctorCheck
@@ -27,7 +29,7 @@ try:
 except ImportError:  # check import error for windows and osx
     doctor_warn(
         'Unable to import ifcfg. '
-        'Use `python3 -m pip install ifcfg` to install needed package.')
+        f'Use `{Path(sys.executable).name} -m pip install ifcfg` to install needed package.')
 
 
 def _is_unix_like_platform() -> bool:
@@ -74,11 +76,10 @@ class NetworkCheck(DoctorCheck):
         if not _is_unix_like_platform():
             if not has_loopback and not has_non_loopback:
                 # no flags found, otherwise one of them should be True.
-                doctor_error(
-                    'No flags found. '
-                    'Run `ipconfig` on Windows or '
-                    'install `ifconfig` on Unix to check network interfaces.')
-                result.add_error()
+                doctor_warn(
+                    'Did not found either a loopback or no loopback interface.'
+                    'Run `ipconfig` on Windows to check what interfaces are available')
+                result.add_warning()
                 return result
         if not has_loopback:
             doctor_error('No loopback IP address is found.')

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import os
-from pathlib import Path
-import sys
 from typing import Tuple
+
+import ifcfg
 
 from ros2doctor.api import DoctorCheck
 from ros2doctor.api import DoctorReport
@@ -23,13 +23,6 @@ from ros2doctor.api import Report
 from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_error
 from ros2doctor.api.format import doctor_warn
-
-try:
-    import ifcfg
-except ImportError:  # check import error for windows and osx
-    doctor_warn(
-        'Unable to import ifcfg. '
-        f'Use `{Path(sys.executable).name} -m pip install ifcfg` to install needed package.')
 
 
 def _is_unix_like_platform() -> bool:
@@ -63,14 +56,7 @@ class NetworkCheck(DoctorCheck):
         """Check network configuration."""
         result = Result()
         # check ifcfg import for windows and osx users
-        try:
-            ifcfg_ifaces = ifcfg.interfaces()
-        except NameError:
-            doctor_error(
-                '`ifcfg` module is not imported. '
-                'Unable to run network check.')
-            result.add_error()
-            return result
+        ifcfg_ifaces = ifcfg.interfaces()
 
         has_loopback, has_non_loopback, has_multicast = _check_network_config_helper(ifcfg_ifaces)
         if not _is_unix_like_platform():
@@ -102,11 +88,7 @@ class NetworkReport(DoctorReport):
     def report(self):
         """Print system and ROS network information."""
         # check ifcfg import for windows and osx users
-        try:
-            ifcfg_ifaces = ifcfg.interfaces()
-        except NameError:
-            doctor_error('ifcfg is not imported. Unable to generate network report.')
-            return Report('')
+        ifcfg_ifaces = ifcfg.interfaces()
 
         network_report = Report('NETWORK CONFIGURATION')
         for iface in ifcfg_ifaces.values():

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -77,8 +77,8 @@ class NetworkCheck(DoctorCheck):
             if not has_loopback and not has_non_loopback:
                 # no flags found, otherwise one of them should be True.
                 doctor_warn(
-                    'Did not found either a loopback or no loopback interface.'
-                    'Run `ipconfig` on Windows to check what interfaces are available')
+                    'Could not find any available network interfaces.'
+                    'Run `ipconfig` on Windows to check what interfaces are available.')
                 result.add_warning()
                 return result
         if not has_loopback:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -63,7 +63,7 @@ class NetworkCheck(DoctorCheck):
             if not has_loopback and not has_non_loopback:
                 # no flags found, otherwise one of them should be True.
                 doctor_warn(
-                    'Interface flags are not available on Windows.'
+                    'Interface flags are not available on Windows. '
                     'Run `ipconfig` to see what interfaces are available.')
                 result.add_warning()
                 return result

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -63,8 +63,8 @@ class NetworkCheck(DoctorCheck):
             if not has_loopback and not has_non_loopback:
                 # no flags found, otherwise one of them should be True.
                 doctor_warn(
-                    'Could not find any available network interfaces. '
-                    'Run `ipconfig` on Windows to check what interfaces are available.')
+                    'Interface flags are not available on Windows.'
+                    'Run `ipconfig` to see what interfaces are available.')
                 result.add_warning()
                 return result
         if not has_loopback:

--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -77,7 +77,7 @@ class NetworkCheck(DoctorCheck):
             if not has_loopback and not has_non_loopback:
                 # no flags found, otherwise one of them should be True.
                 doctor_warn(
-                    'Could not find any available network interfaces.'
+                    'Could not find any available network interfaces. '
                     'Run `ipconfig` on Windows to check what interfaces are available.')
                 result.add_warning()
                 return result

--- a/ros2doctor/ros2doctor/api/package.py
+++ b/ros2doctor/ros2doctor/api/package.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import os
-from pathlib import Path
-import sys
 import textwrap
 
 from ament_index_python import get_packages_with_prefixes
@@ -28,12 +26,7 @@ from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_error
 from ros2doctor.api.format import doctor_warn
 
-try:
-    import rosdistro
-except ImportError:
-    doctor_warn(
-        'Unable to import rosdistro. '
-        f'Use `{Path(sys.executable).name} -m pip install rosdistro` to install needed package.')
+import rosdistro
 
 
 def get_distro_package_versions() -> dict:
@@ -152,12 +145,6 @@ class PackageCheck(DoctorCheck):
     def check(self):
         """Check packages within the directory where command is called."""
         result = Result()
-        try:
-            rosdistro
-        except NameError:
-            doctor_error('`rosdistro` module is not imported. Unable to run package check.')
-            result.add_error()
-            return result
         distro_package_vers = get_distro_package_versions()
         if not distro_package_vers:
             doctor_error('distro packages info is not found.')
@@ -181,11 +168,6 @@ class PackageReport(DoctorReport):
 
     def report(self):
         """Report packages within the directory where command is called."""
-        try:
-            rosdistro
-        except NameError:
-            doctor_error('`rosdistro` module is not imported. Unable to generate package report.')
-            return Report('')
         report = Report('PACKAGE VERSIONS')
         local_package_vers = get_local_package_versions()
         distro_package_vers = get_distro_package_versions()

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import os
+from pathlib import Path
 import platform
+import sys
 from typing import Tuple
 
 from ros2doctor.api import DoctorCheck
@@ -23,7 +25,12 @@ from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_error
 from ros2doctor.api.format import doctor_warn
 
-import rosdistro
+try:
+    import rosdistro
+except ImportError:
+    doctor_warn(
+        'Unable to import rosdistro. '
+        f'Use `{Path(sys.executable).name} -m pip install rosdistro` to install needed package.')
 
 
 def _check_platform_helper() -> Tuple[str, dict, dict]:
@@ -64,6 +71,12 @@ class PlatformCheck(DoctorCheck):
     def check(self):
         """Check system platform against ROS 2 Distro."""
         result = Result()
+        try:
+            rosdistro
+        except NameError:
+            doctor_error('`rosdistro` module is not imported. Unable to run platform check.')
+            result.add_error()
+            return result
         distros = _check_platform_helper()
         if not distros:
             doctor_error('Missing rosdistro info. Unable to check platform.')
@@ -95,7 +108,6 @@ class PlatformReport(DoctorReport):
 
     def report(self):
         platform_name = platform.system()
-
         # platform info
         platform_report = Report('PLATFORM INFORMATION')
         platform_report.add_to_report('system', platform_name)
@@ -114,6 +126,11 @@ class RosdistroReport(DoctorReport):
         return 'platform'
 
     def report(self):
+        try:
+            rosdistro
+        except NameError:
+            doctor_error('`rosdistro` module is not imported. Unable to generate rosdistro platform report.')
+            return Report('')
         ros_report = Report('ROS 2 INFORMATION')
         distros = _check_platform_helper()
         if not distros:

--- a/ros2doctor/ros2doctor/api/platform.py
+++ b/ros2doctor/ros2doctor/api/platform.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import os
-from pathlib import Path
 import platform
-import sys
 from typing import Tuple
 
 from ros2doctor.api import DoctorCheck
@@ -25,12 +23,7 @@ from ros2doctor.api import Result
 from ros2doctor.api.format import doctor_error
 from ros2doctor.api.format import doctor_warn
 
-try:
-    import rosdistro
-except ImportError:
-    doctor_warn(
-        'Unable to import rosdistro. '
-        f'Use `{Path(sys.executable).name} -m pip install rosdistro` to install needed package.')
+import rosdistro
 
 
 def _check_platform_helper() -> Tuple[str, dict, dict]:
@@ -71,12 +64,6 @@ class PlatformCheck(DoctorCheck):
     def check(self):
         """Check system platform against ROS 2 Distro."""
         result = Result()
-        try:
-            rosdistro
-        except NameError:
-            doctor_error('`rosdistro` module is not imported. Unable to run platform check.')
-            result.add_error()
-            return result
         distros = _check_platform_helper()
         if not distros:
             doctor_error('Missing rosdistro info. Unable to check platform.')
@@ -108,6 +95,7 @@ class PlatformReport(DoctorReport):
 
     def report(self):
         platform_name = platform.system()
+
         # platform info
         platform_report = Report('PLATFORM INFORMATION')
         platform_report.add_to_report('system', platform_name)
@@ -126,11 +114,6 @@ class RosdistroReport(DoctorReport):
         return 'platform'
 
     def report(self):
-        try:
-            rosdistro
-        except NameError:
-            doctor_error('`rosdistro` module is not imported. Unable to generate rosdistro platform report.')
-            return Report('')
         ros_report = Report('ROS 2 INFORMATION')
         distros = _check_platform_helper()
         if not distros:


### PR DESCRIPTION
The output of `ros2 doctor` on Windows was confusing.

* Print an useful error message when failing to import rosdistro.
* Print a clearer error message when failing to find either a loopback or no loopback interface on Windows.
* Print "latest version" instead of "required version".
* Print the corrent name of the python executable according to the platform.

See the comment I wrote in the Galactic testing matric for more context.

`rosdistro` python package is not usually installed on Windows, so having a nicer message when not found is helpful.
I updated "latest version" to "required version" because the warning shows that for that ros distribution there's a newer version of the package available in rosdistro, it's not really a required version.