### PR TITLE
Add alias library targets for CMake pkg generation

### DIFF
--- a/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
@@ -22,6 +22,7 @@ find_package(@dep REQUIRED)
 @[if cpp_library_name]@
 
 add_library(@(cpp_library_name) src/@(cpp_library_name).cpp)
+add_library(@(project_name)::@(cpp_library_name) ALIAS @(cpp_library_name))
 target_compile_features(@(cpp_library_name) PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_include_directories(@(cpp_library_name) PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em
@@ -25,6 +25,7 @@ find_package(@dep REQUIRED)
 @[if cpp_library_name]@
 
 add_library(@(cpp_library_name) SHARED src/@(cpp_library_name).cpp)
+add_library(@(project_name)::@(cpp_library_name) ALIAS @(cpp_library_name))
 target_compile_features(@(cpp_library_name) PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 target_include_directories(@(cpp_library_name) PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
Automatically add ALIAS targets for generated libraries, as it's best practice to have those. 

In creating this PR, I was unable to test it; after building this package and sourcing the install environment, the host ros2cli seems to still be used. 

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>