### PR TITLE
Update test lost messages

### DIFF
--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -248,8 +248,8 @@ class TestROS2TopicEchoPub(unittest.TestCase):
                             depth=10,
                             reliability=ReliabilityPolicy.BEST_EFFORT,
                             durability=DurabilityPolicy.VOLATILE)
-                if message_lost:
-                    echo_extra_options.append('--lost-messages')
+                if not message_lost:
+                    echo_extra_options.append('--no-lost-messages')
                 publisher = self.node.create_publisher(String, topic, publisher_qos_profile)
                 assert publisher
 
@@ -281,13 +281,7 @@ class TestROS2TopicEchoPub(unittest.TestCase):
                     command.wait_for_shutdown(timeout=10)
                     # Check results
                     if compatible_qos:
-                        # TODO(ivanpauno): remove special case when FastRTPS implements the feature
-                        # https://github.com/ros2/rmw_fastrtps/issues/395
                         assert command.output, 'Echo CLI printed no output'
-                        if message_lost and 'rmw_fastrtps' in get_rmw_implementation_identifier():
-                            assert 'does not support reporting lost messages' in command.output
-                            assert get_rmw_implementation_identifier() in command.output
-                            return
                         assert 'data: hello' in command.output.splitlines(), (
                             'Echo CLI did not print expected message'
                         )


### PR DESCRIPTION
Opened this PR to fix the test failures in the FastRTPS and FastRTPS jobs: [build.ros2.org/Rci__nightly-fastrtps_ubuntu_focal_amd64#486/ros2topic.ros2topic.test/test_echo_pub/test_echo_pub/](https://build.ros2.org/view/Rci/job/Rci__nightly-fastrtps_ubuntu_focal_amd64/486/testReport/ros2topic.ros2topic.test/test_echo_pub/test_echo_pub/). This is a continuation of #633 

<details>
```
Error Message
test_echo_pub.TestROS2TopicEchoPub.test_echo_basic (topic='/clitest/topic/echo_message_lost', provide_qos=False, compatible_qos=True) failed
Stacktrace
========================================================================================================================================================================================================================================================================================================================================
FAIL: test_echo_pub.TestROS2TopicEchoPub.test_echo_basic (topic='/clitest/topic/echo_message_lost', provide_qos=False, compatible_qos=True)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/ws/src/ros2/ros2cli/ros2topic/test/test_echo_pub.py", line 288, in test_echo_basic
    assert 'does not support reporting lost messages' in command.output
AssertionError: assert 'does not support reporting lost messages' in "WARNING: '--lost-messages' is deprecated; lost messages are reported by default\ndata: hello\n---\ndata: hello\n---\n...llo\n---\ndata: hello\n---\ndata: hello\n---\ndata: hello\n---\ndata: hello\n---\ndata: hello\n---\ndata: hello\n---\n"
 +  where "WARNING: '--lost-messages' is deprecated; lost messages are reported by default\ndata: hello\n---\ndata: hello\n---\n...llo\n---\ndata: hello\n---\ndata: hello\n---\ndata: hello\n---\ndata: hello\n---\ndata: hello\n---\ndata: hello\n---\n" = <launch_testing.tools.process.ProcessProxy object at 0x7f741d0d0fd0>.output
```
</details>

As discussed in that PR, the expectation for the `ros2cli` is to silently continue, the warning was removed for rmw vendors not supporting the lost messages feature. This PR updates the test to remove that special case test and update the CLI options used to test without the lost messages event.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>