### PR TITLE
Custom Completion Finder for fetching topic prototype.

### DIFF
--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -14,9 +14,10 @@
 
 from argparse import ArgumentParser
 from argparse import ArgumentTypeError
-import sys
 from time import sleep
 from typing import Optional
+
+from argcomplete import CompletionFinder
 
 import rclpy
 
@@ -31,7 +32,6 @@ from ros2cli.node.strategy import NodeStrategy
 from rosidl_runtime_py import get_message_interfaces
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message
-import yaml
 
 
 def positive_int(string):
@@ -163,6 +163,17 @@ def _get_msg_class(node, topic, include_hidden_topics):
         raise RuntimeError("The message type '%s' is invalid" % message_type)
 
 
+class YamlCompletionFinder(CompletionFinder):
+    def quote_completions(
+        self, completions: list[str],
+            cword_prequote: str, last_wordbreak_pos: Optional[int]):
+
+        # For YAML content, return as-is without escaping
+        if not any('-' in c for c in completions):
+            return completions
+        return super().quote_completions(completions, cword_prequote, last_wordbreak_pos)
+
+
 class TopicMessagePrototypeCompleter:
     """Callable returning a message prototype."""
 
@@ -171,16 +182,8 @@ class TopicMessagePrototypeCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         message = get_message(getattr(parsed_args, self.topic_type_key))
-
-        # yaml string needs to be dumped twice
-        # as argcomplete escapes characters
-        yaml_snippet = message_to_yaml(message())
-
-        topic_prototype = yaml.dump(
-            yaml_snippet, allow_unicode=False,
-            width=sys.maxsize, default_flow_style=False)
-
-        return [topic_prototype]
+        yaml_snippet = "'" + message_to_yaml(message()) + "'"
+        return [yaml_snippet]
 
 
 def profile_configure_short_keys(

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -14,6 +14,7 @@
 
 from argparse import ArgumentParser
 from argparse import ArgumentTypeError
+import sys
 from time import sleep
 from typing import Optional
 
@@ -30,6 +31,7 @@ from ros2cli.node.strategy import NodeStrategy
 from rosidl_runtime_py import get_message_interfaces
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message
+import yaml
 
 
 def positive_int(string):
@@ -169,7 +171,16 @@ class TopicMessagePrototypeCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         message = get_message(getattr(parsed_args, self.topic_type_key))
-        return [message_to_yaml(message())]
+
+        # yaml string needs to be dumped twice
+        # as argcomplete escapes characters
+        yaml_snippet = message_to_yaml(message())
+
+        topic_prototype = yaml.dump(
+            yaml_snippet, allow_unicode=False,
+            width=sys.maxsize, default_flow_style=False)
+
+        return [topic_prototype]
 
 
 def profile_configure_short_keys(

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -173,7 +173,19 @@ def publisher(
     if yaml_file:
         msg_reader = read_msg_from_yaml(yaml_file)
     else:
-        values_dictionary = yaml.safe_load(values)
+        try:
+            values_string = yaml.safe_load(values)
+
+            # Values need to be loaded in yaml twice due
+            #   to packaging in TopicMessagePrototypeCompleter
+            if not isinstance(values_string, dict):
+                values_dictionary = yaml.safe_load(values_string)
+            else:
+                values_dictionary = values_string
+
+        except yaml.parser.ParserError:
+            return 'The passed value needs to be in YAML string or a dictionary'
+
         if not isinstance(values_dictionary, dict):
             return 'The passed value needs to be a dictionary in YAML format'
 

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -16,6 +16,8 @@ import time
 from typing import Optional
 from typing import TypeVar
 
+import argcomplete
+
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
@@ -25,7 +27,7 @@ from ros2cli.node.direct import DirectNode
 from ros2topic.api import add_qos_arguments
 from ros2topic.api import positive_float
 from ros2topic.api import profile_configure_short_keys
-from ros2topic.api import TopicMessagePrototypeCompleter
+from ros2topic.api import TopicMessagePrototypeCompleter, YamlCompletionFinder
 from ros2topic.api import TopicNameCompleter
 from ros2topic.api import TopicTypeCompleter
 from ros2topic.verb import VerbExtension
@@ -108,6 +110,10 @@ class PubVerb(VerbExtension):
         parser.add_argument(
             '-n', '--node-name',
             help='Name of the created publishing node')
+
+        # Use the custom completion finder
+        argcomplete.autocomplete = YamlCompletionFinder(parser)
+
         add_qos_arguments(parser, 'publish', 'default')
         add_direct_node_arguments(parser)
 
@@ -174,16 +180,14 @@ def publisher(
         msg_reader = read_msg_from_yaml(yaml_file)
     else:
         try:
-            values_string = yaml.safe_load(values)
+            # Handle cases where the user pastes the autocompleted bash safe string
+            if '^J' in values:
+                values = values.replace("'", '')
+                values = values.replace('^J', '\n')
 
-            # Values need to be loaded in yaml twice due
-            #   to packaging in TopicMessagePrototypeCompleter
-            if not isinstance(values_string, dict):
-                values_dictionary = yaml.safe_load(values_string)
-            else:
-                values_dictionary = values_string
+            values_dictionary = yaml.safe_load(values)
 
-        except yaml.parser.ParserError:
+        except (yaml.parser.ParserError, yaml.scanner.ScannerError):
             return 'The passed value needs to be in YAML string or a dictionary'
 
         if not isinstance(values_dictionary, dict):


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #742  |
| Primary OS tested on | Ubuntu |

## Description

* This fixes the autocompletion feature in `ros2 pub <topic_name> <topic_type> <topic_message_prototype>`.
* This addresses the change of escape characters in the YAML message introduced by `argcomplete`.

## Issue explanation

* Let's take an example of publishing command velocity using the current state of the CLI tool:

   ```bash
   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist linear:\
   \ \ x:\ 0.0\
   \ \ y:\ 0.0\
   \ \ z:\ 0.0\
   angular:\
   \ \ x:\ 0.0\
   \ \ y:\ 0.0\
   \ \ z:\ 0.0\ 
   ```
   This is equivalent to the following:
   ```bash
   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist linear:\ \ x:\ 0.0\ \ y:\ 0.0\ \ z:\ 0.0angular:\ \ x:\ 0.0\ \ y:\ 0.0\ \ z:\ 0.0\ 
   ```   
   As you can see,  `argcomplete` ignores all the newline characters in the yaml string. Hence, this cannot be loaded as a yaml string, and the publishing fails.

* The yaml message being passed onto the topic message prototype has the correct formatted yaml string:

   ```yaml
   """linear:
     x: 0.0
     y: 0.0
     z: 0.0
   angular:
     x: 0.0
     y: 0.0
     z: 0.0"""
     ```

   However, `argcomplete` only recognises spaces and replaces each space with `\ `. This explains the two spaces for each field of linear and angular due to its indent. However, important information such as newline characters are ignored.
   
* Therefore, a solution could be to explicitly specify the newline characters wherever required. This can be done by using `yaml.dump()` on the [yaml string](https://github.com/ros2/ros2cli/pull/995/files#diff-1718b9c985edbb391576d8e899c8ceb2c2281eeb0c5bf57de70fdd953e6dc980R179-R182):

   ```yaml
   "linear:\n  x: 0.0\n  y: 0.0\n  z: 0.0\nangular:\n  x: 0.0\n  y: 0.0\n  z: 0.0\n"
   ```
   Hence, while parsing the resulting message, we have to load the string [twice](https://github.com/ros2/ros2cli/pull/995/files#diff-e731586fd641d2de9335f8e2094f2ad1f7bec0c40206deb65564d6cff1aa65e7R175-R176) in order to capture the dictionary.
   
## Results - Double YAML encoding
 
* `argcomplete` attaches an additional backslash for every escape character except space. Hence, an additional backslash is found on double quotes and the newline character:

   ```bash
   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist \"linear:\\n\ \ x:\ 0.0\\n\ \ y:\ 0.0\\n\ \ z:\ 0.0\\nangular:\\n\ \ x:\ 
   0.0\\n\ \ y:\ 0.0\\n\ \ z:\ 0.0\\n\"\ 
   ```
 * Support for dictionary strings is still supported:
 
    ```bash
   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}"
   ```
   
## Edit - Custom Completion Finder

Upon the suggestions made by @fujitatomoya, I have used a custom completion finder which returns the YAML strings unformatted.

## Testing

* This is the autocomplete option suggested by `ros2 topic pub /cmd_vel geometry_msgs/msg/Twist <TAB>`:

   ```bash
   \'linear:\^J\ \ x:\ 0.0\^J\ \ y:\ 0.0\^J\ \ z:\ 0.0\^Jangular:\^J\ \ x:\ 0.0\^J\ \ y:\ 0.0\^J\ \ z:\ 0.0\^J\'
   ```   
* In order to trigger the multi-line string autocomplete, you need to following:

   ```bash
   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist \'<TAB>
   ```   
   This gives the below output:
   
   ```bash
   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist 'linear:
     x: 0.0
     y: 0.0
     z: 0.0
   angular:
     x: 0.0
     y: 0.0
     z: 1.0
   ' 
  ```

* This provides support when the user pastes the autocompleted bash safe string as well:

   ```bash
   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist \'linear:\^J\ \ x:\ 0.0\^J\ \ y:\ 0.0\^J\ \ z:\ 0.0\^Jangular:\^J\ \ x:\ 0.0\^J\ \ y:\ 0.0\^J\ \ z:\ 0.0\^J\'
   ``` 
  
* This still provides support to standardised YAML strings. 

    ```bash
   ros2 topic pub /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.0, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}"
   ```
   