### PR TITLE
[Service Introspection] Support echo verb for ros2 service cli

### DIFF
--- a/ros2service/ros2service/api/__init__.py
+++ b/ros2service/ros2service/api/__init__.py
@@ -33,6 +33,9 @@ def get_service_names(*, node, include_hidden_services=False):
         node=node, include_hidden_services=include_hidden_services)
     return [n for (n, t) in service_names_and_types]
 
+def get_service_type(*, node, service, include_hidden_services=False):
+    pass
+
 
 def service_type_completer(**kwargs):
     """Callable returning a list of service types."""

--- a/ros2service/ros2service/verb/echo.py
+++ b/ros2service/ros2service/verb/echo.py
@@ -1,0 +1,142 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import importlib
+from typing import Optional
+from typing import TypeVar
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSPresetProfiles
+from rclpy.qos import QoSProfile
+from rclpy.serialization import deserialize_message
+
+from rcl_interfaces.msg import ServiceEventType
+
+from ros2topic.api import unsigned_int
+
+from ros2service.api import ServiceNameCompleter
+from ros2service.api import ServiceTypeCompleter
+from ros2service.verb import VerbExtension
+from rosidl_runtime_py.utilities import get_message
+from ros2cli.node.strategy import NodeStrategy
+
+from rosidl_runtime_py import message_to_yaml
+import yaml
+
+DEFAULT_TRUNCATE_LENGTH = 128
+MsgType = TypeVar('MsgType')
+
+
+class EchoVerb(VerbExtension):
+    """Echo a service."""
+
+    def __init__(self):
+        super().__init__()
+        self.srv_module = None
+        self.topic_name = None
+        self.no_str = None
+        self.no_arr = None
+        self.truncate_length = None
+        self.flow_style = None
+        self.hidden_topic_suffix = "/_service_event"
+        self.message_type = get_message("rcl_interfaces/msg/ServiceEvent")
+        self.qos_profile = QoSPresetProfiles.get_from_short_key("services_default")
+
+    def add_arguments(self, parser, cli_name):
+        arg = parser.add_argument(
+            'service_name',
+            help="Name of the ROS service to echo from (e.g. '/add_two_ints')")
+        arg.completer = ServiceNameCompleter(
+            include_hidden_services_key='include_hidden_services')
+        arg = parser.add_argument(
+            'service_type', nargs='?',
+            help="Type of the ROS service (e.g. 'std_srvs/srv/Empty')")
+        arg.completer = ServiceTypeCompleter(
+            service_name_key='service_name')
+        parser.add_argument(
+            '--full-length', '-f', action='store_true',
+            help='Output all elements for arrays, bytes, and string with a '
+                 "length > '--truncate-length', by default they are truncated "
+                 "after '--truncate-length' elements with '...''")
+        parser.add_argument(
+            '--truncate-length', '-l', type=unsigned_int, default=DEFAULT_TRUNCATE_LENGTH,
+            help='The length to truncate arrays, bytes, and string to '
+                 '(default: %d)' % DEFAULT_TRUNCATE_LENGTH)
+        parser.add_argument(
+            '--no-arr', action='store_true', help="Don't print array fields of messages")
+        parser.add_argument(
+            '--no-str', action='store_true', help="Don't print string fields of messages")
+        parser.add_argument(
+            '--include-message-info', '-i', action='store_true',
+            help='Shows the associated message info.')
+
+    def main(self, *, args):
+        self.topic_name = args.service_name + self.hidden_topic_suffix
+        self.truncate_length = args.truncate_length if not args.full_length else None
+        self.no_arr = args.no_arr
+        self.no_str = args.no_str
+
+        try:
+            parts = args.service_type.split('/')
+            if len(parts) == 2:
+                parts = [parts[0], 'srv', parts[1]]
+            package_name = parts[0]
+            print(parts[:-1])
+            module = importlib.import_module('.'.join(parts[:-1]))
+            srv_name = parts[-1]
+            self.srv_module = getattr(module, srv_name)
+        except (AttributeError, ModuleNotFoundError, ValueError):
+            raise RuntimeError('The passed service type is invalid')
+        try:
+            var = self.srv_module.Request
+            var = self.srv_module.Response
+        except AttributeError:
+            raise RuntimeError('The passed type is not a service')
+
+        with NodeStrategy(args) as node:
+            self.subscribe_and_spin(
+                node,
+                self.topic_name,
+                self.message_type
+            )
+
+    def subscribe_and_spin(
+            self,
+            node: Node,
+            topic_name: str,
+            message_type: MsgType,
+    ) -> Optional[str]:
+        """Initialize a node with a single subscription and spin."""
+
+        node.create_subscription(
+            message_type,
+            topic_name,
+            self._subscriber_callback,
+            self.qos_profile)
+
+        rclpy.spin(node)
+
+    def _subscriber_callback(self, msg, info):
+        service_event_type = msg.info.event_type
+        serialized_event = b''.join(msg.serialized_event)
+
+        if service_event_type is ServiceEventType.REQUEST_RECEIVED or \
+                service_event_type is ServiceEventType.REQUEST_SENT:
+            service_request = deserialize_message(serialized_event,
+                                                  self.srv_module.Request)
+        elif service_event_type is ServiceEventType.RESPONSE_RECEIVED or \
+                service_event_type is ServiceEventType.RESPONSE_SENT:
+            service_request = deserialize_message(serialized_event,
+                                                  self.srv_module.Response)

