### PR TITLE
Remove action_msgs dependency

### DIFF
--- a/ros2cli_test_interfaces/package.xml
+++ b/ros2cli_test_interfaces/package.xml
@@ -18,8 +18,6 @@
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <depend>action_msgs</depend>
-
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
It is now properly included in the rosidl dependency chain.

Depends on https://github.com/ros2/rosidl_defaults/pull/22