### PR TITLE
Add timeout to kill hanging tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 junit_family=xunit2
+timeout=900

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 junit_family=xunit2
-timeout=900
+timeout=3

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 junit_family=xunit2
 timeout=3
+timeout_method=thread

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 junit_family=xunit2
-timeout=3
+timeout=900
 timeout_method=thread

--- a/ros2action/package.xml
+++ b/ros2action/package.xml
@@ -31,6 +31,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -28,6 +28,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2component/package.xml
+++ b/ros2component/package.xml
@@ -31,6 +31,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -33,6 +33,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/ros2interface/package.xml
+++ b/ros2interface/package.xml
@@ -30,6 +30,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>ros2cli_test_interfaces</test_depend>
   <test_depend>test_msgs</test_depend>
 

--- a/ros2lifecycle/package.xml
+++ b/ros2lifecycle/package.xml
@@ -32,6 +32,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>ros2lifecycle_test_fixtures</test_depend>
 
   <export>

--- a/ros2multicast/package.xml
+++ b/ros2multicast/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2node/package.xml
+++ b/ros2node/package.xml
@@ -27,6 +27,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>test_msgs</test_depend>
 

--- a/ros2param/package.xml
+++ b/ros2param/package.xml
@@ -32,6 +32,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -32,6 +32,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2run/package.xml
+++ b/ros2run/package.xml
@@ -25,6 +25,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2service/package.xml
+++ b/ros2service/package.xml
@@ -31,6 +31,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/ros2topic/package.xml
+++ b/ros2topic/package.xml
@@ -34,6 +34,7 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>python3-pytest-timeout</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
 


### PR DESCRIPTION
This PR aims to remedy our buildfarm jobs that occasionally hang until they are manually killed. 

This requires the following PR: https://github.com/ros2/ci/pull/632.

You can see that the timeout worked to stop a job here (with absurdly low timeout): https://ci.ros2.org/job/ci_linux/16355/console#console-section-5.