### PR TITLE
Hz verb: Warn users about wrong reported freq

### DIFF
--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -93,7 +93,7 @@ def main(args):
     else:
         filter_expr = None
     print('Reported frequency might not be accurate! https://github.com/ros2/ros2cli/issues/871')
-    
+
     with DirectNode(args) as node:
         _rostopic_hz(node.node, topics, window_size=args.window_size, filter_expr=filter_expr,
                      use_wtime=args.use_wtime)

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -92,7 +92,8 @@ def main(args):
         filter_expr = expr_eval(args.filter_expr)
     else:
         filter_expr = None
-
+    print('Reported frequency might not be accurate! https://github.com/ros2/ros2cli/issues/871')
+    
     with DirectNode(args) as node:
         _rostopic_hz(node.node, topics, window_size=args.window_size, filter_expr=filter_expr,
                      use_wtime=args.use_wtime)


### PR DESCRIPTION
I think enough users have wasted time with this tool and I hope to be the last one.

https://github.com/ros2/ros2cli/issues/871
https://github.com/ros2/ros2cli/issues/843
https://robotics.stackexchange.com/questions/95613/ros2-topic-hz-provides-wrong-rate-for-larger-msgs

Please notify me if that modification is ok for you and I'll fix the tests