### PR TITLE
Remove parentheses from assert statement.

### DIFF
--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -97,7 +97,7 @@ class ROSTopicBandwidth(object):
                 # TODO(yechun1): Subscribing to the msgs and calculate the length may be
                 # inefficient. Optimize here if a better solution is found.
                 self.sizes.append(len(data))  # AnyMsg instance
-                assert(len(self.times) == len(self.sizes))
+                assert len(self.times) == len(self.sizes)
 
                 if len(self.times) > self.window_size:
                     self.times.pop(0)


### PR DESCRIPTION
It isn't needed, and will fix a warning on newer flake8.