### PR TITLE
Update minimum CMake version in CMakeLists.txt.em

### DIFF
--- a/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(@(project_name))
 
 set(@(project_name)_MAJOR_VERSION 0)


### PR DESCRIPTION
There are now deprecation warnings if you use CMake minimum version less than 3.10, so this needs to be updated.

Since Ubuntu 20.04 (Tier 3 support on Humble) uses CMake 3.16 by default, this seems like a safe minimum?

Please backport to the other active distros!