### PR TITLE
Add support for topic QOS for ros2topic bw, delay and hz

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -21,6 +21,9 @@ import rclpy
 
 from rclpy.duration import Duration
 from rclpy.expand_topic_name import expand_topic_name
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSPresetProfiles
+from rclpy.qos import QoSReliabilityPolicy
 from rclpy.topic_or_service_is_hidden import topic_or_service_is_hidden
 from rclpy.validate_full_topic_name import validate_full_topic_name
 from ros2cli.node.strategy import NodeStrategy
@@ -259,3 +262,78 @@ def add_qos_arguments(
             f'Quality of service liveliness lease duration setting to {entity_type} '
             'with (overrides liveliness lease duration value of --qos-profile option, default: '
             f'{default_profile.liveliness_lease_duration})'))
+
+def extract_qos_arguments(args):
+    class QosArgs:
+        pass
+    
+    qos = QosArgs()
+    qos.qos_profile = args.qos_profile
+    qos.qos_reliability = args.qos_reliability
+    qos.qos_durability = args.qos_durability
+    qos.qos_depth = args.qos_depth
+    qos.qos_history = args.qos_history
+    qos.qos_liveliness = args.qos_liveliness
+    qos.qos_liveliness_lease_duration_seconds = args.qos_liveliness_lease_duration_seconds
+
+    return qos
+
+def choose_qos(node, topic_name: str, qos_args):
+    if (qos_args.qos_reliability is not None or
+            qos_args.qos_durability is not None or
+            qos_args.qos_depth is not None or
+            qos_args.qos_history is not None or
+            qos_args.qos_liveliness is not None or
+            qos_args.qos_liveliness_lease_duration_seconds is not None):
+
+        return qos_profile_from_short_keys(
+            qos_args.qos_profile,
+            reliability=qos_args.qos_reliability,
+            durability=qos_args.qos_durability,
+            depth=qos_args.qos_depth,
+            history=qos_args.qos_history,
+            liveliness=qos_args.qos_liveliness,
+            liveliness_lease_duration_s=qos_args.qos_liveliness_lease_duration_seconds)
+
+    qos_profile = QoSPresetProfiles.get_from_short_key(qos_args.qos_profile)
+    reliability_reliable_endpoints_count = 0
+    durability_transient_local_endpoints_count = 0
+
+    pubs_info = node.get_publishers_info_by_topic(topic_name)
+    publishers_count = len(pubs_info)
+    if publishers_count == 0:
+        return qos_profile
+
+    for info in pubs_info:
+        if (info.qos_profile.reliability == QoSReliabilityPolicy.RELIABLE):
+            reliability_reliable_endpoints_count += 1
+        if (info.qos_profile.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL):
+            durability_transient_local_endpoints_count += 1
+
+    # If all endpoints are reliable, ask for reliable
+    if reliability_reliable_endpoints_count == publishers_count:
+        qos_profile.reliability = QoSReliabilityPolicy.RELIABLE
+    else:
+        if reliability_reliable_endpoints_count > 0:
+            print(
+                'Some, but not all, publishers are offering '
+                'QoSReliabilityPolicy.RELIABLE. Falling back to '
+                'QoSReliabilityPolicy.BEST_EFFORT as it will connect '
+                'to all publishers'
+            )
+        qos_profile.reliability = QoSReliabilityPolicy.BEST_EFFORT
+
+    # If all endpoints are transient_local, ask for transient_local
+    if durability_transient_local_endpoints_count == publishers_count:
+        qos_profile.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
+    else:
+        if durability_transient_local_endpoints_count > 0:
+            print(
+                'Some, but not all, publishers are offering '
+                'QoSDurabilityPolicy.TRANSIENT_LOCAL. Falling back to '
+                'QoSDurabilityPolicy.VOLATILE as it will connect '
+                'to all publishers'
+            )
+        qos_profile.durability = QoSDurabilityPolicy.VOLATILE
+
+    return qos_profile

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -263,10 +263,11 @@ def add_qos_arguments(
             'with (overrides liveliness lease duration value of --qos-profile option, default: '
             f'{default_profile.liveliness_lease_duration})'))
 
+
 def extract_qos_arguments(args):
     class QosArgs:
         pass
-    
+
     qos = QosArgs()
     qos.qos_profile = args.qos_profile
     qos.qos_reliability = args.qos_reliability
