### PR TITLE
Use target_link_libraries instead of ament_target_dependencies

### DIFF
--- a/ros2lifecycle_test_fixtures/CMakeLists.txt
+++ b/ros2lifecycle_test_fixtures/CMakeLists.txt
@@ -19,8 +19,8 @@ find_package(rclcpp REQUIRED)
 add_executable(simple_lifecycle_node
   src/simple_lifecycle_node.cpp)
 
-ament_target_dependencies(simple_lifecycle_node
-  "rclcpp_lifecycle")
+target_link_libraries(simple_lifecycle_node PRIVATE
+  rclcpp_lifecycle::rclcpp_lifecycle)
 
 install(TARGETS
   simple_lifecycle_node

--- a/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
@@ -28,10 +28,10 @@ target_include_directories(@(cpp_library_name) PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 @[  if dependencies]@
-ament_target_dependencies(
+target_link_libraries(
   @(cpp_library_name)
 @[    for dep in dependencies]@
-  "@(dep)"
+  ${@(dep)_TARGETS}
 @[    end for]@
 )
 @[  end if]@
@@ -63,10 +63,10 @@ target_link_libraries(@(cpp_node_name) @(cpp_library_name))
 @[  else]@
 target_compile_features(@(cpp_node_name) PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 @[    if dependencies]@
-ament_target_dependencies(
+target_link_libraries(
   @(cpp_node_name)
 @[      for dep in dependencies]@
-  "@(dep)"
+  ${@(dep)_TARGETS}
 @[      end for]@
 )
 @[    end if]@

--- a/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/ament_cmake/CMakeLists.txt.em
@@ -29,7 +29,7 @@ target_include_directories(@(cpp_library_name) PUBLIC
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 @[  if dependencies]@
 target_link_libraries(
-  @(cpp_library_name)
+  @(cpp_library_name) PUBLIC
 @[    for dep in dependencies]@
   ${@(dep)_TARGETS}
 @[    end for]@


### PR DESCRIPTION
This shows one weakness of `target_link_libraries`: the target names are not automatically known. `ament_cmake` packages create a `_TARGETS` variable,  so this CL makes the new `ament_cmake` package script use that. There might be cases where a new package depending on a plain cmake library would have worked before with `ament_target_dependencies()`, but does not work with this change.

I think using pure CMake here is worth it because we can point users to CMake docs instead of our own, but I'm open to feedback.

https://github.com/ament/ament_cmake/issues/292