### PR TITLE
Allow configuring liveliness in ros2 topic echo and pub

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 from argparse import ArgumentTypeError
+from argparse import ArgumentParser
 from time import sleep
 from typing import Optional
 
 import rclpy
 
+from rclpy.duration import Duration
 from rclpy.expand_topic_name import expand_topic_name
 from rclpy.topic_or_service_is_hidden import topic_or_service_is_hidden
 from rclpy.validate_full_topic_name import validate_full_topic_name
@@ -158,8 +160,9 @@ class TopicMessagePrototypeCompleter:
 
 
 def profile_configure_short_keys(
-    profile: rclpy.qos.QoSProfile = None, reliability: str = None,
-    durability: str = None, depth: Optional[int] = None, history: str = None,
+    profile: rclpy.qos.QoSProfile = None, reliability: Optional[str] = None,
+    durability: Optional[str] = None, depth: Optional[int] = None, history: Optional[str] = None,
+    liveliness: Optional[str] = None, liveliness_lease_duration_s: Optional[int] = None,
 ) -> rclpy.qos.QoSProfile:
     """Configure a QoSProfile given a profile, and optional overrides."""
     if history:
@@ -168,6 +171,10 @@ def profile_configure_short_keys(
         profile.durability = rclpy.qos.QoSDurabilityPolicy.get_from_short_key(durability)
     if reliability:
         profile.reliability = rclpy.qos.QoSReliabilityPolicy.get_from_short_key(reliability)
+    if liveliness:
+        profile.liveliness = rclpy.qos.QoSLivelinessPolicy.get_from_short_key(liveliness)
+    if liveliness_lease_duration_s and liveliness_lease_duration_s >= 0:
+        profile.liveliness_lease_duration = Duration(seconds=liveliness_lease_duration_s)
     if depth and depth >= 0:
         profile.depth = depth
     else:
@@ -177,11 +184,57 @@ def profile_configure_short_keys(
 
 
 def qos_profile_from_short_keys(
-    preset_profile: str, reliability: str = None, durability: str = None,
-    depth: Optional[int] = None, history: str = None,
+    preset_profile: str, reliability: Optional[str] = None, durability: Optional[str] = None,
+    depth: Optional[int] = None, history: Optional[str] = None, liveliness: Optional[str] = None,
+    liveliness_lease_duration_s: Optional[float] = None,
 ) -> rclpy.qos.QoSProfile:
     """Construct a QoSProfile given the name of a preset, and optional overrides."""
     # Build a QoS profile based on user-supplied arguments
     profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(preset_profile)
-    profile_configure_short_keys(profile, reliability, durability, depth, history)
+    profile_configure_short_keys(
+        profile, reliability, durability, depth, history, liveliness, liveliness_lease_duration_s)
     return profile
+
+
+def add_qos_arguments(parser: ArgumentParser):
+    default_profile_str = 'sensor_data'
+
+    parser.add_argument(
+        '--qos-profile',
+        choices=rclpy.qos.QoSPresetProfiles.short_keys(),
+        help='Quality of service preset profile to subscribe with (default: {})'
+                .format(default_profile_str),
+        default=default_profile_str)
+    default_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(default_profile_str)
+    parser.add_argument(
+        '--qos-depth', metavar='N', type=int,
+        help='Queue size setting to subscribe with '
+                '(overrides depth value of --qos-profile option)')
+    parser.add_argument(
+        '--qos-history',
+        choices=rclpy.qos.QoSHistoryPolicy.short_keys(),
+        help='History of samples setting to subscribe with '
+                '(overrides history value of --qos-profile option, default: {})'
+                .format(default_profile.history.short_key))
+    parser.add_argument(
+        '--qos-reliability',
+        choices=rclpy.qos.QoSReliabilityPolicy.short_keys(),
+        help='Quality of service reliability setting to subscribe with '
+                '(overrides reliability value of --qos-profile option, default: '
+                'Automatically match existing publishers )')
+    parser.add_argument(
+        '--qos-durability',
+        choices=rclpy.qos.QoSDurabilityPolicy.short_keys(),
+        help='Quality of service durability setting to subscribe with '
+                '(overrides durability value of --qos-profile option, default: '
+                'Automatically match existing publishers )')
+    parser.add_argument(
+        '--qos-liveliness',
+        choices=rclpy.qos.QoSLivelinessPolicy.short_keys(),
+        help='Quality of service liveliness setting to subscribe with '
+                '(overrides liveliness value of --qos-profile option')
+    parser.add_argument(
+        '--qos-liveliness-lease-duration-seconds',
+        type=float,
+        help='Quality of service liveliness lease duration setting to subscribe with '
+                '(overrides liveliness lease duration value of --qos-profile option')

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentTypeError
 from argparse import ArgumentParser
+from argparse import ArgumentTypeError
 from time import sleep
 from typing import Optional
 
@@ -196,45 +196,50 @@ def qos_profile_from_short_keys(
     return profile
 
 
-def add_qos_arguments(parser: ArgumentParser):
-    default_profile_str = 'sensor_data'
-
+def add_qos_arguments(parser: ArgumentParser, subscribe_or_publish: str, default_profile_str):
     parser.add_argument(
         '--qos-profile',
         choices=rclpy.qos.QoSPresetProfiles.short_keys(),
-        help='Quality of service preset profile to subscribe with (default: {})'
-                .format(default_profile_str),
+        help=(
+            f'Quality of service preset profile to {subscribe_or_publish} with'
+            f' (default: {default_profile_str})'),
         default=default_profile_str)
     default_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(default_profile_str)
     parser.add_argument(
         '--qos-depth', metavar='N', type=int,
-        help='Queue size setting to subscribe with '
-                '(overrides depth value of --qos-profile option)')
+        help=(
+            f'Queue size setting to {subscribe_or_publish} with '
+            '(overrides depth value of --qos-profile option)'))
     parser.add_argument(
         '--qos-history',
         choices=rclpy.qos.QoSHistoryPolicy.short_keys(),
-        help='History of samples setting to subscribe with '
-                '(overrides history value of --qos-profile option, default: {})'
-                .format(default_profile.history.short_key))
+        help=(
+            f'History of samples setting to {subscribe_or_publish} with '
+            '(overrides history value of --qos-profile option, default: '
+            f'{default_profile.history.short_key})'))
     parser.add_argument(
         '--qos-reliability',
         choices=rclpy.qos.QoSReliabilityPolicy.short_keys(),
-        help='Quality of service reliability setting to subscribe with '
-                '(overrides reliability value of --qos-profile option, default: '
-                'Automatically match existing publishers )')
+        help=(
+            f'Quality of service reliability setting to {subscribe_or_publish} with '
+            '(overrides reliability value of --qos-profile option, default: '
+            'Compatible profile with running endpoints )'))
     parser.add_argument(
         '--qos-durability',
         choices=rclpy.qos.QoSDurabilityPolicy.short_keys(),
-        help='Quality of service durability setting to subscribe with '
-                '(overrides durability value of --qos-profile option, default: '
-                'Automatically match existing publishers )')
+        help=(
+            f'Quality of service durability setting to {subscribe_or_publish} with '
+            '(overrides durability value of --qos-profile option, default: '
+            'Compatible profile with running endpoints )'))
     parser.add_argument(
         '--qos-liveliness',
         choices=rclpy.qos.QoSLivelinessPolicy.short_keys(),
-        help='Quality of service liveliness setting to subscribe with '
-                '(overrides liveliness value of --qos-profile option')
+        help=(
+            f'Quality of service liveliness setting to {subscribe_or_publish} with '
+            '(overrides liveliness value of --qos-profile option'))
     parser.add_argument(
         '--qos-liveliness-lease-duration-seconds',
         type=float,
-        help='Quality of service liveliness lease duration setting to subscribe with '
-                '(overrides liveliness lease duration value of --qos-profile option')
+        help=(
+            f'Quality of service liveliness lease duration setting to {subscribe_or_publish} '
+            'with (overrides liveliness lease duration value of --qos-profile option'))

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -27,6 +27,7 @@ from rclpy.qos_event import UnsupportedEventTypeError
 from rclpy.task import Future
 from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
 from ros2cli.node.strategy import NodeStrategy