@@ -277,6 +278,7 @@ def extract_qos_arguments(args):
     qos.qos_liveliness_lease_duration_seconds = args.qos_liveliness_lease_duration_seconds
 
     return qos
+
 
 def choose_qos(node, topic_name: str, qos_args):
     if (qos_args.qos_reliability is not None or

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -264,22 +264,6 @@ def add_qos_arguments(
             f'{default_profile.liveliness_lease_duration})'))
 
 
-def extract_qos_arguments(args):
-    class QosArgs:
-        pass
-
-    qos = QosArgs()
-    qos.qos_profile = args.qos_profile
-    qos.qos_reliability = args.qos_reliability
-    qos.qos_durability = args.qos_durability
-    qos.qos_depth = args.qos_depth
-    qos.qos_history = args.qos_history
-    qos.qos_liveliness = args.qos_liveliness
-    qos.qos_liveliness_lease_duration_seconds = args.qos_liveliness_lease_duration_seconds
-
-    return qos
-
-
 def choose_qos(node, topic_name: str, qos_args):
     if (qos_args.qos_reliability is not None or
             qos_args.qos_durability is not None or

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -37,8 +37,8 @@ import rclpy
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
-from ros2topic.api import extract_qos_arguments
 from ros2topic.api import choose_qos
+from ros2topic.api import extract_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -38,7 +38,6 @@ from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
 from ros2topic.api import choose_qos
-from ros2topic.api import extract_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
@@ -76,9 +75,9 @@ class BwVerb(VerbExtension):
         add_direct_node_arguments(parser)
 
     def main(self, *, args):
-        qos_args = extract_qos_arguments(args)
         with DirectNode(args) as node:
-            _rostopic_bw(node.node, args.topic_name, qos_args, window_size=args.window_size)
+            qos_profile = choose_qos(node.node, topic_name=args.topic_name, qos_args=args)
+            _rostopic_bw(node.node, args.topic_name, qos_profile, window_size=args.window_size)
 
 
 class ROSTopicBandwidth(object):
@@ -154,15 +153,13 @@ class ROSTopicBandwidth(object):
         print(f'{bw} from {n} messages\n\tMessage size mean: {mean} min: {min_s} max: {max_s}')
 
 
-def _rostopic_bw(node, topic, qos, window_size=DEFAULT_WINDOW_SIZE):
+def _rostopic_bw(node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE):
     """Periodically print the received bandwidth of a topic to console until shutdown."""
     # pause bw until topic is published
     msg_class = get_msg_class(node, topic, blocking=True, include_hidden_topics=True)
     if msg_class is None:
         node.destroy_node()
         return
-
-    qos_profile = choose_qos(node, topic_name=topic, qos_args=qos)
 
     rt = ROSTopicBandwidth(node, window_size)
     node.create_subscription(

--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -33,13 +33,12 @@ import math
 
 import rclpy
 
-from rclpy.qos import qos_profile_sensor_data
 from rclpy.time import Time
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
-from ros2topic.api import extract_qos_arguments
 from ros2topic.api import choose_qos
+from ros2topic.api import extract_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter

--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -37,6 +37,9 @@ from rclpy.qos import qos_profile_sensor_data
 from rclpy.time import Time
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
+from ros2topic.api import add_qos_arguments
+from ros2topic.api import extract_qos_arguments
+from ros2topic.api import choose_qos
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
@@ -50,12 +53,13 @@ class DelayVerb(VerbExtension):
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
-            'topic',
+            'topic_name',
             help='Topic name to calculate the delay for')
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')
+        add_qos_arguments(parser, 'subscribe', 'sensor_data')
         parser.add_argument(
-            '--window', '-w', type=positive_int, default=DEFAULT_WINDOW_SIZE,
+            '--window', '-w', dest='window_size', type=positive_int, default=DEFAULT_WINDOW_SIZE,
             help='window size, in # of messages, for calculating rate, '
                  'string to (default: %d)' % DEFAULT_WINDOW_SIZE)
         add_direct_node_arguments(parser)
@@ -65,9 +69,9 @@ class DelayVerb(VerbExtension):
 
 
 def main(args):
+    qos_args = extract_qos_arguments(args)
     with DirectNode(args) as node:
-        _rostopic_delay(
-            node.node, args.topic, window_size=args.window)
+        _rostopic_delay(node.node, args.topic_name, qos_args, window_size=args.window_size)
 
 
 class ROSTopicDelay(object):
@@ -155,11 +159,12 @@ class ROSTopicDelay(object):
               % (delay * 1e-9, min_delta * 1e-9, max_delta * 1e-9, std_dev * 1e-9, window))
 
 
