### PR TITLE
[BACKPORT] support QoS Depth and History via ros2 topic pub/echo. (#528)

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
 from typing import Any
 from typing import Callable
 from typing import Optional
@@ -26,6 +25,7 @@ from ros2topic.api import add_qos_arguments_to_argument_parser
 from ros2topic.api import get_msg_class
 from ros2topic.api import qos_profile_from_short_keys
 from ros2topic.api import TopicNameCompleter
+from ros2topic.api import unsigned_int
 from ros2topic.verb import VerbExtension
 from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_yaml
@@ -33,16 +33,6 @@ from rosidl_runtime_py.utilities import get_message
 
 DEFAULT_TRUNCATE_LENGTH = 128
 MsgType = TypeVar('MsgType')
-
-
-def unsigned_int(string):
-    try:
-        value = int(string)
-    except ValueError:
-        value = -1
-    if value < 0:
-        raise ArgumentTypeError('value must be non-negative integer')
-    return value
 
 
 class EchoVerb(VerbExtension):
@@ -89,7 +79,8 @@ def main(args):
         truncate_length = args.truncate_length if not args.full_length else None
         callback = subscriber_cb_csv(truncate_length, args.no_arr, args.no_str)
     qos_profile = qos_profile_from_short_keys(
-        args.qos_profile, reliability=args.qos_reliability, durability=args.qos_durability)
+        args.qos_profile, reliability=args.qos_reliability, durability=args.qos_durability,
+        depth=args.qos_depth, history=args.qos_history)
     with NodeStrategy(args) as node:
         if args.message_type is None:
             message_type = get_msg_class(node, args.topic_name, include_hidden_topics=True)

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -99,7 +99,8 @@ class PubVerb(VerbExtension):
 
 def main(args):
     qos_profile = qos_profile_from_short_keys(
-        args.qos_profile, reliability=args.qos_reliability, durability=args.qos_durability)
+        args.qos_profile, reliability=args.qos_reliability, durability=args.qos_durability,
+        depth=args.qos_depth, history=args.qos_history)
     times = args.times
     if args.once:
         times = 1

--- a/ros2topic/test/test_qos_conversions.py
+++ b/ros2topic/test/test_qos_conversions.py
@@ -19,6 +19,9 @@ from ros2topic.api import qos_profile_from_short_keys
 
 def test_profile_conversion():
     profile = qos_profile_from_short_keys(
-        'sensor_data', reliability='reliable', durability='transient_local')
+        'sensor_data', reliability='reliable', durability='transient_local',
+        depth=10, history='keep_last')
     assert profile.durability == rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL
     assert profile.reliability == rclpy.qos.QoSReliabilityPolicy.RELIABLE
+    assert profile.depth == 10
+    assert profile.history == rclpy.qos.QoSHistoryPolicy.KEEP_LAST


### PR DESCRIPTION
Backporting work of #528 to foxy as discussed in issue #523 

cc: @clalancette 

---

support QoS Depth and History via ros2 topic pub/echo.

Also keep depth at least 1 with transient_local setting.