### PR TITLE
Fix tests with new service and param present

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -75,7 +75,8 @@ def serve(server, *, timeout=2 * 60 * 60):
         ros_domain_id = get_ros_domain_id()
         node_args = argparse.Namespace(
             node_name_suffix=f'_daemon_{ros_domain_id}_{uuid.uuid4().hex}',
-            start_parameter_services=False)
+            start_parameter_services=False,
+            start_type_description_service=False)
         with NetworkAwareNode(node_args) as node:
             functions = [
                 node.get_name,

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -40,6 +40,7 @@ class DirectNode:
         start_parameter_services = getattr(
             args, 'start_parameter_services', False)
         use_sim_time = getattr(args, 'use_sim_time', False)
+        start_type_description_service = getattr(args, 'start_type_description_service', True)
 
         if node_name is None:
             node_name = NODE_NAME_PREFIX + node_name_suffix
@@ -48,7 +49,8 @@ class DirectNode:
             node_name,
             start_parameter_services=start_parameter_services,
             parameter_overrides=[
-                Parameter('use_sim_time', value=use_sim_time)
+                Parameter('use_sim_time', value=use_sim_time),
+                Parameter('start_type_description_service', value=start_type_description_service),
             ], automatically_declare_parameters_from_overrides=True)
 
         timeout = getattr(args, 'spin_time', DEFAULT_TIMEOUT)

--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -63,6 +63,7 @@ EXPECTED_PARAMETER_FILE = (
     '    - 2\n'
     '    - 3\n'
     '    int_param: 42\n'
+    '    start_type_description_service: true\n'
     '    str_array_param:\n'
     '    - foo\n'
     '    - bar\n'

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -180,6 +180,7 @@ class TestVerbList(unittest.TestCase):
                 '  foo.str_param',
                 '  int_array_param',
                 '  int_param',
+                '  start_type_description_service',
                 '  str_array_param',
                 '  str_param',
                 '  use_sim_time'],

--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -66,6 +66,7 @@ INPUT_PARAMETER_FILE = (
     '    - 3\n'
     '    - 3\n'
     '    int_param: -42\n'
+    '    start_type_description_service: true\n'
     '    str_array_param:\n'
     '    - a_foo\n'
     '    - a_bar\n'


### PR DESCRIPTION
Part of ros2/ros2#1159
Depends on ros2/rclpy#1139

ros2/rclpy#1139 starts a new service and introduces a new parameter to enable it. This PR fixes test expectations given the new situation, including turning _off_ the new service on the daemon node.