### PR TITLE
Enable document generation using rosdoc2

### DIFF
--- a/ros2cli/ros2cli/node/__init__.py
+++ b/ros2cli/ros2cli/node/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from rclpy.node import HIDDEN_NODE_PREFIX
-NODE_NAME_PREFIX = HIDDEN_NODE_PREFIX + 'ros2cli'
+NODE_NAME_PREFIX = str(HIDDEN_NODE_PREFIX) + 'ros2cli'

--- a/ros2component/ros2component/api/__init__.py
+++ b/ros2component/ros2component/api/__init__.py
@@ -75,8 +75,8 @@ def get_components_in_container(*, node, remote_container_node_name):
     :param node: an `rclpy.Node` instance.
     :param remote_container_node_names: of the container node to inspect.
     :return: a tuple with either a truthy boolean and a list of `ComponentInfo`
-    instances containing the unique id and name of each component or a falsy
-    boolean and a reason string in case of error.
+        instances containing the unique id and name of each component or a falsy
+        boolean and a reason string in case of error.
     """
     return get_components_in_containers(
         node=node, remote_containers_node_names=[remote_container_node_name]
@@ -92,8 +92,8 @@ def get_components_in_containers(*, node, remote_containers_node_names):
     :param node: an `rclpy.Node` instance.
     :param remote_container_node_names: of the container nodes to inspect.
     :return: a dict of tuples, with either a truthy boolean and a list of `ComponentInfo`
-    instances containing the unique id and name of each component or a falsy boolean and
-    a reason string in case of error, per container node.
+        instances containing the unique id and name of each component or a falsy boolean and
+        a reason string in case of error, per container node.
     """
     def list_components(node, remote_container_node_name):
         list_nodes_client = node.create_client(

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -24,6 +24,7 @@
   <exec_depend>python3-rosdistro-modules</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros_environment</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2interface/package.xml
+++ b/ros2interface/package.xml
@@ -21,6 +21,7 @@
   <depend>ros2cli</depend>
 
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rosidl_adapter</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2node/package.xml
+++ b/ros2node/package.xml
@@ -19,6 +19,8 @@
 
   <depend>ros2cli</depend>
 
+  <exec_depend>rclpy</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
Fix missing `exec_depends` in `package.xmls` and docstrings to generate documentation without any warnings using `autodoc`

> Note: Without explictly casting `HIDDEN_NODE_PREFIX` to `str`, `autodoc` will throw an error as it cannot infer the type of this variable since dep modules are not imported.