### PR TITLE
Switch ros2 doctor to using psutil for network checks.

### DIFF
--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -18,7 +18,7 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
-  <exec_depend>python3-ifcfg</exec_depend>
+  <exec_depend>python3-psutil</exec_depend>
   <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
   <exec_depend>rclpy</exec_depend>


### PR DESCRIPTION
ifcfg has a couple of different problems.  The first is that
the code literally calls 'ifconfig' and parses the output.  While
this generally works, it is pretty ugly.  For those reasons,
Debian has specifically excluded it.

Instead, switch to psutil to get information about the network
interfaces on the system (at least, on POSIX).  This gets us
all of the information we had before, but using ioctl's instead.

Note that we can't actually get any flags from psutil at the
moment.  There is a PR open upstream to get this information,
but since it is not going to be available soon we implement
the equivalent thing in Python by using fcntl.ioctl.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This will also require a change to CI to install psutil on Windows; PR for that will be upcoming.  @nuclearsandwich @j-rivero FYI