### PR TITLE
Try to use the git global user.name for maintainer-name

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -113,13 +113,13 @@ class CreateVerb(VerbExtension):
             sys.exit(0)
 
         maintainer_name: str = (
-            args.maintainer_name 
-            or get_git_config('user.name') 
+            args.maintainer_name
+            or get_git_config('user.name')
             or getpass.getuser())
         maintainer = Person(maintainer_name)
         maintainer.email = (
-            args.maintainer_email 
-            or get_git_config('user.email') 
+            args.maintainer_email
+            or get_git_config('user.email')
             or f"{maintainer.name.replace(' ', '')}@todo.todo")
 
         node_name = None

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Optional
 
 import ament_copyright
 
@@ -90,7 +91,7 @@ class CreateVerb(VerbExtension):
 
     def main(self, *, args):
 
-        def get_git_config(key: str) -> str | None:
+        def get_git_config(key: str) -> Optional[str]:
             # retrieve a value from git config
             git = shutil.which('git')
             if git is not None:

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -79,7 +79,7 @@ class CreateVerb(VerbExtension):
             '--maintainer-email',
             help='email address of the maintainer of this package'),
         parser.add_argument(
-            '--maintainer-name', default=getpass.getuser(),
+            '--maintainer-name',
             help='name of the maintainer of this package'),
         parser.add_argument(
             '--node-name',
@@ -97,13 +97,29 @@ class CreateVerb(VerbExtension):
             print('Supported licenses:\n%s' % ('\n'.join(available_licenses)))
             sys.exit(0)
 
-        maintainer = Person(args.maintainer_name)
+        git = shutil.which('git')
+
+        if args.maintainer_name:
+            maintainer_name = args.maintainer_name
+        else:
+            # try getting the name from the global git config
+            if git is not None:
+                p = subprocess.Popen(
+                    [git, 'config', 'user.name'],
+                    stdout=subprocess.PIPE)
+                resp = p.communicate()
+                name = resp[0].decode().rstrip()
+                if name:
+                    maintainer_name = name
+            if not maintainer_name:
+                maintainer_name = getpass.getuser()
+
+        maintainer = Person(maintainer_name)
 
         if args.maintainer_email:
             maintainer.email = args.maintainer_email
         else:
             # try getting the email from the global git config
-            git = shutil.which('git')
             if git is not None:
                 p = subprocess.Popen(
                     [git, 'config', 'user.email'],

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -87,7 +87,7 @@ class CreateVerb(VerbExtension):
         parser.add_argument(
             '--library-name',
             help='name of the empty library')
-        
+
     def main(self, *, args):
 
         def get_git_config(key: str) -> str | None:
@@ -112,9 +112,15 @@ class CreateVerb(VerbExtension):
             print('Supported licenses:\n%s' % ('\n'.join(available_licenses)))
             sys.exit(0)
 
-        maintainer_name: str = args.maintainer_name or get_git_config('user.name') or getpass.getuser()
+        maintainer_name: str = (
+            args.maintainer_name 
+            or get_git_config('user.name') 
+            or getpass.getuser())
         maintainer = Person(maintainer_name)
-        maintainer.email = args.maintainer_email or get_git_config('user.email') or f"{maintainer.name.replace(' ', '')}@todo.todo"
+        maintainer.email = (
+            args.maintainer_email 
+            or get_git_config('user.email') 
+            or f"{maintainer.name.replace(' ', '')}@todo.todo")
 
         node_name = None
         library_name = None

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -87,8 +87,23 @@ class CreateVerb(VerbExtension):
         parser.add_argument(
             '--library-name',
             help='name of the empty library')
-
+        
     def main(self, *, args):
+
+        def get_git_config(key: str) -> str | None:
+            # retrieve a value from git config
+            git = shutil.which('git')
+            if git is not None:
+                result = subprocess.run(
+                    [git, 'config', key],
+                    stdout=subprocess.PIPE,
+                    text=True
+                )
+                value = result.stdout.strip()
+                if value:
+                    return value
+            return None
+
         available_licenses = {}
         for shortname, entry in ament_copyright.get_licenses().items():
             available_licenses[entry.spdx] = entry.license_files
@@ -97,39 +112,9 @@ class CreateVerb(VerbExtension):
             print('Supported licenses:\n%s' % ('\n'.join(available_licenses)))
             sys.exit(0)
 
-        git = shutil.which('git')
-
-        if args.maintainer_name:
-            maintainer_name = args.maintainer_name
-        else:
-            # try getting the name from the global git config
-            if git is not None:
-                p = subprocess.Popen(
-                    [git, 'config', 'user.name'],
-                    stdout=subprocess.PIPE)
-                resp = p.communicate()
-                name = resp[0].decode().rstrip()
-                if name:
-                    maintainer_name = name
-            if not maintainer_name:
-                maintainer_name = getpass.getuser()
-
+        maintainer_name: str = args.maintainer_name or get_git_config('user.name') or getpass.getuser()
         maintainer = Person(maintainer_name)
-
-        if args.maintainer_email:
-            maintainer.email = args.maintainer_email
-        else:
-            # try getting the email from the global git config
-            if git is not None:
-                p = subprocess.Popen(
-                    [git, 'config', 'user.email'],
-                    stdout=subprocess.PIPE)
-                resp = p.communicate()
-                email = resp[0].decode().rstrip()
-                if email:
-                    maintainer.email = email
-            if not maintainer.email:
-                maintainer.email = maintainer.name + '@todo.todo'
+        maintainer.email = args.maintainer_email or get_git_config('user.email') or f"{maintainer.name.replace(' ', '')}@todo.todo"
 
         node_name = None
         library_name = None


### PR DESCRIPTION
Add code for "ros2 pkg create" so that the first default for the maintainer-name is the git user.name, which is likely a full name, instead of first using an OS login name. This creates more consistency, because the maintainer-email already defaults to the git user.email.