-def _rostopic_delay(node, topic, window_size=DEFAULT_WINDOW_SIZE):
+def _rostopic_delay(node, topic, qos, window_size=DEFAULT_WINDOW_SIZE):
     """
     Periodically print the publishing delay of a topic to console until shutdown.
 
     :param topic: topic name, ``str``
+    :param qos: qos configuration of the subscriber
     :param window_size: number of messages to average over, ``unsigned_int``
     :param blocking: pause delay until topic is published, ``bool``
     """
@@ -170,12 +175,14 @@ def _rostopic_delay(node, topic, window_size=DEFAULT_WINDOW_SIZE):
         node.destroy_node()
         return
 
+    qos_profile = choose_qos(node, topic_name=topic, qos_args=qos)
+
     rt = ROSTopicDelay(node, window_size)
     node.create_subscription(
         msg_class,
         topic,
         rt.callback_delay,
-        qos_profile_sensor_data)
+        qos_profile)
 
     timer = node.create_timer(1, rt.print_delay)
     while rclpy.ok():

--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -38,7 +38,6 @@ from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
 from ros2topic.api import choose_qos
-from ros2topic.api import extract_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
@@ -68,9 +67,9 @@ class DelayVerb(VerbExtension):
 
 
 def main(args):
-    qos_args = extract_qos_arguments(args)
     with DirectNode(args) as node:
-        _rostopic_delay(node.node, args.topic_name, qos_args, window_size=args.window_size)
+        qos_profile = choose_qos(node.node, topic_name=args.topic_name, qos_args=args)
+        _rostopic_delay(node.node, args.topic_name, qos_profile, window_size=args.window_size)
 
 
 class ROSTopicDelay(object):
@@ -158,12 +157,12 @@ class ROSTopicDelay(object):
               % (delay * 1e-9, min_delta * 1e-9, max_delta * 1e-9, std_dev * 1e-9, window))
 
 
-def _rostopic_delay(node, topic, qos, window_size=DEFAULT_WINDOW_SIZE):
+def _rostopic_delay(node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE):
     """
     Periodically print the publishing delay of a topic to console until shutdown.
 
     :param topic: topic name, ``str``
-    :param qos: qos configuration of the subscriber
+    :param qos_profile: qos profile of the subscriber
     :param window_size: number of messages to average over, ``unsigned_int``
     :param blocking: pause delay until topic is published, ``bool``
     """
@@ -173,8 +172,6 @@ def _rostopic_delay(node, topic, qos, window_size=DEFAULT_WINDOW_SIZE):
     if msg_class is None:
         node.destroy_node()
         return
-
-    qos_profile = choose_qos(node, topic_name=topic, qos_args=qos)
 
     rt = ROSTopicDelay(node, window_size)
     node.create_subscription(

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -25,8 +25,8 @@ from ros2cli.helpers import unsigned_int
 from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import add_qos_arguments
-from ros2topic.api import extract_qos_arguments
 from ros2topic.api import choose_qos
+from ros2topic.api import extract_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_float
 from ros2topic.api import TopicNameCompleter

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -19,18 +19,16 @@ import rclpy
 from rclpy.event_handler import SubscriptionEventCallbacks
 from rclpy.event_handler import UnsupportedEventTypeError
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy
-from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
-from rclpy.qos import QoSReliabilityPolicy
 from rclpy.task import Future
 from ros2cli.helpers import unsigned_int
 from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import add_qos_arguments
+from ros2topic.api import extract_qos_arguments
+from ros2topic.api import choose_qos
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_float
-from ros2topic.api import qos_profile_from_short_keys
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 from rosidl_runtime_py import message_to_csv
@@ -116,67 +114,6 @@ class EchoVerb(VerbExtension):
             '-n', '--node-name', type=str, default=None,
             help='The name of the echoing node; by default, will be a hidden node name')
 
