### PR TITLE
Added support for echoing multiple fields in ros2 topic echo

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -69,8 +69,8 @@ class EchoVerb(VerbExtension):
             )
         )
         parser.add_argument(
-            '--field', type=str, default=None,
-            help='Echo a selected field of a message. '
+            '--field', action='append', type=str, default=None,
+            help='Specify one or more fields to echo. Use multiple --field options for multiple fields.'
                  "Use '.' to select sub-fields. "
                  'For example, to echo the position field of a nav_msgs/msg/Odometry message: '
                  "'ros2 topic echo /odom --field pose.pose.position'",
@@ -181,10 +181,15 @@ class EchoVerb(VerbExtension):
 
         # Validate field selection
         self.field = args.field
-        if self.field is not None:
-            self.field = list(filter(None, self.field.split('.')))
-            if not self.field:
-                raise RuntimeError(f"Invalid field value '{args.field}'")
+        if args.field:
+            for field in args.field:
+                try:
+                    value = get_field_value(message, field)
+                    print(f'{field}: {value}')
+                except AttributeError:
+                    print(f"Error: Field '{field}' not found in the message.")
+        else:
+            print(message)
 
         self.truncate_length = args.truncate_length if not args.full_length else None
         self.no_arr = args.no_arr

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -12,35 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 import rclpy
-from rclpy.event_handler import SubscriptionEventCallbacks
-from rclpy.event_handler import UnsupportedEventTypeError
+from rclpy.event_handler import (
+    SubscriptionEventCallbacks,
+    UnsupportedEventTypeError,
+)
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy
-from rclpy.qos import QoSPresetProfiles
-from rclpy.qos import QoSProfile
-from rclpy.qos import QoSReliabilityPolicy
+from rclpy.qos import (
+    QoSDurabilityPolicy,
+    QoSPresetProfiles,
+    QoSProfile,
+    QoSReliabilityPolicy,
+)
 from rclpy.task import Future
 from ros2cli.helpers import unsigned_int
-from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
-from ros2cli.node.strategy import NodeStrategy
-from ros2topic.api import add_qos_arguments
-from ros2topic.api import get_msg_class
-from ros2topic.api import positive_float
-from ros2topic.api import qos_profile_from_short_keys
-from ros2topic.api import TopicNameCompleter
+from ros2cli.node.strategy import (
+    add_arguments as add_strategy_node_arguments,
+    NodeStrategy,
+)
+from ros2topic.api import (
+    add_qos_arguments,
+    get_msg_class,
+    positive_float,
+    qos_profile_from_short_keys,
+    TopicNameCompleter,
+)
 from ros2topic.verb import VerbExtension
-from rosidl_runtime_py import message_to_csv
-from rosidl_runtime_py import message_to_yaml
+from rosidl_runtime_py import message_to_csv, message_to_yaml
 from rosidl_runtime_py.utilities import get_message
-
 import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
-MsgType = TypeVar('MsgType')
+MsgType = TypeVar("MsgType")
 
 
 class EchoVerb(VerbExtension):
@@ -49,80 +54,139 @@ class EchoVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         add_strategy_node_arguments(parser)
 
-        arg = parser.add_argument(
-            'topic_name',
-            help="Name of the ROS topic to listen to (e.g. '/chatter')")
-        arg.completer = TopicNameCompleter(
-            include_hidden_topics_key='include_hidden_topics')
         parser.add_argument(
-            'message_type', nargs='?',
-            help="Type of the ROS message (e.g. 'std_msgs/msg/String')")
-        add_qos_arguments(parser, 'subscribe', 'sensor_data')
+            "topic_name",
+            help="Name of the ROS topic to listen to (e.g. '/chatter')",
+        ).completer = TopicNameCompleter(
+            include_hidden_topics_key="include_hidden_topics"
+        )
+
         parser.add_argument(
-            '--csv', action='store_true',
+            "message_type",
+            nargs="?",
+            help="Type of the ROS message (e.g. 'std_msgs/msg/String')",
+        )
+        add_qos_arguments(parser, "subscribe", "sensor_data")
+
+        parser.add_argument(
+            "--csv",
+            action="store_true",
             help=(
-                'Output all recursive fields separated by commas (e.g. for '
-                'plotting). '
-                'If --include-message-info is also passed, the following fields are prepended: '
-                'source_timestamp, received_timestamp, publication_sequence_number,'
-                ' reception_sequence_number.'
-            )
+                "Output all recursive fields separated by commas"
+                "If --include-message-info is also passed,"
+                "the following fields are "
+                "prepended: source_timestamp, received_timestamp, "
+                "publication_sequence_number, reception_sequence_number."
+            ),
         )
         parser.add_argument(
-            '--field', action='append', type=str, default=None,
-            help='Specify one or more fields to echo. Use multiple --field options for multiple fields.'
-                 "Use '.' to select sub-fields. "
-                 'For example, to echo the position field of a nav_msgs/msg/Odometry message: '
-                 "'ros2 topic echo /odom --field pose.pose.position'",
+            "--field",
+            action="append",
+            type=str,
+            default=None,
+            help=(
+                "Specify one or more fields to echo."
+                "Use multiple --field options for "
+                "multiple fields. Use '.' to select sub-fields."
+                "For example, to echo the position field of a" 
+                "nav_msgs/msg/Odometry message: "
+                "'ros2 topic echo /odom --field pose.pose.position'"
+            ),
         )
         parser.add_argument(
-            '--full-length', '-f', action='store_true',
-            help='Output all elements for arrays, bytes, and string with a '
-                 "length > '--truncate-length', by default they are truncated "
-                 "after '--truncate-length' elements with '...''")
+            "--full-length",
+            "-f",
+            action="store_true",
+            help=(
+                "Output all elements for arrays, bytes, and strings with a length > "
+                "'--truncate-length'. By default, they are truncated after "
+                "'--truncate-length' elements with '...'."
+            ),
+        )
         parser.add_argument(
-            '--truncate-length', '-l', type=unsigned_int, default=DEFAULT_TRUNCATE_LENGTH,
-            help='The length to truncate arrays, bytes, and string to '
-                 '(default: %d)' % DEFAULT_TRUNCATE_LENGTH)
+            "--truncate-length",
+            "-l",
+            type=unsigned_int,
+            default=DEFAULT_TRUNCATE_LENGTH,
+            help=(
+                "The length to truncate arrays, bytes, and strings to (default: "
+                f"{DEFAULT_TRUNCATE_LENGTH})"
+            ),
+        )
         parser.add_argument(
-            '--no-arr', action='store_true', help="Don't print array fields of messages")
+            "--no-arr",
+            action="store_true",
+            help="Don't print array fields of messages",
+        )
         parser.add_argument(
-            '--no-str', action='store_true', help="Don't print string fields of messages")
+            "--no-str",
+            action="store_true",
+            help="Don't print string fields of messages",
+        )
         parser.add_argument(
-            '--flow-style', action='store_true',
-            help='Print collections in the block style (not available with csv format)')
+            "--flow-style",
+            action="store_true",
+            help="Print collections in the block style (not available with CSV format)",
+        )
         parser.add_argument(
-            '--no-lost-messages', action='store_true', help="Don't report when a message is lost")
+            "--no-lost-messages",
+            action="store_true",
+            help="Don't report when a message is lost",
+        )
         parser.add_argument(
-            '--raw', action='store_true', help='Echo the raw binary representation')
+            "--raw",
+            action="store_true",
+            help="Echo the raw binary representation",
+        )
         parser.add_argument(
-            '--filter', dest='filter_expr', help='Python expression to filter messages that '
-                                                 'are printed. Expression can use Python builtins '
-                                                 'as well as m (the message).')
+            "--filter",
+            dest="filter_expr",
+            help=(
+                "Python expression to filter messages that are printed. Expression can "
+                "use Python built-ins as well as m (the message)."
+            ),
+        )
         parser.add_argument(
-            '--once', action='store_true', help='Print the first message received and then exit.')
+            "--once",
+            action="store_true",
+            help="Print the first message received and then exit.",
+        )
         parser.add_argument(
-            '--timeout', metavar='N', type=positive_float,
-            help='Set a timeout in seconds for waiting', default=None)
+            "--timeout",
+            metavar="N",
+            type=positive_float,
+            help="Set a timeout in seconds for waiting",
+            default=None,
+        )
         parser.add_argument(
-            '--include-message-info', '-i', action='store_true',
-            help='Shows the associated message info.')
+            "--include-message-info",
+            "-i",
+            action="store_true",
+            help="Show the associated message info.",
+        )
         parser.add_argument(
-            '--clear', '-c', action='store_true',
-            help='Clear screen before printing next message')
+            "--clear",
+            "-c",
+            action="store_true",
+            help="Clear screen before printing the next message",
+        )
         parser.add_argument(
-            '-n', '--node-name', type=str, default=None,
-            help='The name of the echoing node; by default, will be a hidden node name')
+            "-n",
+            "--node-name",
+            type=str,
+            default=None,
+            help="The name of the echoing node; by default, will be a hidden node name",
+        )
 
     def choose_qos(self, node, args):
