### PR TITLE
ros2cli.node.daemon : try getting fdsize from /proc for open fd limit

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -144,7 +144,7 @@ def spawn_daemon(args, timeout=None, debug=False):
             string_to_find = 'FDSize:'
             with open('/proc/self/status', 'r') as f:
                 line = next(filter(lambda x: x.startswith(string_to_find), iter(f)))
-                fdlimit = int(line[len(string_to_find):].strip())
+                fdlimit = int(line.removeprefix(string_to_find).strip())
         except (FileNotFoundError, StopIteration):
             pass
         # The soft limit might be quite high on some systems.

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -143,15 +143,16 @@ def spawn_daemon(args, timeout=None, debug=False):
         try:
             string_to_find = 'FDSize:'
             with open('/proc/self/status', 'r') as f:
-                line = next(filter(lambda x: x.startswith(string_to_find), iter(f)))
-                fdlimit = int(line.removeprefix(string_to_find).strip())
-        except (FileNotFoundError, StopIteration):
+                for line in f:
+                    if line.startswith(string_to_find):
+                        fdlimit = int(line.removeprefix(string_to_find).strip())
+                        break
+        except (FileNotFoundError, ValueError):
             pass
         # The soft limit might be quite high on some systems.
         if fdlimit is None:
             import resource
             fdlimit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-        #
         for i in range(3, fdlimit):
             try:
                 if i != server.socket.fileno() and os.get_inheritable(i):


### PR DESCRIPTION
#852 remove inheritence of open fds to fix the issue. It use the soft-limit from RLIMIT_NOFILE to loop over all fds.

This breaks ros2cli on some Unices due to a high soft-limit,
https://github.com/ros2/ros2/issues/1531

This PR follows Ruby's approach of reading ~/proc/self/status~ to get fdsize for the loop-limit (as suggested by @clalancette in the bug-report).

Tested this on the latest osrf/ros:rolling-desktop.

Edit:
(lmk what I need to do to fix the ci).