### PR TITLE
Use try_shutdown() instead of shutdown() in DirectNode.__exit__()

### DIFF
--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -84,7 +84,7 @@ class DirectNode:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.node.destroy_node()
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
 
 def add_arguments(parser):


### PR DESCRIPTION
There was a change in signal handling, and now SIGINT/SIGTERM will automatically trigger a shutwon request.

This modifies `DirectNode.__exit__()` to use `try_shutdown()`, in order to not get a "context already shutdown" error when a signal is sent.

I manually tested with the following example and the issue is gone:

```py
import sys
from ros2cli.node.direct import DirectNode

args = sys.argv[1:]

with DirectNode(args) as node:
    from rclpy.executors import SingleThreadedExecutor
    executor = SingleThreadedExecutor()
    executor.add_node(node)
    executor.spin_once(timeout_sec=None)
```


New error message after ctrl-c:

```
^CTraceback (most recent call last):
  File "audrow_example.py", line 10, in <module>
    executor.spin_once(timeout_sec=None)
  File "/home/ivanpauno/ros2_ws/install/rclpy/lib/python3.8/site-packages/rclpy/executors.py", line 704, in spin_once
    handler, entity, node = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
  File "/home/ivanpauno/ros2_ws/install/rclpy/lib/python3.8/site-packages/rclpy/executors.py", line 690, in wait_for_ready_callbacks
    return next(self._cb_iter)
  File "/home/ivanpauno/ros2_ws/install/rclpy/lib/python3.8/site-packages/rclpy/executors.py", line 588, in _wait_for_ready_callbacks
    wait_set.wait(timeout_nsec)
KeyboardInterrupt
```
