### PR TITLE
Label galactic flaky modules as `xfail`

### DIFF
--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -31,13 +31,13 @@ import launch_testing.tools
 import launch_testing_ros.tools
 
 import pytest
-# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
-pytestmark = pytest.mark.xfail
-
 import rclpy
 from rclpy.utilities import get_available_rmw_implementations
 
 from ros2cli.node.strategy import NodeStrategy
+
+# Flaky module on Galactic: https://github.com/ros2/ros2cli/issues/630
+pytestmark = pytest.mark.xfail
 
 TEST_NODE = 'test_node'
 TEST_NAMESPACE = '/foo'

--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -31,6 +31,8 @@ import launch_testing.tools
 import launch_testing_ros.tools
 
 import pytest
+# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
+pytestmark = pytest.mark.xfail
 
 import rclpy
 from rclpy.utilities import get_available_rmw_implementations
@@ -116,8 +118,6 @@ def generate_test_description(rmw_implementation):
     ])
 
 
-# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
-@pytest.mark.xfail
 class TestVerbDump(unittest.TestCase):
 
     @classmethod

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -30,13 +30,14 @@ import launch_testing.tools
 import launch_testing_ros.tools
 
 import pytest
-# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
-pytestmark = pytest.mark.xfail
 
 import rclpy
 from rclpy.utilities import get_available_rmw_implementations
 
 from ros2cli.node.strategy import NodeStrategy
+
+# Flaky module on Galactic: https://github.com/ros2/ros2cli/issues/630
+pytestmark = pytest.mark.xfail
 
 TEST_NODE = 'test_node'
 TEST_NAMESPACE = '/foo'

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.#
+# limitations under the License.
 
 import contextlib
 from pathlib import Path

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -30,6 +30,8 @@ import launch_testing.tools
 import launch_testing_ros.tools
 
 import pytest
+# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
+pytestmark = pytest.mark.xfail
 
 import rclpy
 from rclpy.utilities import get_available_rmw_implementations
@@ -85,8 +87,6 @@ def generate_test_description(rmw_implementation):
     ])
 
 
-# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
-@pytest.mark.xfail
 class TestVerbList(unittest.TestCase):
 
     @classmethod

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License.#
 
 import contextlib
 from pathlib import Path

--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -31,6 +31,8 @@ import launch_testing.tools
 import launch_testing_ros.tools
 
 import pytest
+# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
+pytestmark = pytest.mark.xfail
 
 import rclpy
 from rclpy.utilities import get_available_rmw_implementations
@@ -129,8 +131,6 @@ def generate_test_description(rmw_implementation):
     ])
 
 
-# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
-@pytest.mark.xfail
 class TestVerbDump(unittest.TestCase):
 
     @classmethod

--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -31,8 +31,6 @@ import launch_testing.tools
 import launch_testing_ros.tools
 
 import pytest
-# Flaky on Galactic: https://github.com/ros2/ros2cli/issues/630
-pytestmark = pytest.mark.xfail
 
 import rclpy
 from rclpy.utilities import get_available_rmw_implementations
@@ -40,6 +38,9 @@ from rclpy.utilities import get_available_rmw_implementations
 from ros2cli.node.strategy import NodeStrategy
 
 import yaml
+
+# Flaky module on Galactic: https://github.com/ros2/ros2cli/issues/630
+pytestmark = pytest.mark.xfail
 
 TEST_NODE = 'test_node'
 TEST_NAMESPACE = '/foo'


### PR DESCRIPTION
Disabling known to fail tests on Galactic, draft until properly tested.

FYI: @Crola1702  