### PR TITLE
Fix importlib_metadata warning on Python 3.10.

### DIFF
--- a/ros2cli/ros2cli/entry_points.py
+++ b/ros2cli/ros2cli/entry_points.py
@@ -63,8 +63,13 @@ def get_entry_points(group_name):
       to ``EntryPoint`` instances
     :rtype: dict
     """
+    entry_points_impl = importlib_metadata.entry_points()
+    if hasattr(entry_points_impl, 'select'):
+        groups = entry_points_impl.select(group=group_name)
+    else:
+        groups = entry_points_impl.get(group_name, [])
     entry_points = {}
-    for entry_point in importlib_metadata.entry_points().get(group_name, []):
+    for entry_point in groups:
         entry_points[entry_point.name] = entry_point
     return entry_points
 

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -91,7 +91,12 @@ def run_checks(*, include_warnings=False) -> Tuple[Set[str], int, int]:
     fail_categories = set()  # remove repeating elements
     fail = 0
     total = 0
-    for check_entry_pt in importlib_metadata.entry_points().get('ros2doctor.checks', []):
+    entry_points = importlib_metadata.entry_points()
+    if hasattr(entry_points, 'select'):
+        groups = entry_points.select(group='ros2doctor.checks')
+    else:
+        groups = entry_points.get('ros2doctor.checks', [])
+    for check_entry_pt in groups:
         try:
             check_class = check_entry_pt.load()
         except ImportError as e:
@@ -121,7 +126,12 @@ def generate_reports(*, categories=None) -> List[Report]:
     :return: list of Report objects
     """
     reports = []
-    for report_entry_pt in importlib_metadata.entry_points().get('ros2doctor.report', []):
+    entry_points = importlib_metadata.entry_points()
+    if hasattr(entry_points, 'select'):
+        groups = entry_points.select(group='ros2doctor.report')
+    else:
+        groups = entry_points.get('ros2doctor.report', [])
+    for report_entry_pt in groups:
         try:
             report_class = report_entry_pt.load()
         except ImportError as e:


### PR DESCRIPTION
Use the newer select interface where available, but fallback
to the dict interface as needed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/ros2/issues/1254