--- a/ros2service/ros2service/verb/echo.py
+++ b/ros2service/ros2service/verb/echo.py
@@ -152,17 +152,18 @@ class EchoVerb(VerbExtension):
         elif service_event_type is ServiceEventType.RESPONSE_RECEIVED or \
                 service_event_type is ServiceEventType.RESPONSE_SENT:
             serialize_msg_type = self.srv_module.Response
-        else:  # TODO remove this else condition later
-            print("# Invalid Type")
+        else:  # TODO remove this else condition later once event enum is correct
             return
 
-        # csv: TODO
+        # csv
         if self.csv:
             to_print = message_to_csv(
                 msg,
                 truncate_length=self.truncate_length,
                 no_arr=self.no_arr,
-                no_str=self.no_str)
+                no_str=self.no_str,
+                serialize_msg_type=serialize_msg_type
+            )
             if self.include_message_info:
                 to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
             print(to_print)
@@ -173,7 +174,10 @@ class EchoVerb(VerbExtension):
             print(yaml.dump(info), end='---\n')
         print(
             message_to_yaml(
-                msg, truncate_length=self.truncate_length,
-                no_arr=self.no_arr, no_str=self.no_str, flow_style=self.flow_style,
+                msg,
+                truncate_length=self.truncate_length,
+                no_arr=self.no_arr,
+                no_str=self.no_str,
+                flow_style=self.flow_style,
                 serialize_msg_type=serialize_msg_type),
             end='---\n')

--- a/ros2service/ros2service/verb/echo.py
+++ b/ros2service/ros2service/verb/echo.py
@@ -11,30 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import importlib
 
 from typing import Optional
 from typing import TypeVar
 
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSPresetProfiles
-from rclpy.qos import QoSProfile
-from rclpy.serialization import deserialize_message
 
-from rcl_interfaces.msg import ServiceEventType
-from rcl_interfaces.msg import ServiceEvent
-
+from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import unsigned_int
+from rcl_interfaces.msg import ServiceEventType
 
-from ros2service.api import ServiceNameCompleter, get_service_names_and_types, get_service_class
+from ros2service.api import ServiceNameCompleter, get_service_class
 from ros2service.api import ServiceTypeCompleter
 from ros2service.verb import VerbExtension
-from rosidl_runtime_py.utilities import get_message, get_service
-from ros2cli.node.strategy import NodeStrategy
 
 from rosidl_runtime_py import message_to_yaml, message_to_csv
+from rosidl_runtime_py.utilities import get_message, get_service
+
 import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128

