### PR TITLE
Adds a `--max-wait-time` option to `ros2 topic pub` 

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -105,7 +105,8 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             '--once', action='store_true', help='Print the first message received and then exit.')
         parser.add_argument(
-            '--timeout', metavar='N', type=positive_float, help='Set a timeout in seconds for waiting', default=None)
+            '--timeout', metavar='N', type=positive_float,
+            help='Set a timeout in seconds for waiting', default=None)
         parser.add_argument(
             '--include-message-info', '-i', action='store_true',
             help='Shows the associated message info.')

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -156,7 +156,7 @@ def publisher(
     pub = node.create_publisher(msg_module, topic_name, qos_profile)
 
     if wait_matching_subscriptions == 0 and max_wait_time is not None:
-        return '--max-wait-time-secs option is only effective' +
+        return '--max-wait-time-secs option is only effective' \
             ' with --wait-matching-subscriptions, --once or --times'
 
     times_since_last_log = 0

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -154,7 +154,7 @@ def publisher(
 
     pub = node.create_publisher(msg_module, topic_name, qos_profile)
 
-    if wait_matching_subscriptions is None and max_wait_time is not None:
+    if wait_matching_subscriptions == 0 and max_wait_time is not None:
         return '--max-wait-time-secs option is only effective with --wait-matching-subscriptions, --once or --times'
 
     times_since_last_log = 0

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -167,7 +167,7 @@ def publisher(
             print(
                 f'Waiting for at least {wait_matching_subscriptions} matching subscription(s)...')
         if max_wait_time is not None and max_wait_time <= total_wait_time:
-            return f'Timed out waiting for subscribers: Expected {wait_matching_subscriptions}' +
+            return f'Timed out waiting for subscribers: Expected {wait_matching_subscriptions}' \
                 f' subcribers but only got {pub.get_subscription_count()} subscribers'
         times_since_last_log = (times_since_last_log + 1) % 10
         time.sleep(DEFAULT_WAIT_TIME)

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -86,7 +86,8 @@ class PubVerb(VerbExtension):
         parser.add_argument(
             '--max-wait-time-secs', type=positive_float, default=None,
             help=(
-                'This sets the maximum wait time in seconds if --wait-until-matching-subscriptions is set.'
+                'This sets the maximum wait time in seconds if '
+                '--wait-until-matching-subscriptions is set. '
                 'By default, this flag is not set meaning the subscriber will wait endlessly.'))
         parser.add_argument(
             '--keep-alive', metavar='N', type=positive_float, default=0.1,
@@ -155,7 +156,8 @@ def publisher(
     pub = node.create_publisher(msg_module, topic_name, qos_profile)
 
     if wait_matching_subscriptions == 0 and max_wait_time is not None:
-        return '--max-wait-time-secs option is only effective with --wait-matching-subscriptions, --once or --times'
+        return '--max-wait-time-secs option is only effective' +
+            ' with --wait-matching-subscriptions, --once or --times'
 
     times_since_last_log = 0
     total_wait_time = 0
@@ -165,11 +167,12 @@ def publisher(
             print(
                 f'Waiting for at least {wait_matching_subscriptions} matching subscription(s)...')
         if max_wait_time is not None and max_wait_time <= total_wait_time:
-            return f'Timed out waiting for subscribers: Expected {wait_matching_subscriptions} subcribers but only got {pub.get_subscription_count()} subscribers'       
+            return f'Timed out waiting for subscribers: Expected {wait_matching_subscriptions}' +
+                f' subcribers but only got {pub.get_subscription_count()} subscribers'
         times_since_last_log = (times_since_last_log + 1) % 10
         time.sleep(DEFAULT_WAIT_TIME)
         total_wait_time += DEFAULT_WAIT_TIME
-        
+
     msg = msg_module()
     try:
         timestamp_fields = set_message_fields(

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -114,9 +114,6 @@ def main(args):
     if args.once:
         times = 1
 
-    if args.wait_matching_subscriptions is None and args.max_wait_time_secs is not None:
-        return '--max-wait-time-secs option is only effective with --wait-matching-subscriptions'
-
     with DirectNode(args, node_name=args.node_name) as node:
         return publisher(
             node.node,
@@ -156,6 +153,9 @@ def publisher(
         return 'The passed value needs to be a dictionary in YAML format'
 
     pub = node.create_publisher(msg_module, topic_name, qos_profile)
+
+    if wait_matching_subscriptions is None and max_wait_time is not None:
+        return '--max-wait-time-secs option is only effective with --wait-matching-subscriptions, --once or --times'
 
     times_since_last_log = 0
     total_wait_time = 0

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -159,13 +159,13 @@ def publisher(
         if not times_since_last_log:
             print(
                 f'Waiting for at least {wait_matching_subscriptions} matching subscription(s)...')
+        if max_wait_time is not None and max_wait_time < total_wait_time:
+            return 'Timed out waiting for subscribers'       
         times_since_last_log = (times_since_last_log + 1) % 10
         WAIT_TIME = 0.1
-        total_wait_time += WAIT_TIME
-        if max_wait_time is not None and max_wait_time < total_wait_time:
-            return 'Timed out waiting for subscribers'
         time.sleep(WAIT_TIME)
-
+        total_wait_time += WAIT_TIME
+        
     msg = msg_module()
     try:
         timestamp_fields = set_message_fields(

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -159,7 +159,7 @@ def publisher(
         if not times_since_last_log:
             print(
                 f'Waiting for at least {wait_matching_subscriptions} matching subscription(s)...')
-        if max_wait_time is not None and max_wait_time < total_wait_time:
+        if max_wait_time is not None and max_wait_time <= total_wait_time:
             return 'Timed out waiting for subscribers'       
         times_since_last_log = (times_since_last_log + 1) % 10
         WAIT_TIME = 0.1

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -223,7 +223,8 @@ class TestROS2TopicEchoPub(unittest.TestCase):
             assert command.wait_for_shutdown(timeout=5)
         assert launch_testing.tools.expect_output(
             expected_lines=[
-                '--max-wait-time-secs option is only effective with --wait-matching-subscriptions, --once or --times'
+                '--max-wait-time-secs option is only effective with'
+                ' --wait-matching-subscriptions, --once or --times'
             ],
             text=command.output,
             strict=True)

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -240,12 +240,8 @@ class TestROS2TopicEchoPub(unittest.TestCase):
         )
 
         future = rclpy.task.Future()
-        received_message_count = 0
-
         def message_callback(msg):
             """If we receive one message, the test has succeeded."""
-            nonlocal received_message_count
-            received_message_count += 1
             future.set_result(True)
 
         self.node.create_subscription(String, topic, message_callback, 1)
@@ -256,8 +252,8 @@ class TestROS2TopicEchoPub(unittest.TestCase):
             )
         ) as command:
             self.executor.spin_until_future_complete(future, timeout_sec=10)
+            assert future.done()
             assert command.wait_for_shutdown(timeout=20)
-        assert received_message_count == 1
 
     @launch_testing.markers.retry_on_failure(times=5)
     def test_pub_times(self, launch_service, proc_info, proc_output):

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -534,4 +534,4 @@ class TestROS2TopicEchoPub(unittest.TestCase):
         ) as command:
             # wait for command to shutdown on its own
             assert command.wait_for_shutdown(timeout=5)
-            assert command.output == ""
+            assert command.output == ''

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -176,12 +176,12 @@ class TestROS2TopicEchoPub(unittest.TestCase):
                 finally:
                     # Cleanup
                     self.node.destroy_subscription(subscription)
-    
+
     @launch_testing.markers.retry_on_failure(times=5)
     def test_pub_maxwait_no_subscribers(self, launch_service, proc_info, proc_output):
         command_action = ExecuteProcess(
-            cmd=(['ros2', 'topic', 'pub', '-t', '5', '--max-wait-time-secs', '1', '/clitest/topic/pub_times',
-                  'std_msgs/String', 'data: hello']),
+            cmd=(['ros2', 'topic', 'pub', '-t', '5', '--max-wait-time-secs',
+                  '1', '/clitest/topic/pub_times', 'std_msgs/String', 'data: hello']),
             additional_env={
                 'PYTHONUNBUFFERED': '1'
             },
@@ -198,7 +198,8 @@ class TestROS2TopicEchoPub(unittest.TestCase):
             expected_lines=[
                 'Waiting for at least 1 matching subscription(s)...',
                 'Waiting for at least 1 matching subscription(s)...',
-                'Timed out waiting for subscribers: Expected 1 subcribers but only got 0 subscribers'
+                'Timed out waiting for subscribers: Expected'
+                ' 1 subcribers but only got 0 subscribers'
             ],
             text=command.output,
             strict=True)
@@ -206,8 +207,8 @@ class TestROS2TopicEchoPub(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_pub_maxwait_malformed_arguments(self, launch_service, proc_info, proc_output):
         command_action = ExecuteProcess(
-            cmd=(['ros2', 'topic', 'pub', '--max-wait-time-secs', '1', '/clitest/topic/pub_times',
-                  'std_msgs/String', 'data: hello']),
+            cmd=(['ros2', 'topic', 'pub', '--max-wait-time-secs', '1',
+                  '/clitest/topic/pub_times', 'std_msgs/String', 'data: hello']),
             additional_env={
                 'PYTHONUNBUFFERED': '1'
             },
@@ -240,6 +241,7 @@ class TestROS2TopicEchoPub(unittest.TestCase):
         )
 
         future = rclpy.task.Future()
+
         def message_callback(msg):
             """If we receive one message, the test has succeeded."""
             future.set_result(True)

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -180,7 +180,7 @@ class TestROS2TopicEchoPub(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_pub_basic(self, launch_service, proc_info, proc_output):
         command_action = ExecuteProcess(
-            cmd=(['ros2', 'topic', 'pub', '-t', '5', '--max-wait-time', 1, '/clitest/topic/pub_times',
+            cmd=(['ros2', 'topic', 'pub', '-t', '5', '--max-wait-time', '1', '/clitest/topic/pub_times',
                   'std_msgs/String', 'data: hello']),
             additional_env={
                 'PYTHONUNBUFFERED': '1'
@@ -193,7 +193,7 @@ class TestROS2TopicEchoPub(unittest.TestCase):
                 filtered_rmw_implementation=get_rmw_implementation_identifier()
             )
         ) as command:
-            assert command.wait_for_shutdown(timeout=10)
+            assert command.wait_for_shutdown(timeout=2)
         assert launch_testing.tools.expect_output(
             expected_lines=[
                 'Waiting for at least 1 matching subscription(s)...',

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -257,7 +257,7 @@ class TestROS2TopicEchoPub(unittest.TestCase):
         ) as command:
             self.executor.spin_until_future_complete(future, timeout_sec=10)
             assert command.wait_for_shutdown(timeout=20)
-        assert self.recv_msg_count == 1
+        assert received_message_count == 1
 
     @launch_testing.markers.retry_on_failure(times=5)
     def test_pub_times(self, launch_service, proc_info, proc_output):

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -180,7 +180,7 @@ class TestROS2TopicEchoPub(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5)
     def test_pub_basic(self, launch_service, proc_info, proc_output):
         command_action = ExecuteProcess(
-            cmd=(['ros2', 'topic', 'pub', '-t', '5', '--max-wait-time', '1', '/clitest/topic/pub_times',
+            cmd=(['ros2', 'topic', 'pub', '-t', '5', '--max-wait-time-secs', '1', '/clitest/topic/pub_times',
                   'std_msgs/String', 'data: hello']),
             additional_env={
                 'PYTHONUNBUFFERED': '1'
@@ -193,12 +193,12 @@ class TestROS2TopicEchoPub(unittest.TestCase):
                 filtered_rmw_implementation=get_rmw_implementation_identifier()
             )
         ) as command:
-            assert command.wait_for_shutdown(timeout=2)
+            assert command.wait_for_shutdown(timeout=5)
         assert launch_testing.tools.expect_output(
             expected_lines=[
                 'Waiting for at least 1 matching subscription(s)...',
                 'Waiting for at least 1 matching subscription(s)...'
-                'Timed out waiting for subscribers'
+                'Timed out waiting for subscribers: Expected 1 subcribers but only got 0 subscribers'
             ],
             text=command.output,
             strict=True)


### PR DESCRIPTION
Supercedes #797

When we run `ros2 topic pub -w 1 ...` we can wait for a fixed number
of connections prior to shutting down. This is useful in many scenarios,
however when writing automated tests it may be useful to time out if the
correct number of connections are not recieved in a given amount of
time. This PR adds a `--max-wait-time` option which allows users to set
a timeout on how long to wait for subscribers.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>