+from ros2topic.api import add_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import qos_profile_from_short_keys
 from ros2topic.api import TopicNameCompleter
@@ -40,8 +41,6 @@ import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
 MsgType = TypeVar('MsgType')
-default_profile_str = 'sensor_data'
-
 
 class EchoVerb(VerbExtension):
     """Output messages from a topic."""
@@ -57,34 +56,7 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             'message_type', nargs='?',
             help="Type of the ROS message (e.g. 'std_msgs/msg/String')")
-        parser.add_argument(
-            '--qos-profile',
-            choices=rclpy.qos.QoSPresetProfiles.short_keys(),
-            help='Quality of service preset profile to subscribe with (default: {})'
-                 .format(default_profile_str))
-        default_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(default_profile_str)
-        parser.add_argument(
-            '--qos-depth', metavar='N', type=int,
-            help='Queue size setting to subscribe with '
-                 '(overrides depth value of --qos-profile option)')
-        parser.add_argument(
-            '--qos-history',
-            choices=rclpy.qos.QoSHistoryPolicy.short_keys(),
-            help='History of samples setting to subscribe with '
-                 '(overrides history value of --qos-profile option, default: {})'
-                 .format(default_profile.history.short_key))
-        parser.add_argument(
-            '--qos-reliability',
-            choices=rclpy.qos.QoSReliabilityPolicy.short_keys(),
-            help='Quality of service reliability setting to subscribe with '
-                 '(overrides reliability value of --qos-profile option, default: '
-                 'Automatically match existing publishers )')
-        parser.add_argument(
-            '--qos-durability',
-            choices=rclpy.qos.QoSDurabilityPolicy.short_keys(),
-            help='Quality of service durability setting to subscribe with '
-                 '(overrides durability value of --qos-profile option, default: '
-                 'Automatically match existing publishers )')
+        add_qos_arguments(parser)
         parser.add_argument(
             '--csv', action='store_true',
             help=(
@@ -136,21 +108,23 @@ class EchoVerb(VerbExtension):
 
     def choose_qos(self, node, args):
 
-        if (args.qos_profile is not None or
-                args.qos_reliability is not None or
+        if (args.qos_reliability is not None or
                 args.qos_durability is not None or
                 args.qos_depth is not None or
-                args.qos_history is not None):
+                args.qos_history is not None or
+                args.qos_liveliness is not None or
+                args.qos_liveliness_duration is not None):
 
-            if args.qos_profile is None:
-                args.qos_profile = default_profile_str
-            return qos_profile_from_short_keys(args.qos_profile,
-                                               reliability=args.qos_reliability,
-                                               durability=args.qos_durability,
-                                               depth=args.qos_depth,
-                                               history=args.qos_history)
+            return qos_profile_from_short_keys(
+                args.qos_profile,
+                reliability=args.qos_reliability,
+                durability=args.qos_durability,
+                depth=args.qos_depth,
+                history=args.qos_history,
+                liveliness=args.qos_liveliness,
+                qos_liveliness_duration=args.qos_liveliness_lease_duration_seconds)
 
-        qos_profile = QoSPresetProfiles.get_from_short_key(default_profile_str)
+        qos_profile = QoSPresetProfiles.get_from_short_key(args.qos_profile)
         reliability_reliable_endpoints_count = 0
         durability_transient_local_endpoints_count = 0
 

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -42,6 +42,7 @@ import yaml
 DEFAULT_TRUNCATE_LENGTH = 128
 MsgType = TypeVar('MsgType')
 
+
 class EchoVerb(VerbExtension):
     """Output messages from a topic."""
 
@@ -56,7 +57,7 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             'message_type', nargs='?',
             help="Type of the ROS message (e.g. 'std_msgs/msg/String')")
-        add_qos_arguments(parser)
+        add_qos_arguments(parser, 'subscribe', 'sensor_data')
         parser.add_argument(
             '--csv', action='store_true',
             help=(
@@ -113,7 +114,7 @@ class EchoVerb(VerbExtension):
                 args.qos_depth is not None or
                 args.qos_history is not None or
                 args.qos_liveliness is not None or
-                args.qos_liveliness_duration is not None):
+                args.qos_liveliness_lease_duration_seconds is not None):
 
             return qos_profile_from_short_keys(
                 args.qos_profile,
@@ -122,7 +123,7 @@ class EchoVerb(VerbExtension):
                 depth=args.qos_depth,
                 history=args.qos_history,
                 liveliness=args.qos_liveliness,
-                qos_liveliness_duration=args.qos_liveliness_lease_duration_seconds)
+                liveliness_lease_duration_s=args.qos_liveliness_lease_duration_seconds)
 
         qos_profile = QoSPresetProfiles.get_from_short_key(args.qos_profile)
         reliability_reliable_endpoints_count = 0

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -23,6 +23,7 @@ from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
+from ros2topic.api import add_qos_arguments
 from ros2topic.api import profile_configure_short_keys
 from ros2topic.api import TopicMessagePrototypeCompleter
 from ros2topic.api import TopicNameCompleter
