### PR TITLE
Make the ros2cli output always line buffered

### DIFF
--- a/ros2cli/ros2cli/cli.py
+++ b/ros2cli/ros2cli/cli.py
@@ -14,12 +14,20 @@
 # limitations under the License.
 
 import argparse
+import builtins
+import functools
 import signal
 
 from ros2cli.command import add_subparsers_on_demand
 
 
 def main(*, script_name='ros2', argv=None, description=None, extension=None):
+    # Make the output always line buffered, even when piping the output to another process.
+    # If you explicitly passed `flush=false`, that's not going to be the case.
+    # This only modifies the behavior of print(), if you write to stdout in another way line
+    # buffering is not guaranteed.
+    builtins.print = functools.partial(print, flush=True)
+
     if description is None:
         description = f'{script_name} is an extensible command-line tool ' \
             'for ROS 2.'

--- a/ros2cli/ros2cli/cli.py
+++ b/ros2cli/ros2cli/cli.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import argparse
+import builtins
+import functools
 import signal
 import sys
 
@@ -68,7 +70,9 @@ def main(*, script_name='ros2', argv=None, description=None, extension=None):
         try:
             sys.stdout.reconfigure(line_buffering=True)
         except AttributeError:
-            # if stdout is not a TextIoWrapper instance, we don't do anything
+            # if stdout is not a TextIoWrapper instance, or we're using python older than 3.7,
+            # force line buffering by patching print
+            builtins.print = functools.partial(print, flush=True)
             pass
 
     if extension is None:

--- a/ros2cli/ros2cli/cli.py
+++ b/ros2cli/ros2cli/cli.py
@@ -35,6 +35,7 @@ def main(*, script_name='ros2', argv=None, description=None, extension=None):
     parser.add_argument(
         '--use-python-default-buffering',
         action='store_true',
+        default=False,
         help=(
             'Do not force line buffering in stdout and instead use the python default buffering, '
             'which might be affected by PYTHONUNBUFFERED/-u and depends on whatever stdout is '
@@ -73,7 +74,6 @@ def main(*, script_name='ros2', argv=None, description=None, extension=None):
             # if stdout is not a TextIoWrapper instance, or we're using python older than 3.7,
             # force line buffering by patching print
             builtins.print = functools.partial(print, flush=True)
-            pass
 
     if extension is None:
         # get extension identified by the passed command (if available)


### PR DESCRIPTION
Fixes https://github.com/ros2/ros2cli/issues/595.

This forces all calls to print() to also flush the output buffer, the result is similar to having line buffering.

Alternative: We could also do something like what it's suggested here https://stackoverflow.com/questions/107705/disable-output-buffering.

Another alternative: I don't think we need unbuffered output for all commands though, e.g. it's not needed for `ros2 topic list`.
The ones that need unbuffered (or line buffered) output are the ones that are periodically reporting progress, e.g. `ros2 topic pub`, `ros2 topic echo`, etc.
Some of that output could arguably be going to stderr, which in python is always line buffered (even when non interactive), e.g. the output of `ros2 topic pub`.
The output of `ros2 topic echo` should probably go to `stdout` though, and if we don't want global line buffering we would need to pass the flush argument manually.

See also:

- https://docs.python.org/3/library/sys.html#sys.stderr
- https://stackoverflow.com/questions/230751/how-can-i-flush-the-output-of-the-print-function
- https://stackoverflow.com/questions/881696/unbuffered-stdout-in-python-as-in-python-u-from-within-the-program