### PR TITLE
consider not absolute node name when loading parameter

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -146,6 +146,8 @@ def load_parameter_file(*, node, node_name, parameter_file, use_wildcard):
             param_keys.append('/**')
         if node_name in param_file:
             param_keys.append(node_name)
+        if node_name[1:] in param_file:
+            param_keys.append(node_name[1:])
 
         if param_keys == []:
             raise RuntimeError('Param file does not contain parameters for {}, '


### PR DESCRIPTION
This fixes #648 for me even though it feels pretty dirty. Not sure if there's a better workaround for the described issue.