### PR TITLE
ZSH argcomplete: call compinit only if needed

### DIFF
--- a/ros2cli/completion/ros2-argcomplete.zsh
+++ b/ros2cli/completion/ros2-argcomplete.zsh
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-autoload -U +X compinit && compinit
+if (( ! ${+_comps} )); then
+  autoload -U +X compinit && compinit
+fi
 autoload -U +X bashcompinit && bashcompinit
 
 # Get this scripts directory


### PR DESCRIPTION
Ref #534 