### PR TITLE
Handle ValueError

### DIFF
--- a/ros2pkg/ros2pkg/api/__init__.py
+++ b/ros2pkg/ros2pkg/api/__init__.py
@@ -32,7 +32,7 @@ def get_package_names():
 def get_prefix_path(package_name):
     try:
         prefix_path = get_package_prefix(package_name)
-    except PackageNotFoundError:
+    except (PackageNotFoundError, ValueError):
         return None
     return prefix_path
 

--- a/ros2pkg/test/test_api.py
+++ b/ros2pkg/test/test_api.py
@@ -31,6 +31,6 @@ def test_api():
 
     prefix_path = get_prefix_path('not_existing_package_name')
     assert prefix_path is None
-    
+
     prefix_path = get_prefix_path('invalid.package.name')
     assert prefix_path is None

--- a/ros2pkg/test/test_api.py
+++ b/ros2pkg/test/test_api.py
@@ -29,5 +29,8 @@ def test_api():
     prefix_path = get_prefix_path('ros2cli')
     assert os.path.isdir(prefix_path)
 
-    prefix_path = get_prefix_path('_not_existing_package_name')
+    prefix_path = get_prefix_path('not_existing_package_name')
+    assert prefix_path is None
+    
+    prefix_path = get_prefix_path('invalid.package.name')
     assert prefix_path is None


### PR DESCRIPTION
Changes in https://github.com/ament/ament_index/pull/69 adds a possible ValueError to `get_package_prefix` when the package name is invalid.
This PR handles this case identically to a missing package by returning `None` from the API call.