### PR TITLE
[foxy backport] Fix flaky ros2 param list (#656)

### DIFF
--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -54,10 +54,11 @@ class ListVerb(VerbExtension):
             node_names = [
                 n for n in node_names if node_name == n.full_name]
 
-        with DirectNode(args) as node:
+        with NodeStrategy(args) as node:
             service_names = get_service_names(
                 node=node, include_hidden_services=args.include_hidden_nodes)
 
+        with DirectNode(args) as node:
             clients = {}
             futures = {}
             # create clients for nodes which have the service


### PR DESCRIPTION
Backport #656 to Foxy.

Note, that the test code does not exist in Foxy, so that part was not backported.