### PR TITLE
Fix how ros2 param interprets command-line arguments.

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -62,9 +62,7 @@ def get_parameter_value(*, string_value):
     try:
         yaml_value = yaml.safe_load(string_value)
     except yaml.parser.ParserError:
-        value.type = ParameterType.PARAMETER_STRING
-        value.string_value = string_value
-        return value
+        yaml_value = string_value
 
     if isinstance(yaml_value, bool):
         value.type = ParameterType.PARAMETER_BOOL
@@ -90,10 +88,10 @@ def get_parameter_value(*, string_value):
             value.string_array_value = yaml_value
         else:
             value.type = ParameterType.PARAMETER_STRING
-            value.string_value = string_value
+            value.string_value = yaml_value
     else:
         value.type = ParameterType.PARAMETER_STRING
-        value.string_value = string_value
+        value.string_value = yaml_value
     return value
 
 

--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -88,7 +88,7 @@ def get_parameter_value(*, string_value):
             value.string_array_value = yaml_value
         else:
             value.type = ParameterType.PARAMETER_STRING
-            value.string_value = yaml_value
+            value.string_value = string_value
     else:
         value.type = ParameterType.PARAMETER_STRING
         value.string_value = yaml_value

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -66,6 +66,13 @@ from ros2param.api import get_parameter_value
             'string_value',
             '["foo", "bar", "buzz"',
         ),
+        (
+            # With !!str, text that would otherwise be a bool is a string
+            '!!str off',
+            ParameterType.PARAMETER_STRING,
+            'string_value',
+            'off'
+        ),
     ],
 )
 def test_get_parameter_value(

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -67,11 +67,26 @@ from ros2param.api import get_parameter_value
             '["foo", "bar", "buzz"',
         ),
         (
+            # With 'off', YAML interprets this as a bool
+            'off',
+            ParameterType.PARAMETER_BOOL,
+            'bool_value',
+            False
+        ),
+        (
             # With !!str, text that would otherwise be a bool is a string
             '!!str off',
             ParameterType.PARAMETER_STRING,
             'string_value',
             'off'
+        ),
+        (
+            # While YAML supports a mixed-type list, ROS 2 parameters do not,
+            # so these end up being strings
+            '[true,0.1,1]',
+            ParameterType.PARAMETER_STRING,
+            'string_value',
+            '[true,0.1,1]'
         ),
     ],
 )


### PR DESCRIPTION
Basically ensure that we are *always* using the parsed yaml
string, so that users can override types as appropriate.
This makes it possible for users to specify something like:

ros2 param set /node param '!!str off'

for force a string to be "off" as opposed to having YAML
intepret it as a boolean.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is still a draft because I'm kind of nervous about the change; this has the potential to break some use-cases that worked before.  All of the tests pass, and basic testing here has worked fine for me, but I want to do more testing before marking it as ready.

Fixes #677 (at least, as far as I think we can fix it)