-    def choose_qos(self, node, args):
-
-        if (args.qos_reliability is not None or
-                args.qos_durability is not None or
-                args.qos_depth is not None or
-                args.qos_history is not None or
-                args.qos_liveliness is not None or
-                args.qos_liveliness_lease_duration_seconds is not None):
-
-            return qos_profile_from_short_keys(
-                args.qos_profile,
-                reliability=args.qos_reliability,
-                durability=args.qos_durability,
-                depth=args.qos_depth,
-                history=args.qos_history,
-                liveliness=args.qos_liveliness,
-                liveliness_lease_duration_s=args.qos_liveliness_lease_duration_seconds)
-
-        qos_profile = QoSPresetProfiles.get_from_short_key(args.qos_profile)
-        reliability_reliable_endpoints_count = 0
-        durability_transient_local_endpoints_count = 0
-
-        pubs_info = node.get_publishers_info_by_topic(args.topic_name)
-        publishers_count = len(pubs_info)
-        if publishers_count == 0:
-            return qos_profile
-
-        for info in pubs_info:
-            if (info.qos_profile.reliability == QoSReliabilityPolicy.RELIABLE):
-                reliability_reliable_endpoints_count += 1
-            if (info.qos_profile.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL):
-                durability_transient_local_endpoints_count += 1
-
-        # If all endpoints are reliable, ask for reliable
-        if reliability_reliable_endpoints_count == publishers_count:
-            qos_profile.reliability = QoSReliabilityPolicy.RELIABLE
-        else:
-            if reliability_reliable_endpoints_count > 0:
-                print(
-                    'Some, but not all, publishers are offering '
-                    'QoSReliabilityPolicy.RELIABLE. Falling back to '
-                    'QoSReliabilityPolicy.BEST_EFFORT as it will connect '
-                    'to all publishers'
-                )
-            qos_profile.reliability = QoSReliabilityPolicy.BEST_EFFORT
-
-        # If all endpoints are transient_local, ask for transient_local
-        if durability_transient_local_endpoints_count == publishers_count:
-            qos_profile.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
-        else:
-            if durability_transient_local_endpoints_count > 0:
-                print(
-                    'Some, but not all, publishers are offering '
-                    'QoSDurabilityPolicy.TRANSIENT_LOCAL. Falling back to '
-                    'QoSDurabilityPolicy.VOLATILE as it will connect '
-                    'to all publishers'
-                )
-            qos_profile.durability = QoSDurabilityPolicy.VOLATILE
-
-        return qos_profile
-
     def main(self, *, args):
 
         self.csv = args.csv
@@ -210,7 +147,8 @@ class EchoVerb(VerbExtension):
 
         with NodeStrategy(args, node_name=args.node_name) as node:
 