--- a/ros2service/ros2service/verb/echo.py
+++ b/ros2service/ros2service/verb/echo.py
@@ -155,7 +155,7 @@ class EchoVerb(VerbExtension):
         rclpy.spin(node)
 
     def _subscriber_callback(self, msg, info):
-        serialize_msg_type = None
+        deserialize_msg_type = None
         self.event_enum = msg.info.event_type
 
         if self.client and self.server:
@@ -171,10 +171,10 @@ class EchoVerb(VerbExtension):
 
         if self.event_enum is ServiceEventType.REQUEST_RECEIVED or \
                 self.event_enum is ServiceEventType.REQUEST_SENT:
-            serialize_msg_type = self.srv_module.Request
+            deserialize_msg_type = self.srv_module.Request
         elif self.event_enum is ServiceEventType.RESPONSE_RECEIVED or \
                 self.event_enum is ServiceEventType.RESPONSE_SENT:
-            serialize_msg_type = self.srv_module.Response
+            deserialize_msg_type = self.srv_module.Response
         else:  # TODO remove this once event enum is correct
             print("Returning invalid service event type")
             return
@@ -186,7 +186,7 @@ class EchoVerb(VerbExtension):
                 truncate_length=self.truncate_length,
                 no_arr=self.no_arr,
                 no_str=self.no_str,
-                serialize_msg_type=serialize_msg_type
+                deserialize_msg_type=deserialize_msg_type
             )
             if self.include_message_info:
                 to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
@@ -199,7 +199,7 @@ class EchoVerb(VerbExtension):
         print(
             self.format_output(message_to_ordereddict(
                 msg, truncate_length=self.truncate_length,
-                no_arr=self.no_arr, no_str=self.no_str, serialize_msg_type=serialize_msg_type)),
+                no_arr=self.no_arr, no_str=self.no_str, deserialize_msg_type=deserialize_msg_type)),
             end='---------------------------\n')
 
     def format_output(self, dict_service_event: OrderedDict):

--- a/ros2service/ros2service/verb/echo.py
+++ b/ros2service/ros2service/verb/echo.py
@@ -23,6 +23,7 @@ from rclpy.qos import QoSProfile
 from rclpy.serialization import deserialize_message
 
 from rcl_interfaces.msg import ServiceEventType
+from rcl_interfaces.msg import ServiceEvent
 
 from ros2topic.api import unsigned_int
 
@@ -32,7 +33,7 @@ from ros2service.verb import VerbExtension
 from rosidl_runtime_py.utilities import get_message
 from ros2cli.node.strategy import NodeStrategy
 
-from rosidl_runtime_py import message_to_yaml
+from rosidl_runtime_py import message_to_yaml, message_to_csv
 import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
@@ -50,6 +51,8 @@ class EchoVerb(VerbExtension):
         self.no_arr = None
         self.truncate_length = None
         self.flow_style = None
+        self.csv = None
+        self.include_message_info = None
         self.hidden_topic_suffix = "/_service_event"
         self.message_type = get_message("rcl_interfaces/msg/ServiceEvent")
         self.qos_profile = QoSPresetProfiles.get_from_short_key("services_default")
@@ -79,6 +82,16 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             '--no-str', action='store_true', help="Don't print string fields of messages")
         parser.add_argument(
+            '--csv', action='store_true',
+            help=(
+                'Output all recursive fields separated by commas (e.g. for '
+                'plotting). '
+                'If --include-message-info is also passed, the following fields are prepended: '
+                'source_timestamp, received_timestamp, publication_sequence_number,'
+                ' reception_sequence_number.'
+            )
+        )
+        parser.add_argument(
             '--include-message-info', '-i', action='store_true',
             help='Shows the associated message info.')
 
@@ -87,13 +100,14 @@ class EchoVerb(VerbExtension):
         self.truncate_length = args.truncate_length if not args.full_length else None
         self.no_arr = args.no_arr
         self.no_str = args.no_str
