### PR TITLE
Update daemon.py for Python 3.8 compatibility

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -145,7 +145,7 @@ def spawn_daemon(args, timeout=None, debug=False):
             with open('/proc/self/status', 'r') as f:
                 for line in f:
                     if line.startswith(string_to_find):
-                        fdlimit = int(line.removeprefix(string_to_find).strip())
+                        fdlimit = int(line[len(string_to_find):].strip())
                         break
         except (FileNotFoundError, ValueError):
             pass


### PR DESCRIPTION
Minor fix for containers running Pyhton version < 3.9.0 

Before and after: 
![Fix](https://github.com/ros2/ros2cli/assets/55327408/0cf59446-d8c7-433d-bef4-969ff9329f56)

Tested on:
![environment](https://github.com/ros2/ros2cli/assets/55327408/e20e50a9-1bf2-4753-81e9-fba6f43e2dc1)
