### PR TITLE
Use local username for ROS Pkg

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -94,7 +94,7 @@ class CreateVerb(VerbExtension):
             git = shutil.which('git')
             if git is not None:
                 p = subprocess.Popen(
-                    [git, 'config', '--global', 'user.email'],
+                    [git, 'config', 'user.email'],
                     stdout=subprocess.PIPE)
                 resp = p.communicate()
                 email = resp[0].decode().rstrip()


### PR DESCRIPTION
This issue is reported in #477 and is fixed for ROS2 Eloquent in #479 but not for Foxy.