-
-        if (args.qos_reliability is not None or
-                args.qos_durability is not None or
-                args.qos_depth is not None or
-                args.qos_history is not None or
-                args.qos_liveliness is not None or
-                args.qos_liveliness_lease_duration_seconds is not None):
-
+        if (
+            args.qos_reliability is not None
+            or args.qos_durability is not None
+            or args.qos_depth is not None
+            or args.qos_history is not None
+            or args.qos_liveliness is not None
+            or args.qos_liveliness_lease_duration_seconds is not None
+        ):
             return qos_profile_from_short_keys(
                 args.qos_profile,
                 reliability=args.qos_reliability,
@@ -130,7 +194,9 @@ class EchoVerb(VerbExtension):
                 depth=args.qos_depth,
                 history=args.qos_history,
                 liveliness=args.qos_liveliness,
-                liveliness_lease_duration_s=args.qos_liveliness_lease_duration_seconds)
+                liveliness_lease_duration_s=
+                    args.qos_liveliness_lease_duration_seconds,
+            )
 
         qos_profile = QoSPresetProfiles.get_from_short_key(args.qos_profile)
         reliability_reliable_endpoints_count = 0
@@ -142,9 +208,9 @@ class EchoVerb(VerbExtension):
             return qos_profile
 
         for info in pubs_info:
