### PR TITLE
Try git username for maintainer name

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -1,3 +1,4 @@
+cat create.py 
 # Copyright 2017 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,7 +80,7 @@ class CreateVerb(VerbExtension):
             '--maintainer-email',
             help='email address of the maintainer of this package'),
         parser.add_argument(
-            '--maintainer-name',
+            '--maintainer-name', 
             help='name of the maintainer of this package'),
         parser.add_argument(
             '--node-name',

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -79,7 +79,7 @@ class CreateVerb(VerbExtension):
             '--maintainer-email',
             help='email address of the maintainer of this package'),
         parser.add_argument(
-            '--maintainer-name', default=getpass.getuser(),
+            '--maintainer-name',
             help='name of the maintainer of this package'),
         parser.add_argument(
             '--node-name',
@@ -97,13 +97,29 @@ class CreateVerb(VerbExtension):
             print('Supported licenses:\n%s' % ('\n'.join(available_licenses)))
             sys.exit(0)
 
-        maintainer = Person(args.maintainer_name)
+        git = shutil.which('git')
+
+        if args.maintainer_name:
+            maintainer_name = args.maintainer_name
+        else:
+            # try getting the name from the global git config
+            if git is not None:
+                p = subprocess.Popen(
+                    [git, 'config', 'user.name'],
+                    stdout=subprocess.PIPE)
+                resp = p.communicate()
+                name = resp[0].decode().rstrip()
+                if name:
+                    maintainer_name = name
+            if not maintainer_name:
+                maintainer_name = getpass.getuser()
+
+        maintainer = Person(maintainer_name)
 
         if args.maintainer_email:
             maintainer.email = args.maintainer_email
         else:
             # try getting the email from the global git config
-            git = shutil.which('git')
             if git is not None:
                 p = subprocess.Popen(
                     [git, 'config', 'user.email'],

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -79,7 +79,7 @@ class CreateVerb(VerbExtension):
             '--maintainer-email',
             help='email address of the maintainer of this package'),
         parser.add_argument(
-            '--maintainer-name', 
+            '--maintainer-name',
             help='name of the maintainer of this package'),
         parser.add_argument(
             '--node-name',

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -1,4 +1,3 @@
-cat create.py 
 # Copyright 2017 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Add code for "ros2 pkg create" so that the first default for the maintainer-name is the git global user.name, which is likely a full name, instead of first using an OS login name. This creates more consistency, because the maintainer-email already defaults to the git global user.email.