### PR TITLE
feat(echo --clear): add --clear option to echo

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import platform
-
 from typing import Optional
 from typing import TypeVar
 
@@ -336,7 +333,4 @@ def _message_lost_event_callback(message_lost_status):
 
 
 def clear_terminal():
-    if platform.system() == 'Windows':
-        os.system('cls')
-    else:
-        os.system('clear')
+    print('\x1b[H\x1b[2J')

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -406,6 +406,17 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.wait_for_shutdown(timeout=10)
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_clear(self):
+        with self.launch_topic_command(arguments=['echo', '--clear', '/chatter']) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    re.compile(r".*data: 'Hello World: \d+'"),
+                    '---'
+                ], strict=True
+            ), timeout=10), 'Output does not match: ' + topic_command.output
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_no_str_topic_echo(self):
         with self.launch_topic_command(
             arguments=['echo', '--no-str', '/chatter']
@@ -876,17 +887,6 @@ class TestROS2TopicCLI(unittest.TestCase):
                     'Subscribed to [/defaults]',
                     re.compile(r'\d{2} B/s from \d+ messages'),
                     re.compile(r'\s*Message size mean: \d{2} B min: \d{2} B max: \d{2} B')
-                ], strict=True
-            ), timeout=10)
-        assert topic_command.wait_for_shutdown(timeout=10)
-
-    @launch_testing.markers.retry_on_failure(times=5, delay=1)
-    def test_topic_clear(self):
-        with self.launch_topic_command(arguments=['echo', '--clear', '/chatter']) as topic_command:
-            assert topic_command.wait_for_output(functools.partial(
-                launch_testing.tools.expect_output, expected_lines=[
-                    re.compile(r"\033\[2J\033\[Hdata: 'Hello World: \d+'"),
-                    '---'
                 ], strict=True
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -406,17 +406,6 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.wait_for_shutdown(timeout=10)
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
-    def test_topic_echo_clear(self):
-        with self.launch_topic_command(arguments=['echo', '--clear', '/chatter']) as topic_command:
-            assert topic_command.wait_for_output(functools.partial(
-                launch_testing.tools.expect_output, expected_lines=[
-                    re.compile(r".*data: 'Hello World: \d+'"),
-                    '---'
-                ], strict=True
-            ), timeout=10), 'Output does not match: ' + topic_command.output
-        assert topic_command.wait_for_shutdown(timeout=10)
-
-    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_no_str_topic_echo(self):
         with self.launch_topic_command(
             arguments=['echo', '--no-str', '/chatter']

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -879,3 +879,14 @@ class TestROS2TopicCLI(unittest.TestCase):
                 ], strict=True
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_clear(self):
+        with self.launch_topic_command(arguments=['echo', '--clear', '/chatter']) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    re.compile(r"\033\[2J\033\[Hdata: 'Hello World: \d+'"),
+                    '---'
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)


### PR DESCRIPTION
Adds the `--clear/-c` option to echo.

Solves this issue: https://github.com/ros2/ros2cli/issues/725

This was previously available in ROS.

This clears the screen before a new message is displayed.

`ESC[2J` corresponds to `erase entire screen`
`ESC[H` corresponds to `moves cursor to home position (0, 0)`

I had to build rolling from source to successfully run the tests