### PR TITLE
Load a message/request/goal from standard input

### DIFF
--- a/ros2action/ros2action/verb/send_goal.py
+++ b/ros2action/ros2action/verb/send_goal.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 from action_msgs.msg import GoalStatus
 import rclpy
 from rclpy.action import ActionClient
@@ -21,6 +19,7 @@ from ros2action.api import action_name_completer
 from ros2action.api import ActionGoalPrototypeCompleter
 from ros2action.api import ActionTypeCompleter
 from ros2action.verb import VerbExtension
+from ros2cli.helpers import collect_stdin
 from ros2cli.node import NODE_NAME_PREFIX
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py import set_message_fields
@@ -59,15 +58,11 @@ class SendGoalVerb(VerbExtension):
             feedback_callback = _feedback_callback
 
         if args.stdin:
-            lines = b""
-            while True:
-                line = sys.stdin.buffer.readline()
-                if not line:
-                    break
-                lines += line
-            args.goal = lines
+            goal = collect_stdin()
+        else:
+            goal = args.goal
 
-        return send_goal(args.action_name, args.action_type, args.goal, feedback_callback)
+        return send_goal(args.action_name, args.action_type, goal, feedback_callback)
 
 
 def _goal_status_to_string(status):

--- a/ros2cli/ros2cli/helpers.py
+++ b/ros2cli/ros2cli/helpers.py
@@ -16,6 +16,7 @@ from argparse import ArgumentTypeError
 import functools
 import inspect
 import os
+import sys
 import time
 
 
@@ -107,3 +108,13 @@ def unsigned_int(string):
     if value < 0:
         raise ArgumentTypeError('value must be non-negative integer')
     return value
+
+
+def collect_stdin():
+    lines = b""
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            break
+        lines += line
+    return lines

--- a/ros2cli/ros2cli/helpers.py
+++ b/ros2cli/ros2cli/helpers.py
@@ -111,7 +111,7 @@ def unsigned_int(string):
 
 
 def collect_stdin():
-    lines = b""
+    lines = b''
     while True:
         line = sys.stdin.buffer.readline()
         if not line:

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import importlib
-import sys
 import time
 
 import rclpy
+from ros2cli.helpers import collect_stdin
 from ros2cli.node import NODE_NAME_PREFIX
 from ros2service.api import ServiceNameCompleter
 from ros2service.api import ServicePrototypeCompleter
@@ -61,16 +61,12 @@ class CallVerb(VerbExtension):
         period = 1. / args.rate if args.rate else None
 
         if args.stdin:
-            lines = b""
-            while True:
-                line = sys.stdin.buffer.readline()
-                if not line:
-                    break
-                lines += line
-            args.values = lines
+            values = collect_stdin()
+        else:
+            values = args.values
 
         return requester(
-            args.service_type, args.service_name, args.values, period)
+            args.service_type, args.service_name, values, period)
 
 
 def requester(service_type, service_name, values, period):

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import time
 from typing import Optional
 from typing import TypeVar
@@ -20,6 +19,7 @@ from typing import TypeVar
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
+from ros2cli.helpers import collect_stdin
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
@@ -121,20 +121,16 @@ def main(args):
         times = 1
 
     if args.stdin:
-        lines = b""
-        while True:
-            line = sys.stdin.buffer.readline()
-            if not line:
-                break
-            lines += line
-        args.values = lines
+        values = collect_stdin()
+    else:
+        values = args.values
 
     with DirectNode(args, node_name=args.node_name) as node:
         return publisher(
             node.node,
             args.message_type,
             args.topic_name,
-            args.values,
+            values,
             1. / args.rate,
             args.print,
             times,


### PR DESCRIPTION
Resolve #842

Add option `--stdin` to pass yaml from standard input.
The last positional argument and the new option `--stdin` are mutually_exclusive_group.

The change requires that the send_goal argument `goal` be optional.