### PR TITLE
Depend on launch packages instead of ros_testing to avoid circular dependency

### DIFF
--- a/ros2action/package.xml
+++ b/ros2action/package.xml
@@ -27,8 +27,11 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2action/package.xml
+++ b/ros2action/package.xml
@@ -28,7 +28,6 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>launch</test_depend>
-  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -28,8 +28,11 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/ros2interface/package.xml
+++ b/ros2interface/package.xml
@@ -26,8 +26,11 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
   <test_depend>ros2cli_test_interfaces</test_depend>
   <test_depend>test_msgs</test_depend>
 

--- a/ros2interface/package.xml
+++ b/ros2interface/package.xml
@@ -27,7 +27,6 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>launch</test_depend>
-  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>

--- a/ros2lifecycle/package.xml
+++ b/ros2lifecycle/package.xml
@@ -27,8 +27,11 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
   <test_depend>ros2lifecycle_test_fixtures</test_depend>
 
   <export>

--- a/ros2node/package.xml
+++ b/ros2node/package.xml
@@ -22,9 +22,12 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rclpy</test_depend>
-  <test_depend>ros_testing</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -28,8 +28,11 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -29,7 +29,6 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>launch</test_depend>
-  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>

--- a/ros2service/package.xml
+++ b/ros2service/package.xml
@@ -26,8 +26,11 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2topic/package.xml
+++ b/ros2topic/package.xml
@@ -29,8 +29,11 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>geometry_msgs</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>ros_testing</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
 


### PR DESCRIPTION
ros_testing depends on ros2test which depends on ros2cli. This causes a circular dependency in the repository that means `ros-rolling-ros2cli` gets installed in the PR job for this repo.