-            if (info.qos_profile.reliability == QoSReliabilityPolicy.RELIABLE):
+            if info.qos_profile.reliability == QoSReliabilityPolicy.RELIABLE:
                 reliability_reliable_endpoints_count += 1
-            if (info.qos_profile.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL):
+            if info.qos_profile.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL:
                 durability_transient_local_endpoints_count += 1
 
         # If all endpoints are reliable, ask for reliable
@@ -153,10 +219,10 @@ class EchoVerb(VerbExtension):
         else:
             if reliability_reliable_endpoints_count > 0:
                 print(
-                    'Some, but not all, publishers are offering '
-                    'QoSReliabilityPolicy.RELIABLE. Falling back to '
-                    'QoSReliabilityPolicy.BEST_EFFORT as it will connect '
-                    'to all publishers'
+                    "Some, but not all, publishers are offering "
+                    "QoSReliabilityPolicy.RELIABLE. Falling back to "
+                    "QoSReliabilityPolicy.BEST_EFFORT as it will connect "
+                    "to all publishers"
                 )
             qos_profile.reliability = QoSReliabilityPolicy.BEST_EFFORT
 
@@ -166,32 +232,28 @@ class EchoVerb(VerbExtension):
         else:
             if durability_transient_local_endpoints_count > 0:
                 print(
-                    'Some, but not all, publishers are offering '
-                    'QoSDurabilityPolicy.TRANSIENT_LOCAL. Falling back to '
-                    'QoSDurabilityPolicy.VOLATILE as it will connect '
-                    'to all publishers'
+                    "Some, but not all, publishers are offering "
+                    "QoSDurabilityPolicy.TRANSIENT_LOCAL. Falling back to "
+                    "QoSDurabilityPolicy.VOLATILE as it will connect "
+                    "to all publishers"
                 )
             qos_profile.durability = QoSDurabilityPolicy.VOLATILE
 
         return qos_profile
 
     def main(self, *, args):
-
         self.csv = args.csv
 
         # Validate field selection
         self.field = args.field
-        if args.field:
-            for field in args.field:
-                try:
-                    value = get_field_value(message, field)
-                    print(f'{field}: {value}')
-                except AttributeError:
-                    print(f"Error: Field '{field}' not found in the message.")
-        else:
-            print(message)
+        if self.field is not None:
+            self.field = list(filter(None, self.field.split('.')))
+            if not self.field:
+                raise RuntimeError(f"Invalid field value '{args.field}'")
 
