### PR TITLE
Fix linters for `helpers.py` and `ros2node/api/__init__.py`

### DIFF
--- a/ros2cli/ros2cli/helpers.py
+++ b/ros2cli/ros2cli/helpers.py
@@ -43,6 +43,7 @@ def wait_for(predicate, timeout, period=0.1):
         time.sleep(period)
     return True
 
+
 def bind(func, *args, **kwargs):
     """
     Bind a function with a set of arguments.

--- a/ros2node/ros2node/api/__init__.py
+++ b/ros2node/ros2node/api/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-
 from collections import namedtuple
 from typing import Any
 from typing import List


### PR DESCRIPTION
Linux debug CI shows test regressions with test_flake8:

Reference build: [Linux Debug #2589](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/2589/)

[ros2cli.ros2cli.test.test_flake8.test_flake8](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/2589/testReport/junit/ros2cli.ros2cli.test/test_flake8/test_flake8/)
<details>

```
test/test_flake8.py:23: in test_flake8
    assert rc == 0, \
E   AssertionError: Found 1 code style errors / warnings:
E     ./ros2cli/helpers.py:46:1: E302 expected 2 blank lines, found 1
E   assert 1 == 0
```

</details>


[ros2node.ros2node.test.test_flake8.test_flake8](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/2589/testReport/ros2node.ros2node.test/test_flake8/test_flake8/) 
<details>

```
test/test_flake8.py:23: in test_flake8
    assert rc == 0, \
E   AssertionError: Found 2 code style errors / warnings:
E     ./ros2node/api/__init__.py:15:1: F401 'time' imported but unused
E     ./ros2node/api/__init__.py:17:1: I100 Import statements are in the wrong order. 'from collections import namedtuple' should be before 'import time'
E   assert 1 == 0
```

</details>