### PR TITLE
Add --group and --port options to ros2 multicast

### DIFF
--- a/ros2multicast/ros2multicast/api/__init__.py
+++ b/ros2multicast/ros2multicast/api/__init__.py
@@ -47,6 +47,13 @@ def receive(*, group=DEFAULT_GROUP, port=DEFAULT_PORT, timeout=None):
         s.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
         try:
             data, sender_addr = s.recvfrom(4096)
+        except socket.timeout:
+            if socket.timeout == TimeoutError:
+                # Python >= 3.10
+                raise
+            else:
+                # Python < 3.10
+                raise TimeoutError
         finally:
             s.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP, mreq)
     finally:

--- a/ros2multicast/ros2multicast/verb/__init__.py
+++ b/ros2multicast/ros2multicast/verb/__init__.py
@@ -15,6 +15,30 @@
 from ros2cli.plugin_system import PLUGIN_SYSTEM_VERSION
 from ros2cli.plugin_system import satisfies_version
 
+from ros2multicast.api import DEFAULT_GROUP
+from ros2multicast.api import DEFAULT_PORT
+
+def positive_int(string):
+    try:
+        value = int(string)
+    except ValueError:
+        value = -1
+    if value <= 0:
+        raise ArgumentTypeError('value must be a positive integer')
+    return value
+
+
+def add_group_argument(parser):
+    parser.add_argument(
+        '--group', type=str, default=DEFAULT_GROUP,
+        help='The multicast group address')
+
+
+def add_port_argument(parser):
+    parser.add_argument(
+        '--port', type=positive_int, default=DEFAULT_PORT,
+        help='The multicast port')
+
 
 class VerbExtension:
     """

--- a/ros2multicast/ros2multicast/verb/__init__.py
+++ b/ros2multicast/ros2multicast/verb/__init__.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from argparse import ArgumentTypeError
+
 from ros2cli.plugin_system import PLUGIN_SYSTEM_VERSION
 from ros2cli.plugin_system import satisfies_version
 
 from ros2multicast.api import DEFAULT_GROUP
 from ros2multicast.api import DEFAULT_PORT
+
 
 def positive_int(string):
     try:

--- a/ros2multicast/ros2multicast/verb/receive.py
+++ b/ros2multicast/ros2multicast/verb/receive.py
@@ -13,16 +13,22 @@
 # limitations under the License.
 
 from ros2multicast.api import receive
+from ros2multicast.verb import add_group_argument
+from ros2multicast.verb import add_port_argument
 from ros2multicast.verb import VerbExtension
 
 
 class ReceiveVerb(VerbExtension):
     """Receive a single UDP multicast packet."""
 
+    def add_arguments(self, parser, cli_name):
+        add_group_argument(parser)
+        add_port_argument(parser)
+
     def main(self, *, args):
         print('Waiting for UDP multicast datagram...')
         try:
-            data, (host, port) = receive()
+            data, (host, port) = receive(group=args.group, port=args.port)
         except KeyboardInterrupt:
             pass
         else:

--- a/ros2multicast/ros2multicast/verb/send.py
+++ b/ros2multicast/ros2multicast/verb/send.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
-
 from ros2multicast.api import send
 from ros2multicast.verb import add_group_argument
 from ros2multicast.verb import add_port_argument

--- a/ros2multicast/ros2multicast/verb/send.py
+++ b/ros2multicast/ros2multicast/verb/send.py
@@ -15,27 +15,22 @@
 from argparse import ArgumentTypeError
 
 from ros2multicast.api import send
+from ros2multicast.verb import add_group_argument
+from ros2multicast.verb import add_port_argument
+from ros2multicast.verb import positive_int
 from ros2multicast.verb import VerbExtension
-
-
-def positive_int(string):
-    try:
-        value = int(string)
-    except ValueError:
-        value = -1
-    if value <= 0:
-        raise ArgumentTypeError('value must be a positive integer')
-    return value
 
 
 class SendVerb(VerbExtension):
     """Send a single UDP multicast packet."""
 
     def add_arguments(self, parser, cli_name):
+        add_group_argument(parser)
+        add_port_argument(parser)
         parser.add_argument(
             '--ttl', type=positive_int,
             help='The multicast TTL')
 
     def main(self, *, args):
         print('Sending one UDP multicast datagram...')
-        send(b'Hello World!', ttl=args.ttl)
+        send(b'Hello World!', group=args.group, port=args.port, ttl=args.ttl)

--- a/ros2multicast/test/test_api.py
+++ b/ros2multicast/test/test_api.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 import threading
 import time
 
@@ -19,17 +20,79 @@ from ros2multicast.api import receive
 from ros2multicast.api import send
 
 
-def test_api():
-    sent_data = b'test_api'
+def _send_receive(sent_data, rx_kwargs, tx_kwargs):
     received_data = None
 
     def target():
         nonlocal received_data
-        received_data, _ = receive(timeout=1.0)
+        try:
+            received_data, _ = receive(**rx_kwargs)
+        except TimeoutError:
+            pass
 
     t = threading.Thread(target=target)
     t.start()
     time.sleep(0.1)
-    send(sent_data)
+    send(sent_data, **tx_kwargs)
     t.join()
-    assert sent_data == received_data
+    return received_data
+
+
+def test_api():
+    sent_data = b'test_api'
+
+    rx_kwargs = {'timeout': 1.0}
+    tx_kwargs = {}
+
+    assert sent_data == _send_receive(sent_data, rx_kwargs, tx_kwargs)
+
+
+def test_group_and_port():
+    sent_data = b'test_api'
+
+    r1 = random.randrange(0, 255)
+    r2 = random.randrange(0, 255)
+    r3 = random.randrange(1, 255)
+    port = random.randrange(16000, 18000)
+
+    group = f'234.{r1}.{r2}.{r3}'
+
+    tx_kwargs = {'group': group, 'port': port}
+    rx_kwargs = {'timeout': 1.0}
+    rx_kwargs.update(tx_kwargs)
+
+    assert sent_data == _send_receive(sent_data, rx_kwargs, tx_kwargs)
+
+
+def test_group_mismatch():
+    sent_data = b'test_api'
+
+    r1 = random.randrange(0, 255)
+    r2 = random.randrange(0, 255)
+    r3 = random.randrange(1, 255)
+    port = random.randrange(16000, 18000)
+
+    group1 = f'234.{r1}.{r2}.{r3}'
+    group2 = f'235.{r1}.{r2}.{r3}'
+
+    tx_kwargs = {'group': group1, 'port': port}
+    rx_kwargs = {'group': group2, 'port': port, 'timeout': 1.0}
+
+    assert _send_receive(sent_data, rx_kwargs, tx_kwargs) is None
+
+
+def test_port_mismatch():
+    sent_data = b'test_api'
+
+    r1 = random.randrange(0, 255)
+    r2 = random.randrange(0, 255)
+    r3 = random.randrange(1, 255)
+    port1 = random.randrange(16000, 18000)
+    port2 = port1 + 1
+
+    group = f'234.{r1}.{r2}.{r3}'
+
+    tx_kwargs = {'group': group, 'port': port1}
+    rx_kwargs = {'group': group, 'port': port2, 'timeout': 1.0}
+
+    assert _send_receive(sent_data, rx_kwargs, tx_kwargs) is None


### PR DESCRIPTION
This PR allows specifying `--group` and `--port` to `ros2 multicast`. This is useful when debugging issues with multicast traffic for a specific group and domain id.