### PR TITLE
Conditionally use valid_signals.

### DIFF
--- a/ros2run/ros2run/api/__init__.py
+++ b/ros2run/ros2run/api/__init__.py
@@ -70,7 +70,8 @@ def run_executable(*, path, argv, prefix=None):
             # therefore we continue here until the process has finished
             pass
     if process.returncode != 0:
-        if -process.returncode in signal.valid_signals() and os.name == 'posix':
+        if hasattr(signal, 'valid_signals') and -process.returncode in signal.valid_signals() \
+                and os.name == 'posix':
             # a negative value -N indicates that the child was terminated by signal N.
             print(ROS2RUN_MSG_PREFIX, signal.strsignal(-process.returncode))
         else:


### PR DESCRIPTION
On Python 3.6 (in RHEL-8), signal.valid_signals()
does not exist.  Only use it if it exists.

This should fix #879 .  Note that we only need this fix on Humble, since we don't have to worry about Python 3.6 on Iron and later.