### PR TITLE
Make all of the dependencies in pure Python packages exec_depend.

### DIFF
--- a/ros2action/package.xml
+++ b/ros2action/package.xml
@@ -17,11 +17,10 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>rclpy</depend>
-  <depend>ros2cli</depend>
-
   <exec_depend>action_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -15,14 +15,13 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>ros2cli</depend>
-
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-psutil</exec_depend>
   <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-rosdistro-modules</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
   <exec_depend>ros_environment</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 

--- a/ros2interface/package.xml
+++ b/ros2interface/package.xml
@@ -18,9 +18,8 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
   <author>Siddharth Kucheria</author>
 
-  <depend>ros2cli</depend>
-
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
   <exec_depend>rosidl_adapter</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 

--- a/ros2lifecycle/package.xml
+++ b/ros2lifecycle/package.xml
@@ -17,10 +17,9 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>rclpy</depend>
-  <depend>ros2cli</depend>
-
   <exec_depend>lifecycle_msgs</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
   <exec_depend>ros2node</exec_depend>
   <exec_depend>ros2service</exec_depend>
 

--- a/ros2multicast/package.xml
+++ b/ros2multicast/package.xml
@@ -17,7 +17,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>ros2cli</depend>
+  <exec_depend>ros2cli</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2node/package.xml
+++ b/ros2node/package.xml
@@ -17,9 +17,8 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>ros2cli</depend>
-
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2param/package.xml
+++ b/ros2param/package.xml
@@ -17,10 +17,9 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>rcl_interfaces</depend>
-  <depend>rclpy</depend>
-  <depend>ros2cli</depend>
-
+  <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
   <exec_depend>ros2node</exec_depend>
   <exec_depend>ros2service</exec_depend>
 

--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -17,14 +17,13 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>python3-importlib-resources</depend>
-  <depend>ros2cli</depend>
-
   <exec_depend>ament_copyright</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-empy</exec_depend>
+  <exec_depend>python3-importlib-resources</exec_depend>
   <exec_depend>python3-pkg-resources</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ros2run/package.xml
+++ b/ros2run/package.xml
@@ -17,8 +17,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>ros2cli</depend>
-
+  <exec_depend>ros2cli</exec_depend>
   <exec_depend>ros2pkg</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2service/package.xml
+++ b/ros2service/package.xml
@@ -17,10 +17,9 @@
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
   <author email="william@osrfoundation.org">William Woodall</author>
 
-  <depend>rclpy</depend>
-  <depend>ros2cli</depend>
-
   <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2topic/package.xml
+++ b/ros2topic/package.xml
@@ -18,11 +18,10 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
   <author email="michael.jeronimo@openrobotics.org">Michael Jeronimo</author>
 
-  <depend>ros2cli</depend>
-
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2cli</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
That is, they have no build step, so they shouldn't export a dependency for that.

@cottsay can you double-check my work on this one and make sure I'm not mistaken?  Thanks.