### PR TITLE
Transfer daemon socket ownership on spawn.

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 Open Source Robotics Foundation, Inc.
+# Copyright 2017-2021 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,23 +13,115 @@
 # limitations under the License.
 
 import argparse
-from collections import namedtuple
-import functools
-import inspect
 import os
-
-import netifaces
 
 import rclpy
 import rclpy.action
 
-from ros2cli.node.direct import DirectNode
+from ros2cli.helpers import before_invocation
+from ros2cli.helpers import bind
+from ros2cli.helpers import get_ros_domain_id
+from ros2cli.helpers import pretty_print_call
+
+from ros2cli.node.network_aware import NetworkAwareNode
 
 from ros2cli.xmlrpc.local_server import LocalXMLRPCServer
-from ros2cli.xmlrpc.local_server import RequestHandler
+from ros2cli.xmlrpc.local_server import SimpleXMLRPCRequestHandler
 
 
-def main(*, script_name='_ros2_daemon', argv=None):
+def get_port():
+    base_port = 11511
+    base_port += int(os.environ.get('ROS_DOMAIN_ID', 0))
+    return base_port
+
+
+def get_address():
+    return '127.0.0.1', get_port()
+
+
+class RequestHandler(SimpleXMLRPCRequestHandler):
+    rpc_paths = ('/ros2cli/',)
+
+
+def get_xmlrpc_server_url(address=None):
+    if not address:
+        address = get_address()
+    host, port = address
+    path = RequestHandler.rpc_paths[0]
+    return f'http://{host}:{port}{path}'
+
+
+def make_xmlrpc_server():
+    address = get_address()
+
+    return LocalXMLRPCServer(
+        address, logRequests=False,
+        requestHandler=RequestHandler,
+        allow_none=True
+    )
+
+
+def serve_forever(server, *, timeout=2 * 60 * 60):
+    try:
+        ros_domain_id = get_ros_domain_id()
+        node_args = argparse.Namespace(
+            node_name_suffix=f'_daemon_{ros_domain_id}',
+            start_parameter_services=False)
+        with NetworkAwareNode(node_args) as node:
+            functions = [
+                node.get_name,
+                node.get_namespace,
+                node.get_node_names_and_namespaces,
+                node.get_node_names_and_namespaces_with_enclaves,
+                node.get_topic_names_and_types,
+                node.get_service_names_and_types,
+                bind(rclpy.action.get_action_names_and_types, node),
+                node.get_publisher_names_and_types_by_node,
+                node.get_publishers_info_by_topic,
+                node.get_subscriber_names_and_types_by_node,
+                node.get_subscriptions_info_by_topic,
+                node.get_service_names_and_types_by_node,
+                node.get_client_names_and_types_by_node,
+                bind(rclpy.action.get_action_server_names_and_types_by_node, node),
+                bind(rclpy.action.get_action_client_names_and_types_by_node, node),
+                node.count_publishers,
+                node.count_subscribers
+            ]
+
+            server.register_introspection_functions()
+            for func in functions:
+                server.register_function(
+                    before_invocation(
+                        func, pretty_print_call))
+
+            shutdown = False
+
+            # shutdown the daemon in case of a timeout
+            def timeout_handler():
+                nonlocal shutdown
+                print('Shutdown due to timeout')
+                shutdown = True
+            server.handle_timeout = timeout_handler
+            server.timeout = timeout
+
+            # function to shutdown daemon remotely
+            def shutdown_handler():
+                nonlocal shutdown
+                print('Remote shutdown requested')
+                shutdown = True
+            server.register_function(shutdown_handler, 'system.shutdown')
+
+            print('Serving XML-RPC on ' + get_xmlrpc_server_url(server.server_address))
+            try:
+                while not shutdown:
+                    server.handle_request()
+            except KeyboardInterrupt:
+                pass
+    finally:
+        server.server_close()
+
+
+def main(*, argv=None):
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
@@ -47,179 +139,9 @@ def main(*, script_name='_ros2_daemon', argv=None):
 
     # the arguments are only passed for visibility in e.g. the process list
     assert args.rmw_implementation == rclpy.get_rmw_implementation_identifier()