@@ -104,33 +105,7 @@ class PubVerb(VerbExtension):
         parser.add_argument(
             '-n', '--node-name',
             help='Name of the created publishing node')
-        parser.add_argument(
-            '--qos-profile',
-            choices=rclpy.qos.QoSPresetProfiles.short_keys(),
-            help='Quality of service preset profile to publish)')
-        default_profile = get_pub_qos_profile()
-        parser.add_argument(
-            '--qos-depth', metavar='N', type=int, default=-1,
-            help='Queue size setting to publish with '
-                 '(overrides depth value of --qos-profile option)')
-        parser.add_argument(
-            '--qos-history',
-            choices=rclpy.qos.QoSHistoryPolicy.short_keys(),
-            help='History of samples setting to publish with '
-                 '(overrides history value of --qos-profile option, default: {})'
-                 .format(default_profile.history.short_key))
-        parser.add_argument(
-            '--qos-reliability',
-            choices=rclpy.qos.QoSReliabilityPolicy.short_keys(),
-            help='Quality of service reliability setting to publish with '
-                 '(overrides reliability value of --qos-profile option, default: {})'
-                 .format(default_profile.reliability.short_key))
-        parser.add_argument(
-            '--qos-durability',
-            choices=rclpy.qos.QoSDurabilityPolicy.short_keys(),
-            help='Quality of service durability setting to publish with '
-                 '(overrides durability value of --qos-profile option, default: {})'
-                 .format(default_profile.durability.short_key))
+        add_qos_arguments(parser)
         add_direct_node_arguments(parser)
 
     def main(self, *, args):
