### PR TITLE
* ros2pkg/resource/cpp/main.cpp.em: Use modern C++17 syntax.

### DIFF
--- a/ros2pkg/ros2pkg/resource/cpp/main.cpp.em
+++ b/ros2pkg/ros2pkg/resource/cpp/main.cpp.em
@@ -1,10 +1,6 @@
 #include <cstdio>
 
-int main(int argc, char ** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char ** argv)
 {
-  (void) argc;
-  (void) argv;
-
   printf("hello world @(package_name) package\n");
-  return 0;
 }


### PR DESCRIPTION
According to <https://github.com/shynur/ros2cli/blob/889fba5171393aae9b9577a1dc2b8cea8fc39a3f/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em#L29>, we use C++17 or higher standard.

- `[[maybe_unused]]` is a C++17 attribute, which is more portable.
- `return 0;` is unnecessary in C++, which can be removed to save space.