### PR TITLE
Allow reuse address when firing up the ros2cli daemon.

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -151,6 +151,13 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
             pass
 
 
+def serve_and_close(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
+    try:
+        serve(server, timeout=timeout)
+    finally:
+        server.server_close()
+
+
 def main(*, argv=None):
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -46,7 +46,7 @@ class DaemonNode:
                 for method in self._proxy.system.listMethods()
                 if not method.startswith('system.')
             ]
-        except ConnectionRefusedError:
+        except (ConnectionRefusedError, ConnectionResetError):
             return False
         return True
 

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -168,7 +168,7 @@ def spawn_daemon(args, timeout=None, debug=False):
             'rmw_implementation': rclpy.get_rmw_implementation_identifier()}
 
         daemonize(
-            functools.partial(daemon.serve, server),
+            functools.partial(daemon.serve_and_close, server),
             tags=tags, timeout=timeout, debug=debug)
     finally:
         server.server_close()

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -42,15 +42,15 @@ class LocalXMLRPCServer(SimpleXMLRPCServer):
 
     def server_bind(self):
         # Prevent listening socket from lingering in TIME_WAIT state after close()
-        self.socket.setsockopt(
-            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
+        # self.socket.setsockopt(
+        #     socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
         super(LocalXMLRPCServer, self).server_bind()
 
     def get_request(self):
         # Prevent accepted socket from lingering in TIME_WAIT state after close()
         sock, addr = super(LocalXMLRPCServer, self).get_request()
-        sock.setsockopt(
-            socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
+        # sock.setsockopt(
+        #     socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
         return sock, addr
 
     def verify_request(self, request, client_address):

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import socket
 import struct
 # Import SimpleXMLRPCRequestHandler to re-export it.
@@ -32,7 +33,12 @@ def get_local_ipaddrs():
 
 class LocalXMLRPCServer(SimpleXMLRPCServer):
 
-    allow_reuse_address = False
+    # Allow re-binding even if another server instance was recently bound (i.e. we are still in
+    # TCP TIME_WAIT). This is already the default behavior on Windows, and further SO_REUSEADDR can
+    # lead to undefined behavior on Windows; see
+    # https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse.  # noqa
+    # So we don't set the option for Windows.
+    allow_reuse_address = False if os.name == 'nt' else True
 
     def server_bind(self):
         # Prevent listening socket from lingering in TIME_WAIT state after close()

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -14,7 +14,6 @@
 
 import os
 import socket
-import struct
 # Import SimpleXMLRPCRequestHandler to re-export it.
 from xmlrpc.server import SimpleXMLRPCRequestHandler  # noqa
 from xmlrpc.server import SimpleXMLRPCServer
@@ -39,19 +38,6 @@ class LocalXMLRPCServer(SimpleXMLRPCServer):
     # https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse.  # noqa
     # So we don't set the option for Windows.
     allow_reuse_address = False if os.name == 'nt' else True
-
-    def server_bind(self):
-        # Prevent listening socket from lingering in TIME_WAIT state after close()
-        # self.socket.setsockopt(
-        #     socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
-        super(LocalXMLRPCServer, self).server_bind()
-
-    def get_request(self):
-        # Prevent accepted socket from lingering in TIME_WAIT state after close()
-        sock, addr = super(LocalXMLRPCServer, self).get_request()
-        # sock.setsockopt(
-        #     socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
-        return sock, addr
 
     def verify_request(self, request, client_address):
         if client_address[0] not in get_local_ipaddrs():


### PR DESCRIPTION
Especially in tests where the daemon is being repeatedly created and destroyed, it can take some time for the kernel to actually allow the address to be rebinded (even after the old process has exited).  This can lead to some situations where we fail to spawn the daemon.

To fix this, set "allow_reuse_address" inside the LocalXMLRPCServer, which will set SO_REUSADDR on the socket.