### PR TITLE
Refactor common types

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -38,6 +38,21 @@ def unsigned_int(string):
         raise ArgumentTypeError('value must be non-negative integer')
     return value
 
+def positive_int(string):
+    try:
+        value = int(string)
+    except ValueError:
+        value = -1
+    if value <= 0:
+        raise ArgumentTypeError('value must be a positive integer')
+    return value
+
+def positive_float(inval):
+    ret = float(inval)
+    if ret <= 0.0:
+        # The error message here gets completely swallowed by argparse
+        raise ValueError('Value must be positive')
+    return ret
 
 def get_topic_names_and_types(*, node, include_hidden_topics=False):
     topic_names_and_types = node.get_topic_names_and_types()

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -38,6 +38,7 @@ def unsigned_int(string):
         raise ArgumentTypeError('value must be non-negative integer')
     return value
 
+
 def positive_int(string):
     try:
         value = int(string)
@@ -47,12 +48,14 @@ def positive_int(string):
         raise ArgumentTypeError('value must be a positive integer')
     return value
 
+
 def positive_float(inval):
     ret = float(inval)
     if ret <= 0.0:
         # The error message here gets completely swallowed by argparse
-        raise ValueError('Value must be positive')
+        raise ArgumentTypeError('Value must be positive')
     return ret
+
 
 def get_topic_names_and_types(*, node, include_hidden_topics=False):
     topic_names_and_types = node.get_topic_names_and_types()

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -39,20 +39,11 @@ from rclpy.qos import qos_profile_sensor_data
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_msg_class
+from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
 DEFAULT_WINDOW_SIZE = 100
-
-
-def positive_int(string):
-    try:
-        value = int(string)
-    except ValueError:
-        value = -1
-    if value <= 0:
-        raise ArgumentTypeError('value must be a positive integer')
-    return value
 
 
 def str_bytes(num_bytes):

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -29,7 +29,6 @@
 # This file is originally from:
 # https://github.com/ros/ros_comm/blob/6e5016f4b2266d8a60c9a1e163c4928b8fc7115e/tools/rostopic/src/rostopic/__init__.py
 
-from argparse import ArgumentTypeError
 import sys
 import threading
 import traceback

--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -39,21 +39,11 @@ from rclpy.time import Time
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_msg_class
+from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
 DEFAULT_WINDOW_SIZE = 10000
-
-
-def positive_int(string):
-    try:
-        value = int(string)
-    except ValueError:
-        value = -1
-    if value <= 0:
-        raise ArgumentTypeError('value must be a positive integer')
-    return value
-
 
 class DelayVerb(VerbExtension):
     """Display delay of topic from timestamp in header."""

--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -29,7 +29,6 @@
 # This file is originally from:
 # https://github.com/ros/ros_comm/blob/6e5016f4b2266d8a60c9a1e163c4928b8fc7115e/tools/rostopic/src/rostopic/__init__.py
 
-from argparse import ArgumentTypeError
 import math
 
 import rclpy
@@ -44,6 +43,7 @@ from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
 DEFAULT_WINDOW_SIZE = 10000
+
 
 class DelayVerb(VerbExtension):
     """Display delay of topic from timestamp in header."""

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -29,7 +29,6 @@
 # This file is originally from:
 # https://github.com/ros/ros_comm/blob/6e5016f4b2266d8a60c9a1e163c4928b8fc7115e/tools/rostopic/src/rostopic/__init__.py
 
-from argparse import ArgumentTypeError
 from collections import defaultdict
 
 import functools
@@ -49,6 +48,7 @@ from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
 DEFAULT_WINDOW_SIZE = 10000
+
 
 class HzVerb(VerbExtension):
     """Print the average publishing rate to screen."""

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -44,21 +44,11 @@ from rclpy.qos import qos_profile_sensor_data
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import get_msg_class
+from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
 DEFAULT_WINDOW_SIZE = 10000
-
-
-def positive_int(string):
-    try:
-        value = int(string)
-    except ValueError:
-        value = -1
-    if value <= 0:
-        raise ArgumentTypeError('value must be a positive integer')
-    return value
-
 
 class HzVerb(VerbExtension):
     """Print the average publishing rate to screen."""

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -22,6 +22,7 @@ from rclpy.qos import QoSProfile
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
+from ros2topic.api import positive_float
 from ros2topic.api import profile_configure_short_keys
 from ros2topic.api import TopicMessagePrototypeCompleter
 from ros2topic.api import TopicNameCompleter
@@ -39,14 +40,6 @@ def nonnegative_int(inval):
     if ret < 0:
         # The error message here gets completely swallowed by argparse
         raise ValueError('Value must be positive or zero')
-    return ret
-
-
-def positive_float(inval):
-    ret = float(inval)
-    if ret <= 0.0:
-        # The error message here gets completely swallowed by argparse
-        raise ValueError('Value must be positive')
     return ret
 
 


### PR DESCRIPTION
A lot of types across verbs in ros2 topic are shared. This PR refactors the types to be used by different verbs preventing redefinition of the same types in different verbs. There is no behaviour changed introduced.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>