### PR TITLE
Fix printing of integer and double arrays.

### DIFF
--- a/ros2param/ros2param/verb/get.py
+++ b/ros2param/ros2param/verb/get.py
@@ -85,10 +85,10 @@ class GetVerb(VerbExtension):
                 value = pvalue.bool_array_value
             elif pvalue.type == ParameterType.PARAMETER_INTEGER_ARRAY:
                 label = 'Integer values are:'
-                value = pvalue.integer_array_value
+                value = pvalue.integer_array_value.tolist()
             elif pvalue.type == ParameterType.PARAMETER_DOUBLE_ARRAY:
                 label = 'Double values are:'
-                value = pvalue.double_array_value
+                value = pvalue.double_array_value.tolist()
             elif pvalue.type == ParameterType.PARAMETER_STRING_ARRAY:
                 label = 'String values are:'
                 value = pvalue.string_array_value

--- a/ros2param/ros2param/verb/set.py
+++ b/ros2param/ros2param/verb/set.py
@@ -57,7 +57,7 @@ class SetVerb(VerbExtension):
 
         with DirectNode(args) as node:
             parameter = Parameter()
-            Parameter.name = args.parameter_name
+            parameter.name = args.parameter_name
             parameter.value = get_parameter_value(string_value=args.value)
 
             response = call_set_parameters(


### PR DESCRIPTION
In the ros2param code, we get integer and double arrays as literal Python arrays.  When printing that out in ros2 param get, they look something like:

Double values are: array('d', [1.4, 1.5])

But that isn't really what we want the user to see.  So call .tolist() on these before we print, so it looks like:

Double values are: [1.4, 1.5]

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>