### PR TITLE
Allow space or empty strings when using ros2 param set.

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -91,7 +91,7 @@ def get_parameter_value(*, string_value):
             value.string_value = string_value
     else:
         value.type = ParameterType.PARAMETER_STRING
-        value.string_value = yaml_value
+        value.string_value = yaml_value if yaml_value is not None else string_value
     return value
 
 

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -36,6 +36,8 @@ from ros2param.api import get_parameter_value
         ('1.1234', ParameterType.PARAMETER_DOUBLE, 'double_value', 1.1234),
 
         ('foo', ParameterType.PARAMETER_STRING, 'string_value', 'foo'),
+        (' ', ParameterType.PARAMETER_STRING, 'string_value', ' '),
+        ('', ParameterType.PARAMETER_STRING, 'string_value', ''),
         (
             '[false, true]',
             ParameterType.PARAMETER_BOOL_ARRAY,


### PR DESCRIPTION
closes https://github.com/ros2/ros2cli/issues/960

this is humble backport of https://github.com/ros2/rclpy/pull/1093