### PR TITLE
Fix flaky ros2 param list

### DIFF
--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -101,7 +101,6 @@ class ListVerb(VerbExtension):
                     break
                 rclpy.spin_once(node, timeout_sec=1.0)
 
-
             # wait for all responses
             for future in futures.values():
                 rclpy.spin_until_future_complete(node, future, timeout_sec=1.0)

--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -69,10 +69,11 @@ class ListVerb(VerbExtension):
         if regex_filter is not None:
             regex_filter = re.compile(regex_filter[0])
 
-        with DirectNode(args) as node:
+        with NodeStrategy(args) as node:
             service_names = get_service_names(
                 node=node, include_hidden_services=args.include_hidden_nodes)
 
+        with DirectNode(args) as node:
             clients = {}
             futures = {}
             # create clients for nodes which have the service
@@ -99,6 +100,7 @@ class ListVerb(VerbExtension):
                 if len(futures) == len(clients):
                     break
                 rclpy.spin_once(node, timeout_sec=1.0)
+
 
             # wait for all responses
             for future in futures.values():

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -163,6 +163,7 @@ class TestVerbList(unittest.TestCase):
             strict=True
         )
 
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_verb_list(self):
         with self.launch_param_list_command(
             arguments=[f'{TEST_NAMESPACE}/{TEST_NODE}']


### PR DESCRIPTION
I think this relates to https://github.com/ros2/ros2cli/issues/655, and hopefully fixes it.

By using the daemon node to list parameter services, I hope we avoid a race with discovery with every invocation of `ros2 param list`. There still is a race with the first call if the daemon is not running yet, but I think that's normal for most ros2cli tools.

I've also add a retry decorator to the test to workaround it potentially failing on the first try.