### PR TITLE
Generate LICENSE files on ros2 pkg create.

### DIFF
--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -15,12 +15,12 @@
   <depend>python3-importlib-resources</depend>
   <depend>ros2cli</depend>
 
+  <exec_depend>ament_copyright</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-empy</exec_depend>
   <exec_depend>python3-pkg-resources</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -91,7 +91,7 @@ class CreateVerb(VerbExtension):
     def main(self, *, args):
         available_licenses = {}
         for shortname, entry in ament_copyright.get_licenses().items():
-            available_licenses[entry.name] = entry.license_files
+            available_licenses[entry.spdx] = entry.license_files
 
         if args.license == '?':
             print('Supported licenses:\n%s' % ('\n'.join(available_licenses)))

--- a/ros2pkg/test/test_cli.py
+++ b/ros2pkg/test/test_cli.py
@@ -126,7 +126,7 @@ class TestROS2PkgCLI(unittest.TestCase):
                     'create', 'a_test_package',
                     '--package-format', '3',
                     '--description', 'A test package dummy description',
-                    '--license', 'Apache License, Version 2.0',
+                    '--license', 'Apache-2.0',
                     '--build-type', 'ament_cmake',
                     '--dependencies', 'ros2pkg',
                     '--maintainer-email', 'nobody@nowhere.com',
@@ -146,7 +146,7 @@ class TestROS2PkgCLI(unittest.TestCase):
                     'version: 0.0.0',
                     'description: A test package dummy description',
                     "maintainer: ['Nobody <nobody@nowhere.com>']",
-                    "licenses: ['Apache License, Version 2.0']",
+                    "licenses: ['Apache-2.0']",
                     'build type: ament_cmake',
                     "dependencies: ['ros2pkg']",
                     'node_name: test_node',
@@ -201,6 +201,6 @@ class TestROS2PkgCLI(unittest.TestCase):
             assert root.find('description').text == 'A test package dummy description'
             assert root.find('maintainer').text == 'Nobody'
             assert root.find('maintainer').attrib['email'] == 'nobody@nowhere.com'
-            assert root.find('license').text == 'Apache License, Version 2.0'
+            assert root.find('license').text == 'Apache-2.0'
             assert root.find('depend').text == 'ros2pkg'
             assert root.find('.//build_type').text == 'ament_cmake'

--- a/ros2pkg/test/test_cli.py
+++ b/ros2pkg/test/test_cli.py
@@ -126,7 +126,7 @@ class TestROS2PkgCLI(unittest.TestCase):
                     'create', 'a_test_package',
                     '--package-format', '3',
                     '--description', 'A test package dummy description',
-                    '--license', 'Apache License 2.0',
+                    '--license', 'Apache License, Version 2.0',
                     '--build-type', 'ament_cmake',
                     '--dependencies', 'ros2pkg',
                     '--maintainer-email', 'nobody@nowhere.com',
@@ -146,7 +146,7 @@ class TestROS2PkgCLI(unittest.TestCase):
                     'version: 0.0.0',
                     'description: A test package dummy description',
                     "maintainer: ['Nobody <nobody@nowhere.com>']",
-                    "licenses: ['Apache License 2.0']",
+                    "licenses: ['Apache License, Version 2.0']",
                     'build type: ament_cmake',
                     "dependencies: ['ros2pkg']",
                     'node_name: test_node',
@@ -179,6 +179,7 @@ class TestROS2PkgCLI(unittest.TestCase):
             assert os.path.isdir(os.path.join(tmpdir, 'a_test_package'))
             assert os.path.isfile(os.path.join(tmpdir, 'a_test_package', 'package.xml'))
             assert os.path.isfile(os.path.join(tmpdir, 'a_test_package', 'CMakeLists.txt'))
+            assert os.path.isfile(os.path.join(tmpdir, 'a_test_package', 'LICENSE'))
             assert os.path.isfile(
                 os.path.join(tmpdir, 'a_test_package', 'src', 'test_node.cpp')
             )
@@ -200,6 +201,6 @@ class TestROS2PkgCLI(unittest.TestCase):
             assert root.find('description').text == 'A test package dummy description'
             assert root.find('maintainer').text == 'Nobody'
             assert root.find('maintainer').attrib['email'] == 'nobody@nowhere.com'
-            assert root.find('license').text == 'Apache License 2.0'
+            assert root.find('license').text == 'Apache License, Version 2.0'
             assert root.find('depend').text == 'ros2pkg'
             assert root.find('.//build_type').text == 'ament_cmake'


### PR DESCRIPTION
That is, if the '--license' command-line argument is one of
the ones that ament_copyright knows, fetch the license text
out of ament_copyright and place it in 'LICENSE' at the
root of the package.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Here's the current list of strings that will trigger the creation of the LICENSE file:

* Apache License, Version 2.0
* Boost Software License - Version 1.0
* BSD License 2.0
* 2-Clause BSD License
* 3-Clause BSD License
* GNU General Public License 3.0
* GNU Lesser General Public License 3.0
* MIT License
* MIT-0 License

One thing to be aware of here is that this is the first use of `ament_copyright` in an `exec_depend`.  I don't think that should be a problem, but it is something to think about.

An enhancement we could do here is to add the SPDX identifiers to the [license tuple in ament_copyright](https://github.com/ament/ament_lint/blob/100683ca73de2ccf377937e64955d5b79c43721e/ament_copyright/ament_copyright/licenses.py#L21-L22), and then use that instead.  I don't mind strongly which way we go, but we should think about it and be deliberate; changing it later on will be difficult.  Feedback is most welcome.

@nuclearsandwich @tfoote @gbalke @ros2/team FYI.