### PR TITLE
Drop deprecated get_container_components_info() API.

### DIFF
--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -68,34 +68,6 @@ def get_registered_component_types():
 ComponentInfo = namedtuple('Component', ('uid', 'name'))
 
 
-def get_container_components_info(*, node, remote_container_node_name):
-    """
-    Get information about the components in a container.
-
-    .. deprecated:: Galactic
-
-       Use :func:`get_components_in_container()` instead.
-
-    :param node: an `rclpy.Node` instance.
-    :param remote_container_node_name: of the container node to inspect.
-    :return: a list of `ComponentInfo` instances, with the unique id and name of
-    each component in the container.
-    :throws: RuntimeError if an error occurs.
-    """
-    import warnings
-    warnings.warn(
-        'get_container_components_info() is deprecated. '
-        'Use get_components_in_container() instead.'
-    )
-
-    ok, outcome = get_components_in_container(
-        node=node, remote_container_node_name=remote_container_node_name
-    )
-    if not ok:
-        raise RuntimeError(f'{outcome} for {remote_container_node_name}')
-    return outcome
-
-
 def get_components_in_container(*, node, remote_container_node_name):
     """
     Get information about the components in a container.


### PR DESCRIPTION
Closes #530.

CI up to `ros2component`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14731)](http://ci.ros2.org/job/ci_linux/14731/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9482)](http://ci.ros2.org/job/ci_linux-aarch64/9482/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12396)](http://ci.ros2.org/job/ci_osx/12396/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14876)](http://ci.ros2.org/job/ci_windows/14876/)
