### PR TITLE
Revamp how we get network information in ros2doctor.

### DIFF
--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -26,6 +26,7 @@ from ros2doctor.api.format import doctor_warn
 
 
 class InterfaceFlags:
+
     def __init__(self, interface_name):
         self.flags = ''
         self.has_loopback = False


### PR DESCRIPTION
We already depend on psutil, which can give us information for ros2doctor in a cross-platform way.  Lean more heavily into using this, which should help us deal with cross-platform a little more smoothly.

I will note that this slightly changes the output of ros2doctor on Linux.  Prior to this PR, the flags output would look something like:

```
flags        : 4163<MULTICAST,BROADCAST,UP,RUNNING>
```

After this PR, the output looks like this:

```
flags        : UP,BROADCAST,RUNNING,MULTICAST
```

That is, we lose the decimal bitmask associated with the device.

This should fix #906 