### PR TITLE
Add marshalling functions for rclpy.type_hash.TypeHash (rep2011)

### DIFF
--- a/ros2cli/ros2cli/xmlrpc/marshal/rclpy.py
+++ b/ros2cli/ros2cli/xmlrpc/marshal/rclpy.py
@@ -19,6 +19,7 @@ from xmlrpc.client import Unmarshaller
 import rclpy.duration
 import rclpy.qos
 import rclpy.topic_endpoint_info
+import rclpy.type_hash
 
 from .generic import dump_any_enum
 from .generic import dump_any_with_slots
@@ -75,3 +76,16 @@ Unmarshaller.dispatch[fullname(rclpy.topic_endpoint_info.TopicEndpointTypeEnum)]
     functools.partial(end_any_enum, enum_=rclpy.topic_endpoint_info.TopicEndpointTypeEnum)
 
 Marshaller.dispatch[rclpy.topic_endpoint_info.TopicEndpointTypeEnum] = dump_any_enum
+
+
+def end_type_hash(unmarshaller, data):
+    values = unmarshaller._stack[-1]
+    unmarshaller._stack[-1] = rclpy.type_hash.TypeHash(
+        version=int(values['version']), value=values['value'].data)
+    unmarshaller._value = 0
+
+
+Unmarshaller.dispatch[fullname(rclpy.type_hash.TypeHash)] = end_type_hash
+
+Marshaller.dispatch[rclpy.type_hash.TypeHash] = \
+    functools.partial(dump_any_with_slots, transform=lambda slot: slot.lstrip('_'))

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -32,7 +32,8 @@ class InfoVerb(VerbExtension):
             '-v',
             action='store_true',
             help='Prints detailed information like the node name, node namespace, topic type, '
-                 'GUID and QoS Profile of the publishers and subscribers to this topic')
+                 'topic type hash, GUID and QoS Profile of the publishers and subscribers to '
+                 'this topic')
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')
 

--- a/ros2topic/ros2topic/verb/info.py
+++ b/ros2topic/ros2topic/verb/info.py
@@ -32,7 +32,7 @@ class InfoVerb(VerbExtension):
             '-v',
             action='store_true',
             help='Prints detailed information like the node name, node namespace, topic type, '
-                 'topic type hash, GUID and QoS Profile of the publishers and subscribers to '
+                 'topic type hash, GUID, and QoS Profile of the publishers and subscribers to '
                  'this topic')
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -305,6 +305,10 @@ class TestROS2TopicCLI(unittest.TestCase):
 
     @launch_testing.markers.retry_on_failure(times=5)
     def test_topic_endpoint_info_verbose(self):
+        # Hash value below can be found in std_msgs/msg/String.json
+        STD_MSGS_STRING_TYPE_HASH_STR = 'RIHS01_' \
+            'df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18'
+
         with self.launch_topic_command(arguments=['info', '-v', '/chatter']) as topic_command:
             assert topic_command.wait_for_shutdown(timeout=10)
         assert topic_command.exit_code == launch_testing.asserts.EXIT_OK
@@ -317,7 +321,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 re.compile(r'Node name: \w+'),
                 'Node namespace: /',
                 'Topic type: std_msgs/msg/String',
-                'Topic type hash: UNKNOWN',
+                f'Topic type hash: {STD_MSGS_STRING_TYPE_HASH_STR}',
                 re.compile(r'Endpoint type: (INVALID|PUBLISHER|SUBSCRIPTION)'),
                 re.compile(r'GID: [\w\.]+'),
                 'QoS profile:',


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1159

Depends on https://github.com/ros2/rclpy/pull/1104

Features
- Adds marshalling functions for `rclpy.type_hash.TypeHash`
- Adapt comment that type hash is also printed when doing `rostopic info --verbose`