### PR TITLE
Update ros2 param dump dosctring (`-h` option).

### DIFF
--- a/ros2param/ros2param/verb/dump.py
+++ b/ros2param/ros2param/verb/dump.py
@@ -29,7 +29,7 @@ import yaml
 
 
 class DumpVerb(VerbExtension):
-    """Dump the parameters of a node to a yaml file."""
+    """Show all of the parameters of a node in a YAML file format."""
 
     def add_arguments(self, parser, cli_name):  # noqa: D102
         add_arguments(parser)


### PR DESCRIPTION
As mentioned in #836 , this pull request aims to correct the `ros2 param dump -h` information.

### Current doc

https://github.com/ros2/ros2cli/blob/960962a142323c7a13c4ddef3a7e661d77905f93/ros2param/ros2param/verb/dump.py#L31-L32

### Proposed change

```python
class DumpVerb(VerbExtension):
    """Show all of the parameters of a node in a YAML file format."""
```

### Based on

The current docstring for `ros2 param describe`

https://github.com/ros2/ros2cli/blob/960962a142323c7a13c4ddef3a7e661d77905f93/ros2param/ros2param/verb/describe.py#L27-L28

mixed with the documentation at 
https://docs.ros.org/en/rolling/How-To-Guides/Using-ros2-param.html#ros2-param-dump

```
This command will print out all of the parameters on a particular node in a YAML file format.
```

I'd be glad to update this PR as needed.