### PR TITLE
[ros2pkg] Skip copyright tests in template packages

### DIFF
--- a/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
@@ -78,11 +78,12 @@ install(TARGETS @(cpp_node_name)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
-  # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
   # the following line skips cpplint (only works in a git repo)
-  # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 @[if cpp_library_name]@

--- a/ros2pkg/ros2pkg/resource/ament_python/test_copyright.py.em
+++ b/ros2pkg/ros2pkg/resource/ament_python/test_copyright.py.em
@@ -16,6 +16,8 @@ from ament_copyright.main import main
 import pytest
 
 
+# Remove the `skip` decorator once the source file(s) have a copyright header
+@@pytest.mark.skip(reason='No copyright header has been placed in the generated source file.')
 @@pytest.mark.copyright
 @@pytest.mark.linter
 def test_copyright():


### PR DESCRIPTION
The template sources populated through `ros2 pkg create` for the
`ament_python`/`ament_cmake` build types do not have well-formed
copyright headers, and as such fail the `ament_copyright` tests when
run as-is.

This commit skips said test by default, instead informing the user to -
once the source files have been populated with well-formed headers -
enable the skipped tests either within the test script itself (for
`ament_python`) or within the CMakeLists.txt file (for `ament_cmake`).

Addresses #675.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>