### PR TITLE
Fix some flake8 warnings related to style.

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -105,7 +105,8 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             '--once', action='store_true', help='Print the first message received and then exit.')
         parser.add_argument(
-            '--timeout', metavar='N', type=positive_float, help='Set a timeout in seconds for waiting', default=None)
+            '--timeout', metavar='N', type=positive_float,
+            help='Set a timeout in seconds for waiting', default=None)
         parser.add_argument(
             '--include-message-info', '-i', action='store_true',
             help='Shows the associated message info.')

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -453,4 +453,4 @@ class TestROS2TopicEchoPub(unittest.TestCase):
         ) as command:
             # wait for command to shutdown on its own
             assert command.wait_for_shutdown(timeout=5)
-            assert command.output == ""
+            assert command.output == ''


### PR DESCRIPTION
These were missed in a previous code review; fix them here.

Signed-off-by: Chris Lalancette <clalancette@gmail.com>

In particular, these problems were added in #792.  The issues were not caught in CI due to a bug in colcon (which has subsequently been fixed).  @arjo129 FYI.