### PR TITLE
Set multiple parameters

### DIFF
--- a/ros2param/ros2param/verb/set.py
+++ b/ros2param/ros2param/verb/set.py
@@ -83,13 +83,14 @@ class SetVerb(VerbExtension):
             results = response.results
 
             for i, result in enumerate(results):
+                msg = "Set parameter '%s' " % (parameters[i].name)
                 if result.successful:
-                    msg = f'Set parameter {parameters[i].name} successful'
+                    msg += 'successful'
                     if result.reason:
                         msg += ': ' + result.reason
                     print(msg)
                 else:
-                    msg = 'Set parameter failed'
+                    msg += 'failed'
                     if result.reason:
                         msg += ': ' + result.reason
                     print(msg, file=sys.stderr)

--- a/ros2param/test/test_verb_set.py
+++ b/ros2param/test/test_verb_set.py
@@ -167,7 +167,7 @@ class TestVerbSet(unittest.TestCase):
             assert param_load_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
         assert param_load_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
-            expected_lines=['Set parameter int_param successful'],
+            expected_lines=["Set parameter 'int_param' successful"],
             text=param_load_command.output,
             strict=True)
 
@@ -184,9 +184,9 @@ class TestVerbSet(unittest.TestCase):
         assert param_load_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                'Set parameter int_param successful',
-                'Set parameter str_param successful',
-                'Set parameter bool_param successful'],
+                "Set parameter 'int_param' successful",
+                "Set parameter 'str_param' successful",
+                "Set parameter 'bool_param' successful"],
             text=param_load_command.output,
             strict=True)
 
@@ -220,7 +220,3 @@ class TestVerbSet(unittest.TestCase):
             expected_lines=['Node not found'],
             text=param_load_command.output,
             strict=True)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Support setting multiple parameters at once using `ros2 param set`


See: https://github.com/ros2/ros2cli/pull/727#issuecomment-1164515330

This PR uses features from https://github.com/ros2/ros2cli/pull/716 (Diff: https://github.com/ros2/ros2cli/compare/brianc/parameter_client...brianc/multiple_param_set)


```
$ ros2 param set -h

usage: ros2 param set [-h] [--spin-time SPIN_TIME] [-s] [--no-daemon] [--include-hidden-nodes] node_name parameter_name value

Set parameter

positional arguments:
  node_name             Name of the ROS node
  parameters            List of parameter name and value pairs i.e. "int_param 1 str_param hello_world"

options:
  -h, --help            show this help message and exit
  --spin-time SPIN_TIME
                        Spin time in seconds to wait for discovery (only applies when not using an already running daemon)
  -s, --use-sim-time    Enable ROS simulation time
  --no-daemon           Do not spawn nor use an already running daemon
  --include-hidden-nodes
                        Consider hidden nodes as well
```
Example usage:

`ros2 param set /test_node int_param 12 str_param hello_world`


