### PR TITLE
Drop dependency on python3-pkg-resources

### DIFF
--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -20,7 +20,6 @@
   <exec_depend>python3-argcomplete</exec_depend>
   <exec_depend>python3-importlib-metadata</exec_depend>
   <exec_depend>python3-packaging</exec_depend>
-  <exec_depend>python3-pkg-resources</exec_depend>
   <exec_depend>python3-psutil</exec_depend>
   <exec_depend>rclpy</exec_depend>
 

--- a/ros2pkg/package.xml
+++ b/ros2pkg/package.xml
@@ -22,7 +22,6 @@
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>python3-empy</exec_depend>
   <exec_depend>python3-importlib-resources</exec_depend>
-  <exec_depend>python3-pkg-resources</exec_depend>
   <exec_depend>ros2cli</exec_depend>
 
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
This dependency is no longer used.

Follow-up to #537