### PR TITLE
Shutdown ros2doctor hello when ctrl-c is received

### DIFF
--- a/ros2doctor/ros2doctor/verb/hello.py
+++ b/ros2doctor/ros2doctor/verb/hello.py
@@ -91,7 +91,13 @@ class HelloVerb(VerbExtension):
             executor = SingleThreadedExecutor()
             executor.add_node(node.node)
 
-            executor_thread = threading.Thread(target=executor.spin)
+            def spin():
+                try:
+                    executor.spin()
+                except rclpy.executors.ExternalShutdownException:
+                    rclpy.shutdown()
+
+            executor_thread = threading.Thread(target=spin)
             executor_thread.start()
 
             try:


### PR DESCRIPTION
Uncovered in tutorial party: https://github.com/osrf/ros2_test_cases/issues/548

There was an issue where `ros2 doctor hello` would not shutdown on Windows, instead hanging with the trace: 

```
Traceback (most recent call last):
  File "C:\Python38\lib\threading.py", line 932, in _bootstrap_inner
    self.run()
  File "C:\Python38\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "C:\ros2_iron\Lib\site-packages\rclpy\executors.py", line 280, in spin
    self.spin_once()
  File "C:\ros2_iron\Lib\site-packages\rclpy\executors.py", line 717, in spin_once
    handler, entity, node = self.wait_for_ready_callbacks(timeout_sec=timeout_sec)
  File "C:\ros2_iron\Lib\site-packages\rclpy\executors.py", line 703, in wait_for_ready_callbacks
    return next(self._cb_iter)
  File "C:\ros2_iron\Lib\site-packages\rclpy\executors.py", line 604, in _wait_for_ready_callbacks
    raise ExternalShutdownException()
rclpy.executors.ExternalShutdownException
```

I believe this is because once the rclpy signal handler is installed, the KeyboardInterrupt was not getting triggered in the main thread.  This makes it so that the executor thread will additionally call shutdown in the case that the signal is handled there first.