+        self.csv = args.csv
+        self.include_message_info = args.include_message_info
 
         try:
             parts = args.service_type.split('/')
             if len(parts) == 2:
                 parts = [parts[0], 'srv', parts[1]]
             package_name = parts[0]
-            print(parts[:-1])
             module = importlib.import_module('.'.join(parts[:-1]))
             srv_name = parts[-1]
             self.srv_module = getattr(module, srv_name)
@@ -130,13 +144,36 @@ class EchoVerb(VerbExtension):
 
     def _subscriber_callback(self, msg, info):
         service_event_type = msg.info.event_type
-        serialized_event = b''.join(msg.serialized_event)
+        serialize_msg_type = None
 
         if service_event_type is ServiceEventType.REQUEST_RECEIVED or \
                 service_event_type is ServiceEventType.REQUEST_SENT:
-            service_request = deserialize_message(serialized_event,
-                                                  self.srv_module.Request)
+            serialize_msg_type = self.srv_module.Request
         elif service_event_type is ServiceEventType.RESPONSE_RECEIVED or \
                 service_event_type is ServiceEventType.RESPONSE_SENT:
-            service_request = deserialize_message(serialized_event,
-                                                  self.srv_module.Response)
+            serialize_msg_type = self.srv_module.Response
+        else:  # TODO remove this else condition later
+            print("# Invalid Type")
+            return
+
+        # csv: TODO
+        if self.csv:
+            to_print = message_to_csv(
+                msg,
+                truncate_length=self.truncate_length,
+                no_arr=self.no_arr,
+                no_str=self.no_str)
+            if self.include_message_info:
+                to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
+            print(to_print)
+            return
+
+        # yaml
+        if self.include_message_info:
+            print(yaml.dump(info), end='---\n')
+        print(
+            message_to_yaml(
+                msg, truncate_length=self.truncate_length,
+                no_arr=self.no_arr, no_str=self.no_str, flow_style=self.flow_style,
+                serialize_msg_type=serialize_msg_type),
+            end='---\n')

--- a/ros2service/ros2service/verb/echo.py
+++ b/ros2service/ros2service/verb/echo.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
+
 from typing import Optional
 from typing import TypeVar
 
@@ -151,12 +152,13 @@ class EchoVerb(VerbExtension):
         serialize_msg_type = None
         event_enum = msg.info.event_type
 
-        if self.client:
+        if self.client and self.server:
+            pass
+        elif self.client:
             if event_enum is ServiceEventType.REQUEST_RECEIVED or \
                     event_enum is ServiceEventType.RESPONSE_SENT:
                 return
-
-        if self.server:
+        elif self.server:
             if event_enum is ServiceEventType.REQUEST_SENT or \
                     event_enum is ServiceEventType.RESPONSE_RECEIVED:
                 return

--- a/ros2service/ros2service/verb/echo.py
+++ b/ros2service/ros2service/verb/echo.py
@@ -11,39 +11,34 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
-from typing import Optional
-from typing import TypeVar
-
 from collections import OrderedDict
+import sys
+from typing import Optional, TypeVar
 
 import rclpy
-from rclpy.node import Node
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.qos import QoSPresetProfiles
+from rosidl_runtime_py import message_to_csv
+from rosidl_runtime_py import message_to_ordereddict
+from rosidl_runtime_py.utilities import get_service
+from service_msgs.msg import ServiceEventInfo
+import yaml
 
 from ros2cli.node.strategy import NodeStrategy
-from ros2topic.api import unsigned_int
-from rcl_interfaces.msg import ServiceEventType
-
-from ros2service.api import ServiceNameCompleter, get_service_class
+from ros2service.api import get_service_class
+from ros2service.api import ServiceNameCompleter
 from ros2service.api import ServiceTypeCompleter
 from ros2service.verb import VerbExtension
-
-from rosidl_runtime_py import message_to_csv, message_to_ordereddict
-from rosidl_runtime_py.utilities import get_message, get_service
-
-import yaml
+from ros2topic.api import unsigned_int
 
 DEFAULT_TRUNCATE_LENGTH = 128
 MsgType = TypeVar('MsgType')
