### PR TITLE
Expect type hash cli output in test

### DIFF
--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -317,6 +317,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 re.compile(r'Node name: \w+'),
                 'Node namespace: /',
                 'Topic type: std_msgs/msg/String',
+                'Topic type hash: UNKNOWN',
                 re.compile(r'Endpoint type: (INVALID|PUBLISHER|SUBSCRIPTION)'),
                 re.compile(r'GID: [\w\.]+'),
                 'QoS profile:',


### PR DESCRIPTION
Fixes tests with ros2/rclpy#1110