### PR TITLE
[ros2pkg] Integrate features of 3rd-party ros2-pkg-create CLI tool

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: integrate features of https://github.com/ika-rwth-aachen/ros2-pkg-create
+
 import getpass
 import os
 import shutil


### PR DESCRIPTION
We have recently open-sourced our own package generation tool [`ros2-pkg-create`](https://github.com/ika-rwth-aachen/ros2-pkg-create). Please also see my introductory post on [ROS Discourse](https://discourse.ros.org/t/introducing-ros2-pkg-create-new-powerful-ros-2-package-generator/40669).

I'm opening this draft PR in response to [@tfoote suggesting to integrate `ros2-pkg-create`s features into the official CLI](https://discourse.ros.org/t/introducing-ros2-pkg-create-new-powerful-ros-2-package-generator/40669/2).

> [!NOTE]
> This PR is not carrying any changes just yet. I'm mainly opening this to share some insights into the features of `ros2-pkg-create`, how it's different than this repository's `ros2 pkg create`, and how an integration here could look like. Ideally, we could gather some feedback and suggestions before starting the actual integration efforts.

---

### Features of [`ros2-pkg-create`](https://github.com/ika-rwth-aachen/ros2-pkg-create)

- templates for three types of packages
  - C++ Package
  - Python Package
  - Interfaces Package
- support for basic and advanced features for both C++ and Python
  - publisher
  - subscriber
  - parameter loading
  - launch file (py/xml/yml)
  - service server
  - action servertimer callback, C++ component, C++ lifecycle, [docker-ros](https://github.com/ika-rwth-aachen/docker-ros)
- interactive CLI questionnaire for options not specified as CLI arguments

![image](https://github.com/user-attachments/assets/0a7dd8b4-c293-418a-81d7-c2b03ba2c22f)

### Technical Details of [`ros2-pkg-create`](https://github.com/ika-rwth-aachen/ros2-pkg-create)

### Differences between [`ros2-pkg-create`](https://github.com/ika-rwth-aachen/ros2-pkg-create) and `ros2 pkg create`

### Integration Plan