-
 
 def represent_ordereddict(dumper, data):
     items = []
     for k, v in data.items():
         items.append((dumper.represent_data(k), dumper.represent_data(v)))
     return yaml.nodes.MappingNode(u'tag:yaml.org,2002:map', items)
-
 
 class EchoVerb(VerbExtension):
     """Echo a service."""
@@ -54,15 +49,15 @@ class EchoVerb(VerbExtension):
         self.no_arr = None
         self.csv = None
         self.flow_style = None
-        self.client = None
-        self.server = None
+        self.client_only = None
+        self.server_only = None
         self.truncate_length = None
-        self.include_message_info = None
+        self.exclude_message_info = None
         self.srv_module = None
         self.event_enum = None
-        self.event_msg_type = get_message("rcl_interfaces/msg/ServiceEvent")
         self.qos_profile = QoSPresetProfiles.get_from_short_key("services_default")
         self.__yaml_representer_registered = False
+        self.event_type_map = dict((v, k) for k, v in ServiceEventInfo._Metaclass_ServiceEventInfo__constants.items())
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
@@ -91,146 +86,111 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             '--csv', action='store_true',
             help=(
-                'Output all recursive fields separated by commas (e.g. for '
-                'plotting). '
-                'If --include-message-info is also passed, the following fields are prepended: '
-                'source_timestamp, received_timestamp, publication_sequence_number,'
-                ' reception_sequence_number.'
-            )
-        )
+                'Output all recursive fields separated by commas (e.g. for plotting).'
+            ))
         parser.add_argument(
-            '--include-message-info', '-i', action='store_true',
-            help='Shows the associated message info.')
+            '--exclude-message-info', action='store_true', help='Hide associated message info.')
         parser.add_argument(
-            '--client', action='store_true', help="Echo only request sent or response received by service client")
+            '--client-only', action='store_true', help="Echo only request sent or response received by service client")
         parser.add_argument(
-            '--server', action='store_true', help="Echo only request received or response sent by service server")
+            '--server-only', action='store_true', help="Echo only request received or response sent by service server")
 
     def main(self, *, args):
         self.truncate_length = args.truncate_length if not args.full_length else None
         self.no_arr = args.no_arr
         self.no_str = args.no_str
         self.csv = args.csv
-        self.include_message_info = args.include_message_info
-        self.client = args.client
-        self.server = args.server
+        self.exclude_message_info = args.exclude_message_info
+        self.client_only = args.client_only
+        self.server_only = args.server_only
+        event_topic_name = args.service_name + \
+            _rclpy.service_introspection.RCL_SERVICE_INTROSPECTION_TOPIC_POSTFIX
+
+        if self.server_only and self.client_only:
+            raise RuntimeError("--client-only and --server-only are mutually exclusive")
 
         if args.service_type is None:
             with NodeStrategy(args) as node:
-                self.srv_module = get_service_class(
-                    node, args.service_name, blocking=False, include_hidden_services=True)
+                try:
+                    self.srv_module = get_service_class(
+                        node, args.service_name, blocking=False, include_hidden_services=True)
+                    self.event_msg_type = self.srv_module.Event
+                except (AttributeError, ModuleNotFoundError, ValueError):
+                    raise RuntimeError("The service name '%s' is invalid" % args.service_name)
         else:
             try:
                 self.srv_module = get_service(args.service_type)
+                self.event_msg_type = self.srv_module.Event
             except (AttributeError, ModuleNotFoundError, ValueError):
                 raise RuntimeError("The service type '%s' is invalid" % args.service_type)
 
         if self.srv_module is None:
-            raise RuntimeError(
-                'Could not load the type for the passed service')
-
-        event_topic_name = args.service_name + "/_service_event"
+            raise RuntimeError('Could not load the type for the passed service')
 
         with NodeStrategy(args) as node:
             self.subscribe_and_spin(
                 node,
                 event_topic_name,
-                self.event_msg_type
-            )
+                self.event_msg_type)
 
