### PR TITLE
Fix Humble source build on Nvidia Jetson

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -145,7 +145,7 @@ def spawn_daemon(args, timeout=None, debug=False):
             with open('/proc/self/status', 'r') as f:
                 for line in f:
                     if line.startswith(string_to_find):
-                        fdlimit = int(line.removeprefix(string_to_find).strip())
+                        fdlimit = int(line[len(string_to_find):].strip())
                         break
         except (FileNotFoundError, ValueError):
             pass


### PR DESCRIPTION
Fixes #909 .

Humble source builds are possible on Nvidia Jetson devices running JetPack 5.x.
Python version on JetPack 5.x is 3.8, but removeprefix was introduced in Python 3.9.