@@ -145,7 +120,8 @@ def main(args):
         qos_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(qos_profile_name)
     profile_configure_short_keys(
         qos_profile, args.qos_reliability, args.qos_durability,
-        args.qos_depth, args.qos_history)
+        args.qos_depth, args.qos_history, args.qos_liveliness,
+        args.qos_liveliness_lease_duration_seconds)
 
     times = args.times
     if args.once:

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -18,9 +18,7 @@ from typing import TypeVar
 
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSProfile
-from rclpy.qos import QoSReliabilityPolicy
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
@@ -50,13 +48,6 @@ def positive_float(inval):
         # The error message here gets completely swallowed by argparse
         raise ValueError('Value must be positive')
     return ret
-
-
-def get_pub_qos_profile():
-    return QoSProfile(
-        reliability=QoSReliabilityPolicy.RELIABLE,
-        durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
-        depth=1)
 
 
 class PubVerb(VerbExtension):
@@ -105,7 +96,7 @@ class PubVerb(VerbExtension):
         parser.add_argument(
             '-n', '--node-name',
             help='Name of the created publishing node')
-        add_qos_arguments(parser)
+        add_qos_arguments(parser, 'publish', 'default')
         add_direct_node_arguments(parser)
 
     def main(self, *, args):
@@ -113,11 +104,8 @@ class PubVerb(VerbExtension):
 
 
 def main(args):
-    qos_profile = get_pub_qos_profile()
-
     qos_profile_name = args.qos_profile
-    if qos_profile_name:
-        qos_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(qos_profile_name)
+    qos_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(qos_profile_name)
     profile_configure_short_keys(
         qos_profile, args.qos_reliability, args.qos_durability,
         args.qos_depth, args.qos_history, args.qos_liveliness,

--- a/ros2topic/test/test_qos_conversions.py
+++ b/ros2topic/test/test_qos_conversions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.duration import Duration
 
 from ros2topic.api import qos_profile_from_short_keys
 
@@ -20,8 +21,12 @@ from ros2topic.api import qos_profile_from_short_keys
 def test_profile_conversion():
     profile = qos_profile_from_short_keys(
         'sensor_data', reliability='reliable', durability='transient_local',
-        depth=10, history='keep_last')
+        depth=10, history='keep_last', liveliness='manual_by_topic',
+        liveliness_lease_duration_s=10.3)
     assert profile.durability == rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL
     assert profile.reliability == rclpy.qos.QoSReliabilityPolicy.RELIABLE
     assert profile.depth == 10
     assert profile.history == rclpy.qos.QoSHistoryPolicy.KEEP_LAST
+    assert profile.liveliness == rclpy.qos.QoSLivelinessPolicy.MANUAL_BY_TOPIC
+    assert profile.liveliness == rclpy.qos.QoSLivelinessPolicy.MANUAL_BY_TOPIC
+    assert profile.liveliness_lease_duration == Duration(seconds=10.3)

--- a/ros2topic/test/test_qos_conversions.py
+++ b/ros2topic/test/test_qos_conversions.py
@@ -28,5 +28,4 @@ def test_profile_conversion():
     assert profile.depth == 10
     assert profile.history == rclpy.qos.QoSHistoryPolicy.KEEP_LAST
     assert profile.liveliness == rclpy.qos.QoSLivelinessPolicy.MANUAL_BY_TOPIC
-    assert profile.liveliness == rclpy.qos.QoSLivelinessPolicy.MANUAL_BY_TOPIC
     assert profile.liveliness_lease_duration == Duration(seconds=10.3)


### PR DESCRIPTION
For a subscription to have manual_by_topic liveliness, it means that it requires publishers to provide manual_by_topic liveliness (i.e. if not it won't match).
When a publisher uses manual_by_topic liveliness, liveliness is asserted when either a message is published or is asserted manually.
`ros2 topic pub` will only assert liveliness through publishing messages, and never manually.
Though this is not more useful than automatic liveliness, it's useful for testing. e.g. you have a subscription requiring manual_by_topic liveliness and you want `ros2 topic pub` to match it.

Also, deduplicated some code.