-    def subscribe_and_spin(
-            self,
-            node: Node,
-            event_topic_name: str,
-            event_msg_type: MsgType,
-    ) -> Optional[str]:
+    def subscribe_and_spin(self, node, event_topic_name: str, event_msg_type: MsgType) -> Optional[str]:
         """Initialize a node with a single subscription and spin."""
-
         node.create_subscription(
             event_msg_type,
             event_topic_name,
             self._subscriber_callback,
             self.qos_profile)
-
         rclpy.spin(node)
 
-    def _subscriber_callback(self, msg, info):
-        deserialize_msg_type = None
-        self.event_enum = msg.info.event_type
-
-        if self.client and self.server:
-            pass
-        elif self.client:
-            if self.event_enum is ServiceEventType.REQUEST_RECEIVED or \
-                    self.event_enum is ServiceEventType.RESPONSE_SENT:
-                return
-        elif self.server:
-            if self.event_enum is ServiceEventType.REQUEST_SENT or \
-                    self.event_enum is ServiceEventType.RESPONSE_RECEIVED:
-                return
-
-        if self.event_enum is ServiceEventType.REQUEST_RECEIVED or \
-                self.event_enum is ServiceEventType.REQUEST_SENT:
-            deserialize_msg_type = self.srv_module.Request
-        elif self.event_enum is ServiceEventType.RESPONSE_RECEIVED or \
-                self.event_enum is ServiceEventType.RESPONSE_SENT:
-            deserialize_msg_type = self.srv_module.Response
-        else:  # TODO remove this once event enum is correct
-            print("Returning invalid service event type")
-            return
-
-        # csv
+    def _subscriber_callback(self, msg):
         if self.csv:
-            to_print = message_to_csv(
-                msg,
-                truncate_length=self.truncate_length,
-                no_arr=self.no_arr,
-                no_str=self.no_str,
-                deserialize_msg_type=deserialize_msg_type
-            )
-            if self.include_message_info:
-                to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
-            print(to_print)
-            return
+            print(self.format_csv_output(msg))
+        else:
+            print(self.format_yaml_output(msg))
+        print('---------------------------')
 
-        # yaml
-        if self.include_message_info:
-            print(yaml.dump(info), end='---\n')
-        print(
-            self.format_output(message_to_ordereddict(
-                msg, truncate_length=self.truncate_length,
-                no_arr=self.no_arr, no_str=self.no_str, deserialize_msg_type=deserialize_msg_type)),
-            end='---------------------------\n')
+    def format_csv_output(self, msg: MsgType):
+        """Convert a message to a CSV string."""
+        if self.exclude_message_info:
+            msg.info = ServiceEventInfo()
+        to_print = message_to_csv(
+            msg,
+            truncate_length=self.truncate_length,
+            no_arr=self.no_arr,
+            no_str=self.no_str)
+        return to_print
 
-    def format_output(self, dict_service_event: OrderedDict):
-        dict_output = OrderedDict()
-        dict_output['stamp'] = dict_service_event['info']['stamp']
-        dict_output['client_id'] = dict_service_event['info']['client_id']
-        dict_output['sequence_number'] = dict_service_event['info']['sequence_number']
+    def format_yaml_output(self, msg: MsgType):
+        """Pretty-format a service event message."""
+        event_dict = message_to_ordereddict(
+            msg,
+            truncate_length=self.truncate_length,
+            no_arr=self.no_arr,
+            no_str=self.no_str)
 
-        if self.event_enum is ServiceEventType.REQUEST_SENT:
-            dict_output['event_type'] = 'CLIENT_REQUEST_SENT'
-        elif self.event_enum is ServiceEventType.RESPONSE_RECEIVED:
-            dict_output['event_type'] = 'CLIENT_RESPONSE_RECEIVED'
-        elif self.event_enum is ServiceEventType.REQUEST_RECEIVED:
-            dict_output['event_type'] = 'SERVER_REQUEST_RECEIVED'
-        elif self.event_enum is ServiceEventType.RESPONSE_SENT:
-            dict_output['event_type'] = 'SERVER_RESPONSE_SENT'
+        event_dict['info']['event_type'] = \
+            self.event_type_map[event_dict['info']['event_type']]
 