-        self.truncate_length = args.truncate_length if not args.full_length else None
+        self.truncate_length = (
+            args.truncate_length if not args.full_length else None
+        )
         self.no_arr = args.no_arr
         self.no_str = args.no_str
         self.flow_style = args.flow_style
@@ -209,21 +271,22 @@ class EchoVerb(VerbExtension):
         self.include_message_info = args.include_message_info
 
         with NodeStrategy(args, node_name=args.node_name) as node:
-
             qos_profile = self.choose_qos(node, args)
 
             if args.message_type is None:
                 message_type = get_msg_class(
-                    node, args.topic_name, include_hidden_topics=True)
+                    node, args.topic_name, include_hidden_topics=True
+                )
             else:
                 try:
                     message_type = get_message(args.message_type)
                 except (AttributeError, ModuleNotFoundError, ValueError):
-                    raise RuntimeError('The passed message type is invalid')
+                    raise RuntimeError("The passed message type is invalid")
 
             if message_type is None:
                 raise RuntimeError(
-                    'Could not determine the type for the passed topic')
+                    "Could not determine the type for the passed topic"
+                )
 
             if args.timeout is not None:
                 self.timer = node.create_timer(args.timeout, self._timed_out)
@@ -234,7 +297,8 @@ class EchoVerb(VerbExtension):
                 message_type,
                 qos_profile,
                 args.no_lost_messages,
-                args.raw)
+                args.raw,
+            )
 
     def subscribe_and_spin(
         self,
@@ -249,7 +313,8 @@ class EchoVerb(VerbExtension):
         event_callbacks = None
         if not no_report_lost_messages:
             event_callbacks = SubscriptionEventCallbacks(
-                message_lost=_message_lost_event_callback)
+                message_lost=_message_lost_event_callback
+            )
         try:
             node.create_subscription(
                 message_type,
@@ -257,7 +322,8 @@ class EchoVerb(VerbExtension):
                 self._subscriber_callback,
                 qos_profile,
                 event_callbacks=event_callbacks,
-                raw=raw)
+                raw=raw,
+            )
         except UnsupportedEventTypeError:
             assert not no_report_lost_messages
             node.create_subscription(
@@ -266,7 +332,8 @@ class EchoVerb(VerbExtension):
                 self._subscriber_callback,
                 qos_profile,
                 event_callbacks=None,
-                raw=raw)
+                raw=raw,
+            )
 
         if self.future is not None:
             rclpy.spin_until_future_complete(node, self.future)
@@ -283,7 +350,9 @@ class EchoVerb(VerbExtension):
                 try:
                     submsg = getattr(submsg, field)
                 except AttributeError as ex:
-                    raise RuntimeError(f"Invalid field '{'.'.join(self.field)}': {ex}")
+                    raise RuntimeError(
+                        f"Invalid field '{'.'.join(self.field)}': {ex}"
+                    )
 
         # Evaluate the current msg against the supplied expression
         if self.filter_fn is not None and not self.filter_fn(submsg):
@@ -292,17 +361,17 @@ class EchoVerb(VerbExtension):
         if self.future is not None and self.once:
             self.future.set_result(True)
 
-        # Clear terminal screen before print
+        # Clear terminal screen before prin
         if self.clear_screen:
             clear_terminal()
 
-        if not hasattr(submsg, '__slots__'):
+        if not hasattr(submsg, "__slots__"):
             # raw
             if self.include_message_info:
-                print('---Got new message, message info:---')
+                print("---Got new message, message info:---")
                 print(info)
-                print('---Message data:---')
-            print(submsg, end='\n---\n')
+                print("---Message data:---")
+            print(submsg, end="\n---\n")
             return
 
         if self.csv:
@@ -310,35 +379,42 @@ class EchoVerb(VerbExtension):
                 submsg,
                 truncate_length=self.truncate_length,
                 no_arr=self.no_arr,
-                no_str=self.no_str)
+                no_str=self.no_str,
+            )
             if self.include_message_info:
-                to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
+                to_print = f'{"".join(str(x) for x in info.values())},{to_print}'
             print(to_print)
             return
         # yaml
         if self.include_message_info:
