### PR TITLE
Add verbose option to echo that also prints the associated message info

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -312,7 +312,10 @@ class EchoVerb(VerbExtension):
 
         if self.csv:
             to_print = message_to_csv(
-                submsg, truncate_length=self.truncate_length, no_arr=self.no_arr, no_str=self.no_str)
+                submsg,
+                truncate_length=self.truncate_length,
+                no_arr=self.no_arr,
+                no_str=self.no_str)
             if self.include_message_info:
                 to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
             print(to_print)

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -301,18 +301,18 @@ class EchoVerb(VerbExtension):
         if self.future is not None:
             self.future.set_result(True)
 
-        if not hasattr(msg, '__slots__'):
+        if not hasattr(submsg, '__slots__'):
             # raw
             if self.include_message_info:
                 print('---Got new message, message info:---')
                 print(info)
                 print('---Message data:---')
-            print(msg, end='\n---\n')
+            print(submsg, end='\n---\n')
             return
 
         if self.csv:
             to_print = message_to_csv(
-                msg, truncate_length=self.truncate_length, no_arr=self.no_arr, no_str=self.no_str)
+                submsg, truncate_length=self.truncate_length, no_arr=self.no_arr, no_str=self.no_str)
             if self.include_message_info:
                 to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
             print(to_print)
@@ -322,7 +322,7 @@ class EchoVerb(VerbExtension):
             print(yaml.dump(info), end='---\n')
         print(
             message_to_yaml(
-                msg, truncate_length=self.truncate_length,
+                submsg, truncate_length=self.truncate_length,
                 no_arr=self.no_arr, no_str=self.no_str, flow_style=self.flow_style),
             end='---\n')
 

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -88,8 +88,14 @@ class EchoVerb(VerbExtension):
                  'Automatically match existing publishers )')
         parser.add_argument(
             '--csv', action='store_true',
-            help='Output all recursive fields separated by commas (e.g. for '
-                 'plotting)')
+            help=(
+                'Output all recursive fields separated by commas (e.g. for '
+                'plotting). '
+                'If --include-message-info is also passed, the following fields are prepended: '
+                'source_timestamp, received_timestamp, publication_sequence_number,'
+                ' reception_sequence_number.'
+            )
+        )
         parser.add_argument(
             '--field', type=str, default=None,
             help='Echo a selected field of a message. '

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -32,7 +32,6 @@ from ros2topic.api import qos_profile_from_short_keys
 from ros2topic.api import TopicNameCompleter
 from ros2topic.api import unsigned_int
 from ros2topic.verb import VerbExtension
-import rosidl_parser
 from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message
@@ -310,7 +309,7 @@ class EchoVerb(VerbExtension):
                 print('---Message data:---')
             print(msg, end='\n---\n')
             return
-                    
+
         if self.csv:
             to_print = message_to_csv(
                 msg, truncate_length=self.truncate_length, no_arr=self.no_arr, no_str=self.no_str)

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import remove
 import sys
 from typing import Optional
 from typing import TypeVar
@@ -312,10 +311,12 @@ class EchoVerb(VerbExtension):
             self.print_func(
                 submsg, self.truncate_length, self.no_arr, self.no_str, self.flow_style)
 
+
 def _expr_eval(expr):
     def eval_fn(m):
         return eval(expr)
     return eval_fn
+
 
 class MessageInfo:
 
@@ -332,13 +333,14 @@ class MessageInfo:
         int,
     ]
 
-    def __init__(self, dict):
+    def __init__(self, message_info_dict):
         for slot in self.__slots__:
-            value = dict[slot[1:]]
+            value = message_info_dict[slot[1:]]
             if value is None:
                 self.__slots__.remove(slot)
             else:
                 setattr(self, slot, value)
+
 
 class MessageWrapperWithInfo:
 
@@ -351,7 +353,8 @@ class MessageWrapperWithInfo:
     def __init__(self, msg, info):
         self._message = msg
         self._message_info = MessageInfo(info)
-    
+
+
 def _print_yaml(msg, truncate_length, noarr, nostr, flowstyle):
     if hasattr(msg, '__slots__'):
         print(


### PR DESCRIPTION
Depends on https://github.com/ros2/rclpy/pull/922.

Exampler

``` bash
# terminal 1
ros2 run demo_nodes_py talker
```

```# terminal 2
ros2 topic echo /chatter -v
```

<details>
<summary>Expected output</summary>

```
message_info:
  source_timestamp: 1650489540621873147
  received_timestamp: 1650489540622072614
  publication_sequence_number: 857
message:
  data: 'Hello World: 856'
---
message_info:
  source_timestamp: 1650489541623013413
  received_timestamp: 1650489541623204404
  publication_sequence_number: 858
message:
  data: 'Hello World: 857'
---
message_info:
  source_timestamp: 1650489542623151805
  received_timestamp: 1650489542623384098
  publication_sequence_number: 859
message:
  data: 'Hello World: 858'
---
```
</details>

```
# terminal 2
ros2 topic echo /chatter -v --csv
```

<details>
<summary>Expected output</summary>

```
1650489559622070757,1650489559622579350,876,Hello World: 875
1650489560622630220,1650489560622846798,877,Hello World: 876
1650489561622649720,1650489561622884896,878,Hello World: 877
1650489562622548056,1650489562622715317,879,Hello World: 878
```
</details>

```# terminal 2
ros2 topic echo /chatter -v --raw
```

<details>
<summary>Expected output</summary>

```
---Got new message, message info:---     
{'source_timestamp': 1650489633622441430, 'received_timestamp': 1650489633622663794, 'publication_sequence_number': 950, 'reception_sequence_number': None}
---Message data:---
b'\x00\x01\x00\x00\x11\x00\x00\x00Hello World: 949\x00\x00\x00\x00'
---
---Got new message, message info:---
{'source_timestamp': 1650489634622511979, 'received_timestamp': 1650489634622743998, 'publication_sequence_number': 951, 'reception_sequence_number': None}
---Message data:---                      
b'\x00\x01\x00\x00\x11\x00\x00\x00Hello World: 950\x00\x00\x00\x00'
---     
---Got new message, message info:---
{'source_timestamp': 1650489635620004061, 'received_timestamp': 1650489635620098772, 'publication_sequence_number': 952, 'reception_sequence_number': None}
---Message data:---
b'\x00\x01\x00\x00\x11\x00\x00\x00Hello World: 951\x00\x00\x00\x00'
---
```
</details>

---

I'm not sure what to do in the case of the `--csv` option.
The yaml and raw outputs look reasonable to me.
The implementation is a bit tricky, I'm open to suggestions.