-        if self.event_enum is ServiceEventType.REQUEST_RECEIVED or \
-                self.event_enum is ServiceEventType.REQUEST_SENT:
-            dict_output['request'] = dict_service_event['serialized_event']
-        elif self.event_enum is ServiceEventType.RESPONSE_RECEIVED or \
-                self.event_enum is ServiceEventType.RESPONSE_SENT:
-            dict_output['response'] = dict_service_event['serialized_event']
+        if self.exclude_message_info:
+            del event_dict['info']
+
+        # unpack Request, Response sequences
+        if len(event_dict['request']) == 0:
+            del event_dict['request']
+        else:
+            event_dict['request'] = event_dict['request'][0]
+
+        if len(event_dict['response']) == 0:
+            del event_dict['response']
+        else:
+            event_dict['response'] = event_dict['response'][0]
 
         # Register custom representer for YAML output
         if not self.__yaml_representer_registered:
             yaml.add_representer(OrderedDict, represent_ordereddict)
             self.__yaml_representer_registered = True
 
-        return yaml.dump(dict_output,
+        return yaml.dump(event_dict,
                          allow_unicode=True,
                          width=sys.maxsize,
-                         default_flow_style=self.flow_style,
-                         )
+                         default_flow_style=self.flow_style)

--- a/ros2service/setup.py
+++ b/ros2service/setup.py
@@ -44,6 +44,7 @@ The package provides the service command for the ROS 2 command line tools.""",
             'find = ros2service.verb.find:FindVerb',
             'list = ros2service.verb.list:ListVerb',
             'type = ros2service.verb.type:TypeVerb',
+            'echo = ros2service.verb.echo:EchoVerb',
         ],
     }
 )

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -142,8 +142,9 @@ def _get_msg_class(node, topic, include_hidden_topics):
 
     try:
         return get_message(message_type)
-    except (AttributeError, ModuleNotFoundError, ValueError):
-        raise RuntimeError("The message type '%s' is invalid" % message_type)
+    except (AttributeError, ModuleNotFoundError, ValueError) as e:
+        raise e
+        # raise RuntimeError("The message type '%s' is invalid" % message_type)
 
 
 class TopicMessagePrototypeCompleter:

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -230,9 +230,15 @@ class EchoVerb(VerbExtension):
             if args.message_type is None:
                 message_type = get_msg_class(
                     node, args.topic_name, include_hidden_topics=True)
+                print("Debug 1")
+                print(message_type)
+                print(type(message_type))
             else:
+                print("Debug 2")
                 try:
                     message_type = get_message(args.message_type)
+                    print(message_type)
+                    print(type(message_type))
                 except (AttributeError, ModuleNotFoundError, ValueError):
                     raise RuntimeError('The passed message type is invalid')
 

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -230,15 +230,9 @@ class EchoVerb(VerbExtension):
             if args.message_type is None:
                 message_type = get_msg_class(
                     node, args.topic_name, include_hidden_topics=True)
-                print("Debug 1")
-                print(message_type)
-                print(type(message_type))
             else:
-                print("Debug 2")
                 try:
                     message_type = get_message(args.message_type)
-                    print(message_type)
-                    print(type(message_type))
                 except (AttributeError, ModuleNotFoundError, ValueError):
                     raise RuntimeError('The passed message type is invalid')
 


### PR DESCRIPTION
Related to the proposed service introspection REP (https://github.com/ros-infrastructure/rep/pull/360) 

This PR implements the cli for echoing service events. 
`ros2 service echo /name_of_service`

Depends on https://github.com/ros2/rosidl_runtime_py/pull/17 for deserializing bytes type data and echoing contents to the user.

Connects to: https://github.com/ros2/ros2/issues/1285

Signed-off-by: deepanshu <deepanshubansal01@gmail.com>