-            print(yaml.dump(info), end='---\n')
+            print(yaml.dump(info), end="---\n")
         print(
             message_to_yaml(
-                submsg, truncate_length=self.truncate_length,
-                no_arr=self.no_arr, no_str=self.no_str, flow_style=self.flow_style),
-            end='---\n')
+                submsg,
+                truncate_length=self.truncate_length,
+                no_arr=self.no_arr,
+                no_str=self.no_str,
+                flow_style=self.flow_style,
+            ),
+            end="---\n",
+        )
 
 
 def _expr_eval(expr):
     def eval_fn(m):
         return eval(expr)
+
     return eval_fn
 
 
 def _message_lost_event_callback(message_lost_status):
     print(
-        'A message was lost!!!\n\ttotal count change:'
-        f'{message_lost_status.total_count_change}'
-        f'\n\ttotal count: {message_lost_status.total_count}',
-        end='---\n'
+        "A message was lost!!!\n\ttotal count change:"
+        f"{message_lost_status.total_count_change}"
+        f"\n\ttotal count: {message_lost_status.total_count}",
+        end="---\n",
     )
 
 
 def clear_terminal():
-    print('\x1b[H\x1b[2J')
+    print("\x1b[H\x1b[2J")

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -594,14 +594,20 @@ class TestROS2TopicCLI(unittest.TestCase):
         with self.launch_topic_command(
             arguments=['echo', '/arrays', '--field', 'alignment_check', '--field', 'data']
     ) as topic_command:
-        assert topic_command.wait_for_output(functools.partial(
-            launch_testing.tools.expect_output, expected_lines=[
-                'alignment_check: 0',
-                'data: []',
-                '---',
-            ], strict=True
-        ), timeout=10)
-    assert topic_command.wait_for_shutdown(timeout=10)
+        # Validate the expected output
+        assert topic_command.wait_for_output(
+            functools.partial(
+                launch_testing.tools.expect_output,
+                expected_lines=[
+                    'alignment_check: 0',
+                    'data: []',
+                    '---',
+                ],
+                strict=True
+            ),
+            timeout=15),
+    assert topic_command.wait_for_shutdown(timeout=10),
+
 
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -588,6 +588,21 @@ class TestROS2TopicCLI(unittest.TestCase):
                 ], strict=True
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)
+    
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_multiple_fields(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--field', 'alignment_check', '--field', 'data']
+    ) as topic_command:
+        assert topic_command.wait_for_output(functools.partial(
+            launch_testing.tools.expect_output, expected_lines=[
+                'alignment_check: 0',
+                'data: []',
+                '---',
+            ], strict=True
+        ), timeout=10)
+    assert topic_command.wait_for_shutdown(timeout=10)
+
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_echo_field_nested(self):

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -593,20 +593,19 @@ class TestROS2TopicCLI(unittest.TestCase):
     def test_topic_echo_multiple_fields(self):
         with self.launch_topic_command(
             arguments=['echo', '/arrays', '--field', 'alignment_check', '--field', 'data']
-    ) as topic_command:
-        # Validate the expected output
-        assert topic_command.wait_for_output(
-            functools.partial(
-                launch_testing.tools.expect_output,
-                expected_lines=[
-                    'alignment_check: 0',
-                    'data: []',
-                    '---',
-                ],
-                strict=True
-            ),
-            timeout=15),
-    assert topic_command.wait_for_shutdown(timeout=10),
+        ) as topic_command:
+            assert topic_command.wait_for_output(
+                functools.partial(
+                    launch_testing.tools.expect_output,
+                    expected_lines=[
+                        'alignment_check: 0',
+                        'data: []',
+                        '---',
+                    ],
+                    strict=True
+                ),
+                timeout=15),
+        assert topic_command.wait_for_shutdown(timeout=10),
 
 
 

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -603,9 +603,8 @@ class TestROS2TopicCLI(unittest.TestCase):
                         '---',
                     ],
                     strict=True
-                ),
-                timeout=15),
-        assert topic_command.wait_for_shutdown(timeout=10),
+                ),timeout=15)
+        assert topic_command.wait_for_shutdown(timeout=10)
 
 
 


### PR DESCRIPTION
#951 
# Now ros2 topic echo has support  for multiple fields
This PR extends the functionality of the ros2 topic echo command to allow users to specify and display multiple fields from a ROS topic message. Previously, the command supported either displaying the entire message or a single field using the --field argument. With this enhancement, users can specify multiple --field arguments to display specific fields, including nested fields.