### PR TITLE
Add interface type filters to ros2 interface package

### DIFF
--- a/ros2interface/ros2interface/verb/package.py
+++ b/ros2interface/ros2interface/verb/package.py
@@ -21,16 +21,41 @@ class PackageVerb(VerbExtension):
     """Output a list of available interface types within one package."""
 
     def add_arguments(self, parser, cli_name):
+        parser.add_argument(
+            '-m', '--only-msgs', action='store_true',
+            help='Print out only the message types')
+
+        parser.add_argument(
+            '-s', '--only-srvs', action='store_true',
+            help='Print out only the service types')
+
+        parser.add_argument(
+            '-a', '--only-actions', action='store_true',
+            help='Print out only the action types')
+
         arg = parser.add_argument(
             'package_name',
             help="Name of the ROS package (e.g. 'example_interfaces')")
         arg.completer = package_name_completer
 
     def main(self, *, args):
+        types_to_filter = []
+        if args.only_msgs or args.only_srvs or args.only_actions:
+            if not args.only_msgs:
+                types_to_filter.append('msg')
+            if not args.only_srvs:
+                types_to_filter.append('srv')
+            if not args.only_actions:
+                types_to_filter.append('action')
+
         try:
             interfaces = get_interfaces([args.package_name])
         except LookupError as e:
             return str(e)
         for package_name in sorted(interfaces):
             for interface_name in interfaces[package_name]:
+                if types_to_filter:
+                    interface_type = interface_name[:interface_name.index('/')]
+                    if interface_type in types_to_filter:
+                        continue
                 print(f'{package_name}/{interface_name}')

--- a/ros2interface/ros2interface/verb/package.py
+++ b/ros2interface/ros2interface/verb/package.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import collections
+
 from ros2interface.api import package_name_completer
 from ros2interface.verb import VerbExtension
 from rosidl_runtime_py import get_action_interfaces, get_interfaces

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -200,6 +200,22 @@ class TestROS2InterfaceCLI(unittest.TestCase):
         )
         assert all(interface in output_lines for interface in some_interfaces)
 
+    def test_package_on_test_msgs_only_srvs(self):
+        with self.launch_interface_command(
+            arguments=['package', 'test_msgs', '-s']
+        ) as interface_command:
+            assert interface_command.wait_for_shutdown(timeout=2)
+        assert interface_command.exit_code == launch_testing.asserts.EXIT_OK
+        output_lines = interface_command.output.splitlines()
+        assert launch_testing.tools.expect_output(
+            expected_lines=itertools.repeat(
+                re.compile(r'test_msgs/srv/[A-z0-9_]+'), len(output_lines)
+            ),
+            lines=output_lines,
+            strict=True
+        )
+        assert all(interface in output_lines for interface in some_services_from_test_msgs)
+
     def test_packages(self):
         with self.launch_interface_command(arguments=['packages']) as interface_command:
             assert interface_command.wait_for_shutdown(timeout=2)

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -214,7 +214,7 @@ class TestROS2InterfaceCLI(unittest.TestCase):
             lines=output_lines,
             strict=True
         )
-        assert all(interface in output_lines for interface in some_services_from_test_msgs)
+        assert all(interface in output_lines for interface in some_messages_from_test_msgs)
 
     def test_package_on_test_msgs_only_srvs(self):
         with self.launch_interface_command(
@@ -246,7 +246,7 @@ class TestROS2InterfaceCLI(unittest.TestCase):
             lines=output_lines,
             strict=True
         )
-        assert all(interface in output_lines for interface in some_services_from_test_msgs)
+        assert all(interface in output_lines for interface in some_actions_from_test_msgs)
 
     def test_packages(self):
         with self.launch_interface_command(arguments=['packages']) as interface_command:

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -200,16 +200,48 @@ class TestROS2InterfaceCLI(unittest.TestCase):
         )
         assert all(interface in output_lines for interface in some_interfaces)
 
+    def test_package_on_test_msgs_only_msgs(self):
+        with self.launch_interface_command(
+            arguments=['package', 'test_msgs', '-m']
+        ) as interface_command:
+            assert interface_command.wait_for_shutdown(timeout=5)
+        assert interface_command.exit_code == launch_testing.asserts.EXIT_OK
+        output_lines = interface_command.output.splitlines()
+        assert launch_testing.tools.expect_output(
+            expected_lines=itertools.repeat(
+                re.compile(r'test_msgs/msg/[A-z0-9_]+'), len(output_lines)
+            ),
+            lines=output_lines,
+            strict=True
+        )
+        assert all(interface in output_lines for interface in some_services_from_test_msgs)
+
     def test_package_on_test_msgs_only_srvs(self):
         with self.launch_interface_command(
             arguments=['package', 'test_msgs', '-s']
         ) as interface_command:
-            assert interface_command.wait_for_shutdown(timeout=2)
+            assert interface_command.wait_for_shutdown(timeout=5)
         assert interface_command.exit_code == launch_testing.asserts.EXIT_OK
         output_lines = interface_command.output.splitlines()
         assert launch_testing.tools.expect_output(
             expected_lines=itertools.repeat(
                 re.compile(r'test_msgs/srv/[A-z0-9_]+'), len(output_lines)
+            ),
+            lines=output_lines,
+            strict=True
+        )
+        assert all(interface in output_lines for interface in some_services_from_test_msgs)
+
+    def test_package_on_test_msgs_only_actions(self):
+        with self.launch_interface_command(
+            arguments=['package', 'test_msgs', '-a']
+        ) as interface_command:
+            assert interface_command.wait_for_shutdown(timeout=5)
+        assert interface_command.exit_code == launch_testing.asserts.EXIT_OK
+        output_lines = interface_command.output.splitlines()
+        assert launch_testing.tools.expect_output(
+            expected_lines=itertools.repeat(
+                re.compile(r'test_msgs/action/[A-z0-9_]+'), len(output_lines)
             ),
             lines=output_lines,
             strict=True


### PR DESCRIPTION
Seemed like it was missing. 