-            qos_profile = self.choose_qos(node, args)
+            qos = extract_qos_arguments(args)
+            qos_profile = choose_qos(node, topic_name=args.topic_name, qos_args=qos)
 
             if args.message_type is None:
                 message_type = get_msg_class(

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -26,7 +26,6 @@ from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import add_qos_arguments
 from ros2topic.api import choose_qos
-from ros2topic.api import extract_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_float
 from ros2topic.api import TopicNameCompleter
@@ -147,8 +146,7 @@ class EchoVerb(VerbExtension):
 
         with NodeStrategy(args, node_name=args.node_name) as node:
 
-            qos = extract_qos_arguments(args)
-            qos_profile = choose_qos(node, topic_name=args.topic_name, qos_args=qos)
+            qos_profile = choose_qos(node, topic_name=args.topic_name, qos_args=args)
 
             if args.message_type is None:
                 message_type = get_msg_class(

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -44,8 +44,8 @@ from rclpy.executors import ExternalShutdownException
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
-from ros2topic.api import extract_qos_arguments
 from ros2topic.api import choose_qos
+from ros2topic.api import extract_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
@@ -99,8 +99,8 @@ def main(args):
     qos_args = extract_qos_arguments(args)
 
     with DirectNode(args) as node:
-        _rostopic_hz(node.node, topics, qos_args, window_size=args.window_size, filter_expr=filter_expr,
-                     use_wtime=args.use_wtime)
+        _rostopic_hz(node.node, topics, qos_args, window_size=args.window_size,
+                     filter_expr=filter_expr, use_wtime=args.use_wtime)
 
 
 class ROSTopicHz(object):
@@ -283,7 +283,8 @@ def _get_ascii_table(header, cols):
     return table
 
 
-def _rostopic_hz(node, topics, qos, window_size=DEFAULT_WINDOW_SIZE, filter_expr=None, use_wtime=False):
+def _rostopic_hz(node, topics, qos, window_size=DEFAULT_WINDOW_SIZE, filter_expr=None,
+                 use_wtime=False):
     """
     Periodically print the publishing rate of a topic to console until shutdown.
 

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -45,7 +45,6 @@ from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
 from ros2topic.api import choose_qos
-from ros2topic.api import extract_qos_arguments
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
@@ -96,10 +95,8 @@ def main(args):
     else:
         filter_expr = None
 
-    qos_args = extract_qos_arguments(args)
-
     with DirectNode(args) as node:
-        _rostopic_hz(node.node, topics, qos_args, window_size=args.window_size,
+        _rostopic_hz(node.node, topics, qos_args=args, window_size=args.window_size,
                      filter_expr=filter_expr, use_wtime=args.use_wtime)
 
 
@@ -283,13 +280,13 @@ def _get_ascii_table(header, cols):
     return table
 
 
-def _rostopic_hz(node, topics, qos, window_size=DEFAULT_WINDOW_SIZE, filter_expr=None,
+def _rostopic_hz(node, topics, qos_args, window_size=DEFAULT_WINDOW_SIZE, filter_expr=None,
                  use_wtime=False):
     """
     Periodically print the publishing rate of a topic to console until shutdown.
 
     :param topics: list of topic names, ``list`` of ``str``
-    :param qos: qos configuration of the subscriber
+    :param qos_args: qos arguments used to pick the qos profile of the subscriber
     :param window_size: number of messages to average over, -1 for infinite, ``int``
     :param filter_expr: Python filter expression that is called with m, the message instance
     """
@@ -306,7 +303,7 @@ def _rostopic_hz(node, topics, qos, window_size=DEFAULT_WINDOW_SIZE, filter_expr
             print('WARNING: failed to find message type for topic [%s]' % topic)
             continue
 
-        qos_profile = choose_qos(node, topic_name=topic, qos_args=qos)
+        qos_profile = choose_qos(node, topic_name=topic, qos_args=qos_args)
 
         node.create_subscription(
             msg_class,

--- a/ros2topic/test/test_bw_delay_hz.py
+++ b/ros2topic/test/test_bw_delay_hz.py
@@ -1,0 +1,200 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import sys
+import unittest
+
+from geometry_msgs.msg import PointStamped  # Used because delay requires a message with a header
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+import launch_testing_ros.tools
+
+import pytest
+
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.qos import DurabilityPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import ReliabilityPolicy
+from rclpy.utilities import get_rmw_implementation_identifier
+
+
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
+
+
+TEST_NODE = 'cli_bw_delay_hz_test_node'
+TEST_NAMESPACE = 'cli_bw_delay_hz'
+
+
+@pytest.mark.rostest
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    return LaunchDescription([
+        # Always restart daemon to isolate tests.
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                ExecuteProcess(
+                    cmd=['ros2', 'daemon', 'start'],
+                    name='daemon-start',
+                    on_exit=[
+                        launch_testing.actions.ReadyToTest()
+                    ],
+                )
+            ]
+        )
+    ])
+
+
+class TestROS2TopicBwDelayHz(unittest.TestCase):
+
+    def setUp(self):
+        self.context = rclpy.context.Context()
+        rclpy.init(context=self.context)
+        self.node = rclpy.create_node(
+            TEST_NODE, namespace=TEST_NAMESPACE, context=self.context
+        )
+        self.executor = SingleThreadedExecutor(context=self.context)
+        self.executor.add_node(self.node)
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown(context=self.context)
+
+    def helper_verb_basic(self, launch_service, proc_info, proc_output, verb, success_regex):
+        params = [
+            (f'/clitest/topic/{verb}_basic', False, True),
+            (f'/clitest/topic/{verb}_compatible_qos', True, True),
+            (f'/clitest/topic/{verb}_incompatible_qos', True, False),
+        ]
+        for topic, provide_qos, compatible_qos in params:
+            with self.subTest(topic=topic, provide_qos=provide_qos, compatible_qos=compatible_qos):
+                # Check for inconsistent arguments
+                assert provide_qos if not compatible_qos else True
+                verb_extra_options = []
+                publisher_qos_profile = 10
+                if provide_qos:
+                    if compatible_qos:
+                        # For compatible test, put publisher at very high quality
+                        # and subscription at low
+                        verb_extra_options = [
+                            '--qos-reliability', 'best_effort',
+                            '--qos-durability', 'volatile']
+                        publisher_qos_profile = QoSProfile(
+                            depth=10,
+                            reliability=ReliabilityPolicy.RELIABLE,
+                            durability=DurabilityPolicy.TRANSIENT_LOCAL)
+                    else:
+                        # For an incompatible example, reverse the quality extremes
+                        # and expect no messages to arrive
+                        verb_extra_options = [
+                            '--qos-reliability', 'reliable',
+                            '--qos-durability', 'transient_local']
+                        publisher_qos_profile = QoSProfile(
+                            depth=10,
+                            reliability=ReliabilityPolicy.BEST_EFFORT,
+                            durability=DurabilityPolicy.VOLATILE)
+                publisher = self.node.create_publisher(PointStamped, topic, publisher_qos_profile)
+                assert publisher
+
+                def publish_message():
+                    msg = PointStamped()
+                    # msg.header.stamp = self.node.get_clock().now()
+                    publisher.publish(msg)
+
+                publish_timer = self.node.create_timer(0.5, publish_message)
+
+                try:
+                    command_action = ExecuteProcess(
+                        cmd=(['ros2', 'topic', verb] +
+                             verb_extra_options +
+                             [topic]),
+                        additional_env={
+                            'PYTHONUNBUFFERED': '1'
+                        },
+                        output='screen'
+                    )
+                    with launch_testing.tools.launch_process(
+                        launch_service, command_action, proc_info, proc_output,
+                        output_filter=launch_testing_ros.tools.basic_output_filter(
+                            filtered_rmw_implementation=get_rmw_implementation_identifier()
+                        )
+                    ) as command:
+                        # The future won't complete - we will hit the timeout
+                        self.executor.spin_until_future_complete(
+                            rclpy.task.Future(), timeout_sec=5
+                        )
+                    command.wait_for_shutdown(timeout=10)
+                    # Check results
+                    if compatible_qos:
+                        assert command.output, f'{verb} CLI printed no output'
+                        assert re.search(success_regex, command.output, flags=re.MULTILINE), (
+                            f'{verb} CLI did not print expected message'
+                        )
+                    else:
+                        assert command.output, (
+                            f'{verb} CLI did not print incompatible QoS warning'
+                        )
+                        assert ("New publisher discovered on topic '{}', offering incompatible"
+                                ' QoS.'.format(topic) in command.output), (
+                                f'{verb} CLI did not print expected incompatible QoS warning'
+                            )
+                finally:
+                    # Cleanup
+                    self.node.destroy_timer(publish_timer)
+                    self.node.destroy_publisher(publisher)
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_bw_basic(self, launch_service, proc_info, proc_output):
+        self.helper_verb_basic(
+            launch_service,
+            proc_info,
+            proc_output,
+            'bw',
+            r'^[0-9]+ B/s from [0-9]+ messages$'
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_delay_basic(self, launch_service, proc_info, proc_output):
+        self.helper_verb_basic(
+            launch_service,
+            proc_info,
+            proc_output,
+            'delay',
+            r'^average delay: [0-9\.]+$'
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_hw_basic(self, launch_service, proc_info, proc_output):
+        self.helper_verb_basic(
+            launch_service,
+            proc_info,
+            proc_output,
+            'hz',
+            r'^average rate: [0-9\.]+$'
+        )

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -946,7 +946,7 @@ class TestROS2TopicCLI(unittest.TestCase):
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
                     'Subscribed to [/defaults]',
-                    re.compile(r'\d{2} B/s from \d+ messages'),
+                    re.compile(r'\d{2,3} B/s from \d+ messages'),
                     re.compile(r'\s*Message size mean: \d{2} B min: \d{2} B max: \d{2} B')
                 ], strict=True
             ), timeout=10)


### PR DESCRIPTION
This PR adds support for QoS configuration for the verbs: bw, delay and hz.

It moves the logic to decide on the QoS from `echo` into `ros2topic.api` to keep the same logic for the 4 verbs.

I'm not really satisfied with my `extract_qos_arguments` function. It's a bit useless, it might be cleaner to just pass the full args to each `_rostopic_verb` function 

Resolves: #719