### PR TITLE
Extend timeout to shutdown the command line process.

### DIFF
--- a/ros2topic/test/test_use_sim_time.py
+++ b/ros2topic/test/test_use_sim_time.py
@@ -121,7 +121,7 @@ class TestROS2TopicUseSimTime(unittest.TestCase):
                 self.executor.spin_until_future_complete(
                     rclpy.task.Future(), timeout_sec=3
                 )
-                assert command.wait_for_shutdown(timeout=1)
+                assert command.wait_for_shutdown(timeout=5)
             assert launch_testing.tools.expect_output(
                 expected_lines=[
                     'publisher: beginning loop',


### PR DESCRIPTION
  address flaky test: https://github.com/ros2/ros2cli/issues/772

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>