-    assert args.ros_domain_id == int(os.environ.get('ROS_DOMAIN_ID', 0))
+    assert args.ros_domain_id == get_ros_domain_id()
 
-    addr = ('localhost', get_daemon_port())
-    NodeArgs = namedtuple(
-        'NodeArgs', ('node_name_suffix', 'start_parameter_services'))
-    node_args = NodeArgs(
-        node_name_suffix='_daemon_%d' % args.ros_domain_id,
-        start_parameter_services=False)
-    with NetworkAwareNode(node_args) as node:
-        server = LocalXMLRPCServer(
-            addr, logRequests=False,
-            requestHandler=RequestHandler,
-            allow_none=True)
-
-        try:
-            server.register_introspection_functions()
-
-            # expose getter functions of node
-            server.register_function(
-                _print_invoked_function_name(node.get_name))
-            server.register_function(
-                _print_invoked_function_name(node.get_namespace))
-            server.register_function(
-                _print_invoked_function_name(node.get_node_names_and_namespaces))
-            server.register_function(
-                _print_invoked_function_name(node.get_node_names_and_namespaces_with_enclaves))
-            server.register_function(
-                _print_invoked_function_name(node.get_topic_names_and_types))
-            server.register_function(
-                _print_invoked_function_name(node.get_service_names_and_types))
-            server.register_function(
-                _print_invoked_function_name(_bind_function(
-                    rclpy.action.get_action_names_and_types, node)))
-            server.register_function(
-                _print_invoked_function_name(node.get_publisher_names_and_types_by_node))
-            server.register_function(
-                _print_invoked_function_name(node.get_publishers_info_by_topic))
-            server.register_function(
-                _print_invoked_function_name(node.get_subscriber_names_and_types_by_node))
-            server.register_function(
-                _print_invoked_function_name(node.get_subscriptions_info_by_topic))
-            server.register_function(
-                _print_invoked_function_name(node.get_service_names_and_types_by_node))
-            server.register_function(
-                _print_invoked_function_name(node.get_client_names_and_types_by_node))
-            server.register_function(
-                _print_invoked_function_name(_bind_function(
-                    rclpy.action.get_action_server_names_and_types_by_node, node)))
-            server.register_function(
-                _print_invoked_function_name(_bind_function(
-                    rclpy.action.get_action_client_names_and_types_by_node, node)))
-            server.register_function(
-                _print_invoked_function_name(node.count_publishers))
-            server.register_function(
-                _print_invoked_function_name(node.count_subscribers))
-
-            shutdown = False
-
-            # shutdown the daemon in case of a timeout
-            def timeout_handler():
-                nonlocal shutdown
-                print('Shutdown due to timeout')
-                shutdown = True
-            server.handle_timeout = timeout_handler
-            server.timeout = args.timeout
-
-            # function to shutdown daemon remotely
-            def shutdown_handler():
-                nonlocal shutdown
-                print('Remote shutdown requested')
-                shutdown = True
-            server.register_function(shutdown_handler, 'system.shutdown')
-
-            print('Serving XML-RPC on %s:%d/ros2cli/' % (addr[0], addr[1]))
-            try:
-                while not shutdown:
-                    server.handle_request()
-            except KeyboardInterrupt:
-                pass
-        finally:
-            server.server_close()
-
-
-def get_interfaces_ip_addresses():
-    addresses_by_interfaces = {}
-    for (kind, info_list) in netifaces.gateways().items():
-        if kind not in (netifaces.AF_INET, netifaces.AF_INET6):
-            continue
-        print('Interface kind: {}, info: {}'.format(kind, info_list))
-        addresses_by_interfaces[kind] = {}
-        for info in info_list:
-            interface_name = info[1]
-            addresses_by_interfaces[kind][interface_name] = (
-                netifaces.ifaddresses(interface_name)[kind][0]['addr']
-            )
-    print('Addresses by interfaces: {}'.format(addresses_by_interfaces))
-    return addresses_by_interfaces
-
-
-class NetworkAwareNode:
-    """A direct node, that resets itself when a network interface changes."""
-
-    def __init__(self, args):
-        self.args = args
-        # TODO(ivanpauno): A race condition is possible here, since it isn't possible to know
-        # exactly which interfaces were available at node creation.
-        self.node = DirectNode(args)
-        self.addresses_at_start = get_interfaces_ip_addresses()
-
-    def __enter__(self):
-        self.node.__enter__()
-        return self
-
-    def __getattr__(self, name):
-        attr = getattr(self.node, name)
-
-        if inspect.ismethod(attr):
-            @functools.wraps(attr)
-            def wrapper(*args, **kwargs):
-                self.reset_if_addresses_changed()
-                return getattr(self.node, name)(*args, **kwargs)
-            wrapper.__signature__ = inspect.signature(attr)
-            return wrapper
-        self.reset_if_addresses_changed()
-        return attr
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.node.__exit__(exc_type, exc_value, traceback)
-
-    def reset_if_addresses_changed(self):
-        new_addresses = get_interfaces_ip_addresses()
-        if new_addresses != self.addresses_at_start:
-            self.addresses_at_start = new_addresses
-            self.node.destroy_node()
-            rclpy.shutdown()
-            self.node = DirectNode(self.args)
-            self.node.__enter__()
-            print('Daemon node was reset')
-
-
-def get_daemon_port():
-    base_port = 11511
-    base_port += int(os.environ.get('ROS_DOMAIN_ID', 0))
-    return base_port
-
-
-def _bind_function(func, *args, **kwargs):
-    """
-    Bind a function with a set of arguments.
-
-    A functools.partial equivalent that is actually a function.
-    """
-    partial = functools.partial(func, *args, **kwargs)
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        return partial(*args, **kwargs)
-    wrapper.__signature__ = inspect.signature(func)
-    return wrapper
-
-
-def _print_invoked_function_name(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        name = func.__name__
-        arguments = ', '.join(
-            [f'{v!r}' for v in args] +
-            [f'{k}={v!r}' for k, v in kwargs.items()]
-        )
-        print(f'{name}({arguments})')
-        return func(*args, **kwargs)
-    wrapper.__signature__ = inspect.signature(func)
-    return wrapper
+    serve_forever(make_xmlrpc_server(), timeout=args.timeout)
 
 
 if __name__ == '__main__':

--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -52,6 +52,7 @@ def get_xmlrpc_server_url(address=None):
 
 
 def make_xmlrpc_server():
+    """Make local XMLRPC server listening over ros2cli daemon's default port."""
     address = get_address()
 
     return LocalXMLRPCServer(
@@ -61,7 +62,14 @@ def make_xmlrpc_server():
     )
 
 
-def serve_forever(server, *, timeout=2 * 60 * 60):
+def serve(server, *, timeout=2 * 60 * 60):
+    """
+    Serve the ros2cli daemon API using the given `server`.
+
+    :param server: an XMLRPC server instance
+    :param timeout: how long to wait before shutting
+      down the server due to inactivity.
+    """
     try:
         ros_domain_id = get_ros_domain_id()
         node_args = argparse.Namespace(
@@ -141,7 +149,7 @@ def main(*, argv=None):
     assert args.rmw_implementation == rclpy.get_rmw_implementation_identifier()
     assert args.ros_domain_id == get_ros_domain_id()
 
-    serve_forever(make_xmlrpc_server(), timeout=args.timeout)
+    serve(make_xmlrpc_server(), timeout=args.timeout)
 
 
 if __name__ == '__main__':

--- a/ros2cli/ros2cli/daemon/daemonize.py
+++ b/ros2cli/ros2cli/daemon/daemonize.py
@@ -39,7 +39,7 @@ class PicklerForProcess(pickle.Pickler):
     @staticmethod
     def load_socket(data):
         if platform.system() == 'Windows':
-            return socket.socket.fromshare(data)
+            return socket.fromshare(data)
         return socket.socket(fileno=data)
 
     def reduce_socket(self, obj):
@@ -69,9 +69,8 @@ def daemonize(func, tags={}, timeout=None, debug=False):
         cmd += [flag, str(value)]
     kwargs = {}
     if platform.system() == 'Windows':
-        # Process Creation Flag documented in the MSDN
-        DETACHED_PROCESS = 0x00000008  # noqa: N806
-        kwargs.update(creationflags=DETACHED_PROCESS)
+        if not debug:
+            kwargs.update(creationflags=subprocess.DETACHED_PROCESS)
         # avoid showing cmd windows for subprocess
         si = subprocess.STARTUPINFO()
         si.dwFlags = subprocess.STARTF_USESHOWWINDOW

--- a/ros2cli/ros2cli/daemon/daemonize.py
+++ b/ros2cli/ros2cli/daemon/daemonize.py
@@ -1,0 +1,114 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copyreg
+import os
+import pickle
+import platform
+import socket
+import subprocess
+import sys
+import threading
+
+from ros2cli.helpers import wait_for
+
+
+class PicklerForProcess(pickle.Pickler):
+
+    def __init__(self, process, *args, **kwargs):
+        super().__init__(process.stdin, *args, **kwargs)
+        self.process = process
+        self.dispatch_table = copyreg.dispatch_table.copy()
+        self.dispatch_table[socket.socket] = self.reduce_socket
+        self.dispatch_table[threading.Event] = self.reduce_event
+
+    def reduce_event(self, obj):
+        return threading.Event, ()
+
+    @staticmethod
+    def load_socket(data):
+        if platform.system() == 'Windows':
+            return socket.socket.fromshare(data)
+        return socket.socket(fileno=data)
+
+    def reduce_socket(self, obj):
+        if platform.system() == 'Windows':
+            data = obj.share(self.process.pid)
+        else:
+            data = obj.fileno()
+        return PicklerForProcess.load_socket, (data,)
+
+    def dump(self, *args, **kwargs):
+        super().dump(*args, **kwargs)
+        self.process.stdin.flush()
+
+
+def main():
+    func = pickle.load(sys.stdin.buffer)
+    sys.stdin.close()
+    os.close(0)  # force C stream close
+    return func()
+
+
+def daemonize(func, tags={}, timeout=None, debug=False):
+    prog = f'from {__name__} import main; main()'
+    cmd = [sys.executable, '-c', prog]
+    for name, value in tags.items():
+        flag = '--' + name.replace('_', '-')
+        cmd += [flag, str(value)]
+    kwargs = {}
+    if platform.system() == 'Windows':
+        # Process Creation Flag documented in the MSDN
+        DETACHED_PROCESS = 0x00000008  # noqa: N806
+        kwargs.update(creationflags=DETACHED_PROCESS)
+        # avoid showing cmd windows for subprocess
+        si = subprocess.STARTUPINFO()
+        si.dwFlags = subprocess.STARTF_USESHOWWINDOW
+        si.wShowWindow = subprocess.SW_HIDE
+        kwargs['startupinfo'] = si
+        # don't keep handle of current working directory in daemon process
+        kwargs.update(cwd=os.environ.get('SYSTEMROOT', None))
+
+    kwargs['stdin'] = subprocess.PIPE
+    if not debug:
+        kwargs['stdout'] = subprocess.DEVNULL
+        kwargs['stderr'] = subprocess.DEVNULL
+    kwargs['close_fds'] = False
+
+    process = subprocess.Popen(cmd, **kwargs)
+
+    pickler = PicklerForProcess(process)
+
+    pickler.dump(func)
+
+    if timeout is not None:
+        def daemon_ready():
+            try:
+                pickler.dump(None)
+                return False
+            except OSError:
+                return True
+        if not wait_for(daemon_ready, timeout):
+            process.terminate()
+            raise RuntimeError(
+                'Timed out waiting for '
+                'daemon to become ready'
+            )
+    if process.poll() is not None:
+        rc = process.returncode
+        raise RuntimeError(
+            'Daemon process died '
+            f'with returncode {rc}'
+        )
+    return

--- a/ros2cli/ros2cli/daemon/daemonize.py
+++ b/ros2cli/ros2cli/daemon/daemonize.py
@@ -142,7 +142,7 @@ def daemonize(callable_, tags={}, timeout=None, debug=False):
             try:
                 pickler.dump(None)
                 return False
-            except BrokenPipeError:
+            except OSError:
                 return True
         if not wait_for(daemon_ready, timeout):
             process.terminate()

--- a/ros2cli/ros2cli/helpers.py
+++ b/ros2cli/ros2cli/helpers.py
@@ -23,6 +23,17 @@ def get_ros_domain_id():
 
 
 def wait_for(predicate, timeout, period=0.1):
+    """
+    Wait for a predicate to evaluate to `True`.
+
+    :param timeout: duration, in seconds, to wait
+      for the predicate to evaluate to `True`.
+      Non-positive durations will result in an
+      indefinite wait.
+    :param period: predicate evaluation period,
+      in seconds.
+    :return: predicate result
+    """
     if timeout < 0:
         timeout = float('+inf')
     deadline = time.time() + timeout
@@ -49,6 +60,11 @@ def bind(func, *args, **kwargs):
 
 
 def pretty_print_call(func, *args, **kwargs):
+    """
+    Print a function invocation.
+
+    See `before_invocation` for usage as a hook.
+    """
     name = func.__name__
     arguments = ', '.join(
         [f'{v!r}' for v in args] +
@@ -58,6 +74,12 @@ def pretty_print_call(func, *args, **kwargs):
 
 
 def before_invocation(func, hook):
+    """
+    Invoke a `hook` before every `func` invocation.
+
+    `hook` may take no arguments or take the `func`
+    and arbitrary positional and keyword arguments.
+    """
     signature = inspect.signature(hook)
     nargs = len(signature.parameters)
     if inspect.ismethod(hook):

--- a/ros2cli/ros2cli/helpers.py
+++ b/ros2cli/ros2cli/helpers.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import inspect
+import os
+import time
+
+
+def get_ros_domain_id():
+    return int(os.environ.get('ROS_DOMAIN_ID', 0))
+
+
+def wait_for(predicate, timeout, period=0.1):
+    if timeout < 0:
+        timeout = float('+inf')
+    deadline = time.time() + timeout
+    while not predicate():
+        if time.time() > deadline:
+            break
+        time.sleep(period)
+    return predicate()
+
+
+def bind(func, *args, **kwargs):
+    """
+    Bind a function with a set of arguments.
+
+    A functools.partial equivalent that is actually a function.
+    """
+    partial = functools.partial(func, *args, **kwargs)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return partial(*args, **kwargs)
+    wrapper.__signature__ = inspect.signature(func)
+    return wrapper
+
+
+def pretty_print_call(func, *args, **kwargs):
+    name = func.__name__
+    arguments = ', '.join(
+        [f'{v!r}' for v in args] +
+        [f'{k}={v!r}' for k, v in kwargs.items()]
+    )
+    print(f'{name}({arguments})')
+
+
+def before_invocation(func, hook):
+    signature = inspect.signature(hook)
+    nargs = len(signature.parameters)
+    if inspect.ismethod(hook):
+        nargs = nargs - 1
+    if nargs > 0:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            hook(func, *args, **kwargs)
+            return func(*args, **kwargs)
+    else:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            hook()
+            return func(*args, **kwargs)
+    wrapper.__signature__ = inspect.signature(func)
+    return wrapper

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Open Source Robotics Foundation, Inc.
+# Copyright 2017-2021 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,87 +13,18 @@
 # limitations under the License.
 
 import errno
-import os
-import platform
+import functools
 import socket
-import struct
-import subprocess
-import sys
-import time
 
 import rclpy
-from ros2cli.daemon import get_daemon_port
 
-from ros2cli.xmlrpc.client import ProtocolError
+import ros2cli.daemon as daemon
+from ros2cli.daemon.daemonize import daemonize
+
+from ros2cli.helpers import get_ros_domain_id
+from ros2cli.helpers import wait_for
+
 from ros2cli.xmlrpc.client import ServerProxy
-
-
-def is_daemon_running(args):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
-    addr = ('localhost', get_daemon_port())
-    try:
-        s.bind(addr)
-    except socket.error as e:
-        if e.errno == errno.EADDRINUSE:
-            return True
-    finally:
-        s.close()
-    return False
-
-
-def spawn_daemon(args, wait_until_spawned=None, debug=False):
-    ros_domain_id = int(os.environ.get('ROS_DOMAIN_ID', 0))
-    kwargs = {}
-    if platform.system() != 'Windows':
-        cmd = ['_ros2_daemon']
-    else:
-        # allow closing the shell the daemon was spawned from
-        # while the daemon is still running
-        cmd = [
-            sys.executable,
-            os.path.join(
-                os.path.dirname(os.path.dirname(__file__)),
-                'daemon/__init__.py')]
-        # Process Creation Flag documented in the MSDN
-        DETACHED_PROCESS = 0x00000008  # noqa: N806
-        kwargs.update(creationflags=DETACHED_PROCESS)
-        # avoid showing cmd windows for subprocess
-        si = subprocess.STARTUPINFO()
-        si.dwFlags = subprocess.STARTF_USESHOWWINDOW
-        si.wShowWindow = subprocess.SW_HIDE
-        kwargs['startupinfo'] = si
-        # don't keep handle of current working directory in daemon process
-        kwargs.update(cwd=os.environ.get('SYSTEMROOT', None))
-
-    rmw_implementation_identifier = rclpy.get_rmw_implementation_identifier()
-    if rmw_implementation_identifier is None:
-        raise RuntimeError(
-            'Unable to get rmw_implementation_identifier, '
-            'try specifying the implementation to use via the '
-            "'RMW_IMPLEMENTATION' environment variable")
-    cmd.extend([
-        # the arguments are only passed for visibility in e.g. the process list
-        '--rmw-implementation', rmw_implementation_identifier,
-        '--ros-domain-id', str(ros_domain_id)])
-    if not debug:
-        kwargs['stdout'] = subprocess.DEVNULL
-        kwargs['stderr'] = subprocess.DEVNULL
-    subprocess.Popen(cmd, **kwargs)
-
-    if wait_until_spawned is None:
-        return True
-
-    if wait_until_spawned > 0.0:
-        timeout = time.time() + wait_until_spawned
-    else:
-        timeout = None
-    while True:
-        if is_daemon_running(args):
-            return True
-        time.sleep(0.1)
-        if timeout is not None and time.time() >= timeout:
-            return None
 
 
 class DaemonNode:
@@ -101,28 +32,28 @@ class DaemonNode:
     def __init__(self, args):
         self._args = args
         self._proxy = ServerProxy(
-            'http://localhost:%d/ros2cli/' % get_daemon_port(),
+            daemon.get_xmlrpc_server_url(),
             allow_none=True)
         self._methods = []
 
     @property
+    def connected(self):
+        try:
+            self._proxy.system.listMethods()
+        except ConnectionRefusedError:
+            return False
+        return True
+
+    @property
     def methods(self):
-        return self._methods
+        return [
+            method
+            for method in self._proxy.system.listMethods()
+            if not method.startswith('system.')
+        ]
 
     def __enter__(self):
         self._proxy.__enter__()
-
-        try:
-            methods = self._proxy.system.listMethods()
-        except ProtocolError as e:
-            if e.errcode != 404:
-                raise
-            # remote daemon returned 404, likely using different rmw impl.
-            self._proxy.__exit__()
-            self._proxy = None
-        else:
-            self._methods = [m for m in methods if not m.startswith('system.')]
-
         return self
 
     def __getattr__(self, name):
@@ -132,7 +63,12 @@ class DaemonNode:
         self._proxy.__exit__(exc_type, exc_value, traceback)
 
 
-def shutdown_daemon(args, wait_duration=None):
+def is_daemon_running(args):
+    with DaemonNode(args) as node:
+        return node.connected
+
+
+def shutdown_daemon(args, timeout=None):
     """
     Shuts down remote daemon node.
 
@@ -143,20 +79,39 @@ def shutdown_daemon(args, wait_duration=None):
     :return: whether the daemon is shut down already or not.
     """
     with DaemonNode(args) as node:
-        node.system.shutdown()
-
-    if wait_duration is None:
-        return not is_daemon_running(args)
-
-    if wait_duration > 0.0:
-        timeout = time.time() + wait_duration
-    else:
-        timeout = None
-
-    while is_daemon_running(args):
-        time.sleep(0.1)
-        if timeout and time.time() >= timeout:
+        if not node.connected:
             return False
+        node.system.shutdown()
+        if timeout is not None:
+            predicate = (lambda: not node.connected)
+            if not wait_for(predicate, timeout):
+                raise RuntimeError(
+                    'Timed out waiting for '
+                    'daemon to shutdown'
+                )
+        return True
+
+
+def spawn_daemon(args, timeout=None, debug=False):
+    try:
+        server = daemon.make_xmlrpc_server()
+        server.socket.set_inheritable(True)
+    except socket.error as e:
+        if e.errno == errno.EADDRINUSE:
+            return False
+        raise
+
+    try:
+        tags = {
+            'name': 'ros2-daemon', 'ros_domain_id': get_ros_domain_id(),
+            'rmw_implementation': rclpy.get_rmw_implementation_identifier()}
+
+        daemonize(
+            functools.partial(daemon.serve_forever, server),
+            tags=tags, timeout=timeout, debug=debug)
+    finally:
+        server.server_close()
+
     return True
 
 

--- a/ros2cli/ros2cli/node/network_aware.py
+++ b/ros2cli/ros2cli/node/network_aware.py
@@ -1,0 +1,75 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+
+import netifaces
+import rclpy
+
+from ros2cli.helpers import before_invocation
+
+from ros2cli.node.direct import DirectNode
+
+
+def get_interfaces_ip_addresses():
+    addresses_by_interfaces = {}
+    for (kind, info_list) in netifaces.gateways().items():
+        if kind not in (netifaces.AF_INET, netifaces.AF_INET6):
+            continue
+        print('Interface kind: {}, info: {}'.format(kind, info_list))
+        addresses_by_interfaces[kind] = {}
+        for info in info_list:
+            interface_name = info[1]
+            addresses_by_interfaces[kind][interface_name] = (
+                netifaces.ifaddresses(interface_name)[kind][0]['addr']
+            )
+    print('Addresses by interfaces: {}'.format(addresses_by_interfaces))
+    return addresses_by_interfaces
+
+
+class NetworkAwareNode:
+    """A direct node, that resets itself when a network interface changes."""
+
+    def __init__(self, args):
+        self.args = args
+        # TODO(ivanpauno): A race condition is possible here, since it isn't possible to know
+        # exactly which interfaces were available at node creation.
+        self.node = DirectNode(args)
+        self.addresses_at_start = get_interfaces_ip_addresses()
+
+    def __enter__(self):
+        self.node.__enter__()
+        return self
+
+    def __getattr__(self, name):
+        attr = getattr(self.node, name)
+
+        if inspect.ismethod(attr):
+            return before_invocation(
+                attr, self.reset_if_addresses_changed)
+        self.reset_if_addresses_changed()
+        return attr
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.node.__exit__(exc_type, exc_value, traceback)
+
+    def reset_if_addresses_changed(self):
+        new_addresses = get_interfaces_ip_addresses()
+        if new_addresses != self.addresses_at_start:
+            self.addresses_at_start = new_addresses
+            self.node.destroy_node()
+            rclpy.shutdown()
+            self.node = DirectNode(self.args)
+            self.node.__enter__()
+            print('Daemon node was reset')

--- a/ros2cli/ros2cli/verb/daemon/start.py
+++ b/ros2cli/ros2cli/verb/daemon/start.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
-from ros2cli.node.daemon import is_daemon_running
 from ros2cli.node.daemon import spawn_daemon
 from ros2cli.verb.daemon import VerbExtension
 
@@ -28,16 +25,7 @@ class StartVerb(VerbExtension):
             help='Print debug messages')
 
     def main(self, *, args):
-        running = is_daemon_running(args)
-        if running:
-            print('The daemon is already running')
-            return
-
-        spawned = spawn_daemon(args, wait_until_spawned=10.0, debug=args.debug)
-        if spawned:
+        if spawn_daemon(args, timeout=10.0, debug=args.debug):
             print('The daemon has been started')
         else:
-            print(
-                'Failed to confirm that the daemon started successfully',
-                file=sys.stderr)
-            return 1
+            print('The daemon is already running')

--- a/ros2cli/ros2cli/verb/daemon/status.py
+++ b/ros2cli/ros2cli/verb/daemon/status.py
@@ -20,8 +20,7 @@ class StatusVerb(VerbExtension):
     """Output the status of the daemon."""
 
     def main(self, *, args):
-        running = is_daemon_running(args)
-        if running:
+        if is_daemon_running(args):
             print('The daemon is running')
         else:
             print('The daemon is not running')

--- a/ros2cli/ros2cli/verb/daemon/stop.py
+++ b/ros2cli/ros2cli/verb/daemon/stop.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ros2cli.node.daemon import DaemonNode
-from ros2cli.node.daemon import is_daemon_running
+from ros2cli.node.daemon import shutdown_daemon
 from ros2cli.verb.daemon import VerbExtension
 
 
@@ -21,16 +20,7 @@ class StopVerb(VerbExtension):
     """Stop the daemon if it is running."""
 
     def main(self, *, args):
-        running = is_daemon_running(args)
-        if not running:
+        if shutdown_daemon(args, timeout=10.0):
+            print('The daemon has been stopped')
+        else:
             print('The daemon is not running')
-            return
-
-        with DaemonNode(args) as daemon:
-            try:
-                shutdown = daemon.system.shutdown
-            except AttributeError:
-                return 'Failed to shutdown daemon, ' \
-                    'it might be using a different rmw implementation'
-            shutdown()
-        print('The daemon has been stopped')

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -14,6 +14,7 @@
 
 import socket
 import struct
+# Import SimpleXMLRPCRequestHandler to re-export it.
 from xmlrpc.server import SimpleXMLRPCRequestHandler  # noqa
 from xmlrpc.server import SimpleXMLRPCServer
 

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -14,7 +14,7 @@
 
 import socket
 import struct
-from xmlrpc.server import SimpleXMLRPCRequestHandler
+from xmlrpc.server import SimpleXMLRPCRequestHandler  # noqa
 from xmlrpc.server import SimpleXMLRPCServer
 
 
@@ -39,7 +39,3 @@ class LocalXMLRPCServer(SimpleXMLRPCServer):
         if client_address[0] != '127.0.0.1':
             return False
         return super(LocalXMLRPCServer, self).verify_request(request, client_address)
-
-
-class RequestHandler(SimpleXMLRPCRequestHandler):
-    rpc_paths = ('/ros2cli/',)

--- a/ros2cli/test/test_daemon.py
+++ b/ros2cli/test/test_daemon.py
@@ -21,6 +21,7 @@ import rclpy.action
 
 from ros2cli.node.daemon import DaemonNode
 from ros2cli.node.daemon import is_daemon_running
+from ros2cli.node.daemon import shutdown_daemon
 from ros2cli.node.daemon import spawn_daemon
 
 import test_msgs.action
@@ -107,9 +108,8 @@ def local_node():
 @pytest.fixture(scope='module')
 def daemon_node():
     if is_daemon_running(args=[]):
-        with DaemonNode(args=[]) as node:
-            node.system.shutdown()
-    assert spawn_daemon(args=[], wait_until_spawned=5.0)
+        assert shutdown_daemon(args=[], timeout=5.0)
+    assert spawn_daemon(args=[], timeout=5.0)
     with DaemonNode(args=[]) as node:
         attempts = 3
         delay_between_attempts = 2  # seconds

--- a/ros2cli/test/test_strategy.py
+++ b/ros2cli/test/test_strategy.py
@@ -25,14 +25,14 @@ from ros2cli.node.strategy import NodeStrategy
 @pytest.fixture
 def enforce_no_daemon_is_running():
     if is_daemon_running(args=[]):
-        assert shutdown_daemon(args=[], wait_duration=5.0)
+        assert shutdown_daemon(args=[], timeout=5.0)
     yield
 
 
 @pytest.fixture
 def enforce_daemon_is_running():
     if not is_daemon_running(args=[]):
-        assert spawn_daemon(args=[], wait_until_spawned=5.0)
+        assert spawn_daemon(args=[], timeout=5.0)
     yield
 
 


### PR DESCRIPTION
This patch is an alternative to #632, transferring socket ownership on spawn to preclude the TOCTOU races that running daemon checks induce. 

This patch is functional in my local Linux environment. Let's see what CI (and Windows) have to say:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14866)](http://ci.ros2.org/job/ci_linux/14866/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9616)](http://ci.ros2.org/job/ci_linux-aarch64/9616/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12533)](http://ci.ros2.org/job/ci_osx/12533/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=15034)](http://ci.ros2.org/job/ci_windows/15034/)
