### PR TITLE
ros2pkg warning message typo fix.

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -223,4 +223,4 @@ class CreateVerb(VerbExtension):
         else:
             print("\n[WARNING]: Unknown license '%s'.  This has been set in the package.xml, but "
                   'no LICENSE file has been created.\nIt is recommended to use one of the ament '
-                  'license identitifers:\n%s' % (args.license, '\n'.join(available_licenses)))
+                  'license identifiers:\n%s' % (args.license, '\n'.join(available_licenses)))


### PR DESCRIPTION
part of https://github.com/osrf/ros2_test_cases/issues/954