### PR TITLE
Fix the type annotation in pub.py.

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -140,7 +140,7 @@ def publisher(
     print_nth: int,
     times: int,
     wait_matching_subscriptions: int,
-    max_wait_time: float | None,
+    max_wait_time: Optional[float],
     qos_profile: QoSProfile,
     keep_alive: float,
 ) -> Optional[str]:


### PR DESCRIPTION
In particular, Python 3.11 on RHEL-9 doesn't seem to like the pipe syntax for an optional argument.  But we have the Optional marking available from typing, so switch to that instead.