### PR TITLE
Enable `ros2 topic echo` with entries of array fields

### DIFF
--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -226,7 +226,7 @@ class EchoVerb(VerbExtension):
                             submsg = getattr(submsg, field)
                         else:
                             submsg = submsg[int(match.group(1))]
-                    except (AttributeError, TypeError, IndexError) as ex:
+                    except (AttributeError, IndexError, TypeError, ValueError) as ex:
                         raise RuntimeError(f"Invalid field '{'.'.join(fields)}': {ex}")
                 submsgs.append(submsg)
         else:

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -19,25 +19,21 @@ import rclpy
 from rclpy.event_handler import SubscriptionEventCallbacks
 from rclpy.event_handler import UnsupportedEventTypeError
 from rclpy.node import Node
-from rclpy.qos import QoSDurabilityPolicy
-from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
-from rclpy.qos import QoSReliabilityPolicy
 from rclpy.task import Future
 from ros2cli.helpers import unsigned_int
 from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import add_qos_arguments
+from ros2topic.api import choose_qos
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_float
-from ros2topic.api import qos_profile_from_short_keys
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message
 
-import re
 import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
@@ -58,7 +54,9 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             'message_type', nargs='?',
             help="Type of the ROS message (e.g. 'std_msgs/msg/String')")
-        add_qos_arguments(parser, 'subscribe', 'sensor_data')
+        add_qos_arguments(
+            parser, 'subscribe', 'sensor_data',
+            ' / compatible profile with running endpoints')
         parser.add_argument(
             '--csv', action='store_true',
             help=(
@@ -70,7 +68,7 @@ class EchoVerb(VerbExtension):
             )
         )
         parser.add_argument(
-            '--field', type=str, default=None,
+            '--field', action='append', type=str, default=None,
             help='Echo a selected field of a message. '
                  "Use '.' to select sub-fields. "
                  'For example, to echo the position field of a nav_msgs/msg/Odometry message: '
@@ -108,84 +106,33 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             '--include-message-info', '-i', action='store_true',
             help='Shows the associated message info.')
-
-    def choose_qos(self, node, args):
-
-        if (args.qos_reliability is not None or
-                args.qos_durability is not None or
-                args.qos_depth is not None or
-                args.qos_history is not None or
-                args.qos_liveliness is not None or
-                args.qos_liveliness_lease_duration_seconds is not None):
-
-            return qos_profile_from_short_keys(
-                args.qos_profile,
-                reliability=args.qos_reliability,
-                durability=args.qos_durability,
-                depth=args.qos_depth,
-                history=args.qos_history,
-                liveliness=args.qos_liveliness,
-                liveliness_lease_duration_s=args.qos_liveliness_lease_duration_seconds)
-
-        qos_profile = QoSPresetProfiles.get_from_short_key(args.qos_profile)
-        reliability_reliable_endpoints_count = 0
-        durability_transient_local_endpoints_count = 0
-
-        pubs_info = node.get_publishers_info_by_topic(args.topic_name)
-        publishers_count = len(pubs_info)
-        if publishers_count == 0:
-            return qos_profile
-
-        for info in pubs_info:
-            if (info.qos_profile.reliability == QoSReliabilityPolicy.RELIABLE):
-                reliability_reliable_endpoints_count += 1
-            if (info.qos_profile.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL):
-                durability_transient_local_endpoints_count += 1
-
-        # If all endpoints are reliable, ask for reliable
-        if reliability_reliable_endpoints_count == publishers_count:
-            qos_profile.reliability = QoSReliabilityPolicy.RELIABLE
-        else:
-            if reliability_reliable_endpoints_count > 0:
-                print(
-                    'Some, but not all, publishers are offering '
-                    'QoSReliabilityPolicy.RELIABLE. Falling back to '
-                    'QoSReliabilityPolicy.BEST_EFFORT as it will connect '
-                    'to all publishers'
-                )
-            qos_profile.reliability = QoSReliabilityPolicy.BEST_EFFORT
-
-        # If all endpoints are transient_local, ask for transient_local
-        if durability_transient_local_endpoints_count == publishers_count:
-            qos_profile.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
-        else:
-            if durability_transient_local_endpoints_count > 0:
-                print(
-                    'Some, but not all, publishers are offering '
-                    'QoSDurabilityPolicy.TRANSIENT_LOCAL. Falling back to '
-                    'QoSDurabilityPolicy.VOLATILE as it will connect '
-                    'to all publishers'
-                )
-            qos_profile.durability = QoSDurabilityPolicy.VOLATILE
-
-        return qos_profile
+        parser.add_argument(
+            '--clear', '-c', action='store_true',
+            help='Clear screen before printing next message')
+        parser.add_argument(
+            '-n', '--node-name', type=str, default=None,
+            help='The name of the echoing node; by default, will be a hidden node name')
 
     def main(self, *, args):
 
         self.csv = args.csv
 
         # Validate field selection
-        self.field = args.field
-        if self.field is not None:
-            self.field = list(filter(None, self.field.split('.')))
-            if not self.field:
-                raise RuntimeError(f"Invalid field value '{args.field}'")
+        self.fields_list = []
+        if args.field:
+            for field in args.field:
+                if field is not None:
+                    field_filtered = list(filter(None, field.split('.')))
+                    self.fields_list.append(field_filtered)
+                    if not field_filtered:
+                        raise RuntimeError(f"Invalid field value '{field}'")
 
         self.truncate_length = args.truncate_length if not args.full_length else None
         self.no_arr = args.no_arr
         self.no_str = args.no_str
         self.flow_style = args.flow_style
         self.once = args.once
+        self.clear_screen = args.clear
 
         self.filter_fn = None
         if args.filter_expr:
@@ -197,9 +144,9 @@ class EchoVerb(VerbExtension):
 
         self.include_message_info = args.include_message_info
 
-        with NodeStrategy(args) as node:
+        with NodeStrategy(args, node_name=args.node_name) as node:
 
-            qos_profile = self.choose_qos(node, args)
+            qos_profile = choose_qos(node, topic_name=args.topic_name, qos_args=args)
 
             if args.message_type is None:
                 message_type = get_msg_class(
@@ -266,53 +213,67 @@ class EchoVerb(VerbExtension):
         self.future.set_result(True)
 
     def _subscriber_callback(self, msg, info):
-        submsg = msg
-        if self.field is not None:
-            for field in self.field:
-                is_indexing = re.compile(r"^\[(\d+)\]$")
-                match = is_indexing.match(field)
-                try:
-                    if match is None:
+        submsgs = []
+        if self.fields_list:
+            for fields in self.fields_list:
+                submsg = msg
+                for field in fields:
+                    try:
                         submsg = getattr(submsg, field)
-                    else:
-                        submsg = submsg[int(match.group(1))]
-                except (AttributeError, TypeError, IndexError) as ex:
-                    raise RuntimeError(f"Invalid field '{'.'.join(self.field)}': {ex}")
+                    except AttributeError as ex:
+                        raise RuntimeError(f"Invalid field '{'.'.join(fields)}': {ex}")
+                submsgs.append(submsg)
+        else:
+            submsgs.append(msg)
 
         # Evaluate the current msg against the supplied expression
-        if self.filter_fn is not None and not self.filter_fn(submsg):
-            return
+        if self.filter_fn is not None:
+            for submsg in submsgs:
+                if not self.filter_fn(submsg):
+                    submsgs.remove(submsg)
+            if not submsgs:
+                return
 
         if self.future is not None and self.once:
             self.future.set_result(True)
 
-        if not hasattr(submsg, '__slots__'):
-            # raw
-            if self.include_message_info:
-                print('---Got new message, message info:---')
-                print(info)
-                print('---Message data:---')
-            print(submsg, end='\n---\n')
-            return
+        # Clear terminal screen before print
+        if self.clear_screen:
+            clear_terminal()
 
-        if self.csv:
-            to_print = message_to_csv(
-                submsg,
-                truncate_length=self.truncate_length,
-                no_arr=self.no_arr,
-                no_str=self.no_str)
+        for i, submsg in enumerate(submsgs):
+            if i == len(submsgs)-1:
+                line_end = '---\n'
+            else:
+                line_end = ''
+            if not hasattr(submsg, '__slots__'):
+                # raw
+                if self.include_message_info:
+                    print('---Got new message, message info:---')
+                    print(info)
+                    print('---Message data:---')
+                line_end = '\n' + line_end
+                print(submsg, end=line_end)
+                continue
+
+            if self.csv:
+                to_print = message_to_csv(
+                    submsg,
+                    truncate_length=self.truncate_length,
+                    no_arr=self.no_arr,
+                    no_str=self.no_str)
+                if self.include_message_info:
+                    to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
+                print(to_print)
+                continue
+            # yaml
             if self.include_message_info:
-                to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
-            print(to_print)
-            return
-        # yaml
-        if self.include_message_info:
-            print(yaml.dump(info), end='---\n')
-        print(
-            message_to_yaml(
-                submsg, truncate_length=self.truncate_length,
-                no_arr=self.no_arr, no_str=self.no_str, flow_style=self.flow_style),
-            end='---\n')
+                print(yaml.dump(info), end=line_end)
+            print(
+                message_to_yaml(
+                    submsg, truncate_length=self.truncate_length,
+                    no_arr=self.no_arr, no_str=self.no_str, flow_style=self.flow_style),
+                end=line_end)
 
 
 def _expr_eval(expr):
@@ -328,3 +289,7 @@ def _message_lost_event_callback(message_lost_status):
         f'\n\ttotal count: {message_lost_status.total_count}',
         end='---\n'
     )
+
+
+def clear_terminal():
+    print('\x1b[H\x1b[2J')

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -227,7 +227,7 @@ class EchoVerb(VerbExtension):
                         else:
                             submsg = submsg[int(match.group(1))]
                     except (AttributeError, TypeError, IndexError) as ex:
-                        raise RuntimeError(f"Invalid field '{'.'.join(self.field)}': {ex}")
+                        raise RuntimeError(f"Invalid field '{'.'.join(fields)}': {ex}")
                 submsgs.append(submsg)
         else:
             submsgs.append(msg)

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -218,10 +218,12 @@ class EchoVerb(VerbExtension):
     def _subscriber_callback(self, msg, info):
         submsgs = []
         if self.fields_list:
+            # Matches strings exactly in the format "[digits]" (e.g., "[123]")
+            # and captures the digits as a group
+            is_indexing = re.compile(r'^\[(\d+)\]$')
             for fields in self.fields_list:
                 submsg = msg
                 for field in fields:
-                    is_indexing = re.compile(r'^\[(\d+)\]$')
                     match = is_indexing.match(field)
                     try:
                         if match is None:

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -34,6 +34,7 @@ from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message
 
+import re
 import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
@@ -218,10 +219,15 @@ class EchoVerb(VerbExtension):
             for fields in self.fields_list:
                 submsg = msg
                 for field in fields:
+                    is_indexing = re.compile(r"^\[(\d+)\]$")
+                    match = is_indexing.match(field)
                     try:
-                        submsg = getattr(submsg, field)
-                    except AttributeError as ex:
-                        raise RuntimeError(f"Invalid field '{'.'.join(fields)}': {ex}")
+                        if match is None:
+                            submsg = getattr(submsg, field)
+                        else:
+                            submsg = submsg[int(match.group(1))]
+                    except (AttributeError, TypeError, IndexError) as ex:
+                        raise RuntimeError(f"Invalid field '{'.'.join(self.field)}': {ex}")
                 submsgs.append(submsg)
         else:
             submsgs.append(msg)

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -19,21 +19,25 @@ import rclpy
 from rclpy.event_handler import SubscriptionEventCallbacks
 from rclpy.event_handler import UnsupportedEventTypeError
 from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
 from rclpy.task import Future
 from ros2cli.helpers import unsigned_int
 from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
 from ros2cli.node.strategy import NodeStrategy
 from ros2topic.api import add_qos_arguments
-from ros2topic.api import choose_qos
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_float
+from ros2topic.api import qos_profile_from_short_keys
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message
 
+import re
 import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
@@ -54,9 +58,7 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             'message_type', nargs='?',
             help="Type of the ROS message (e.g. 'std_msgs/msg/String')")
-        add_qos_arguments(
-            parser, 'subscribe', 'sensor_data',
-            ' / compatible profile with running endpoints')
+        add_qos_arguments(parser, 'subscribe', 'sensor_data')
         parser.add_argument(
             '--csv', action='store_true',
             help=(
@@ -68,7 +70,7 @@ class EchoVerb(VerbExtension):
             )
         )
         parser.add_argument(
-            '--field', action='append', type=str, default=None,
+            '--field', type=str, default=None,
             help='Echo a selected field of a message. '
                  "Use '.' to select sub-fields. "
                  'For example, to echo the position field of a nav_msgs/msg/Odometry message: '
@@ -106,33 +108,84 @@ class EchoVerb(VerbExtension):
         parser.add_argument(
             '--include-message-info', '-i', action='store_true',
             help='Shows the associated message info.')
-        parser.add_argument(
-            '--clear', '-c', action='store_true',
-            help='Clear screen before printing next message')
-        parser.add_argument(
-            '-n', '--node-name', type=str, default=None,
-            help='The name of the echoing node; by default, will be a hidden node name')
+
+    def choose_qos(self, node, args):
+
+        if (args.qos_reliability is not None or
+                args.qos_durability is not None or
+                args.qos_depth is not None or
+                args.qos_history is not None or
+                args.qos_liveliness is not None or
+                args.qos_liveliness_lease_duration_seconds is not None):
+
+            return qos_profile_from_short_keys(
+                args.qos_profile,
+                reliability=args.qos_reliability,
+                durability=args.qos_durability,
+                depth=args.qos_depth,
+                history=args.qos_history,
+                liveliness=args.qos_liveliness,
+                liveliness_lease_duration_s=args.qos_liveliness_lease_duration_seconds)
+
+        qos_profile = QoSPresetProfiles.get_from_short_key(args.qos_profile)
+        reliability_reliable_endpoints_count = 0
+        durability_transient_local_endpoints_count = 0
+
+        pubs_info = node.get_publishers_info_by_topic(args.topic_name)
+        publishers_count = len(pubs_info)
+        if publishers_count == 0:
+            return qos_profile
+
+        for info in pubs_info:
+            if (info.qos_profile.reliability == QoSReliabilityPolicy.RELIABLE):
+                reliability_reliable_endpoints_count += 1
+            if (info.qos_profile.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL):
+                durability_transient_local_endpoints_count += 1
+
+        # If all endpoints are reliable, ask for reliable
+        if reliability_reliable_endpoints_count == publishers_count:
+            qos_profile.reliability = QoSReliabilityPolicy.RELIABLE
+        else:
+            if reliability_reliable_endpoints_count > 0:
+                print(
+                    'Some, but not all, publishers are offering '
+                    'QoSReliabilityPolicy.RELIABLE. Falling back to '
+                    'QoSReliabilityPolicy.BEST_EFFORT as it will connect '
+                    'to all publishers'
+                )
+            qos_profile.reliability = QoSReliabilityPolicy.BEST_EFFORT
+
+        # If all endpoints are transient_local, ask for transient_local
+        if durability_transient_local_endpoints_count == publishers_count:
+            qos_profile.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
+        else:
+            if durability_transient_local_endpoints_count > 0:
+                print(
+                    'Some, but not all, publishers are offering '
+                    'QoSDurabilityPolicy.TRANSIENT_LOCAL. Falling back to '
+                    'QoSDurabilityPolicy.VOLATILE as it will connect '
+                    'to all publishers'
+                )
+            qos_profile.durability = QoSDurabilityPolicy.VOLATILE
+
+        return qos_profile
 
     def main(self, *, args):
 
         self.csv = args.csv
 
         # Validate field selection
-        self.fields_list = []
-        if args.field:
-            for field in args.field:
-                if field is not None:
-                    field_filtered = list(filter(None, field.split('.')))
-                    self.fields_list.append(field_filtered)
-                    if not field_filtered:
-                        raise RuntimeError(f"Invalid field value '{field}'")
+        self.field = args.field
+        if self.field is not None:
+            self.field = list(filter(None, self.field.split('.')))
+            if not self.field:
+                raise RuntimeError(f"Invalid field value '{args.field}'")
 
         self.truncate_length = args.truncate_length if not args.full_length else None
         self.no_arr = args.no_arr
         self.no_str = args.no_str
         self.flow_style = args.flow_style
         self.once = args.once
-        self.clear_screen = args.clear
 
         self.filter_fn = None
         if args.filter_expr:
@@ -144,9 +197,9 @@ class EchoVerb(VerbExtension):
 
         self.include_message_info = args.include_message_info
 
-        with NodeStrategy(args, node_name=args.node_name) as node:
+        with NodeStrategy(args) as node:
 
-            qos_profile = choose_qos(node, topic_name=args.topic_name, qos_args=args)
+            qos_profile = self.choose_qos(node, args)
 
             if args.message_type is None:
                 message_type = get_msg_class(
@@ -213,67 +266,53 @@ class EchoVerb(VerbExtension):
         self.future.set_result(True)
 
     def _subscriber_callback(self, msg, info):
-        submsgs = []
-        if self.fields_list:
-            for fields in self.fields_list:
-                submsg = msg
-                for field in fields:
-                    try:
+        submsg = msg
+        if self.field is not None:
+            for field in self.field:
+                is_indexing = re.compile(r"^\[(\d+)\]$")
+                match = is_indexing.match(field)
+                try:
+                    if match is None:
                         submsg = getattr(submsg, field)
-                    except AttributeError as ex:
-                        raise RuntimeError(f"Invalid field '{'.'.join(fields)}': {ex}")
-                submsgs.append(submsg)
-        else:
-            submsgs.append(msg)
+                    else:
+                        submsg = submsg[int(match.group(1))]
+                except (AttributeError, TypeError, IndexError) as ex:
+                    raise RuntimeError(f"Invalid field '{'.'.join(self.field)}': {ex}")
 
         # Evaluate the current msg against the supplied expression
-        if self.filter_fn is not None:
-            for submsg in submsgs:
-                if not self.filter_fn(submsg):
-                    submsgs.remove(submsg)
-            if not submsgs:
-                return
+        if self.filter_fn is not None and not self.filter_fn(submsg):
+            return
 
         if self.future is not None and self.once:
             self.future.set_result(True)
 
-        # Clear terminal screen before print
-        if self.clear_screen:
-            clear_terminal()
-
-        for i, submsg in enumerate(submsgs):
-            if i == len(submsgs)-1:
-                line_end = '---\n'
-            else:
-                line_end = ''
-            if not hasattr(submsg, '__slots__'):
-                # raw
-                if self.include_message_info:
-                    print('---Got new message, message info:---')
-                    print(info)
-                    print('---Message data:---')
-                line_end = '\n' + line_end
-                print(submsg, end=line_end)
-                continue
-
-            if self.csv:
-                to_print = message_to_csv(
-                    submsg,
-                    truncate_length=self.truncate_length,
-                    no_arr=self.no_arr,
-                    no_str=self.no_str)
-                if self.include_message_info:
-                    to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
-                print(to_print)
-                continue
-            # yaml
+        if not hasattr(submsg, '__slots__'):
+            # raw
             if self.include_message_info:
-                print(yaml.dump(info), end=line_end)
-            print(
-                message_to_yaml(
-                    submsg, truncate_length=self.truncate_length,
-                    no_arr=self.no_arr, no_str=self.no_str, flow_style=self.flow_style),
-                end=line_end)
+                print('---Got new message, message info:---')
+                print(info)
+                print('---Message data:---')
+            print(submsg, end='\n---\n')
+            return
+
+        if self.csv:
+            to_print = message_to_csv(
+                submsg,
+                truncate_length=self.truncate_length,
+                no_arr=self.no_arr,
+                no_str=self.no_str)
+            if self.include_message_info:
+                to_print = f'{",".join(str(x) for x in info.values())},{to_print}'
+            print(to_print)
+            return
+        # yaml
+        if self.include_message_info:
+            print(yaml.dump(info), end='---\n')
+        print(
+            message_to_yaml(
+                submsg, truncate_length=self.truncate_length,
+                no_arr=self.no_arr, no_str=self.no_str, flow_style=self.flow_style),
+            end='---\n')
 
 
 def _expr_eval(expr):
@@ -289,7 +328,3 @@ def _message_lost_event_callback(message_lost_status):
         f'\n\ttotal count: {message_lost_status.total_count}',
         end='---\n'
     )
-
-
-def clear_terminal():
-    print('\x1b[H\x1b[2J')

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Optional
 from typing import TypeVar
 
@@ -34,7 +35,6 @@ from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message
 
-import re
 import yaml
 
 DEFAULT_TRUNCATE_LENGTH = 128
@@ -73,7 +73,9 @@ class EchoVerb(VerbExtension):
             help='Echo a selected field of a message. '
                  "Use '.' to select sub-fields. "
                  'For example, to echo the position field of a nav_msgs/msg/Odometry message: '
-                 "'ros2 topic echo /odom --field pose.pose.position'",
+                 "'ros2 topic echo /odom --field pose.pose.position'. "
+                 'Use the --field option multiple times to echo multiple fields. '
+                 'If the field is an array, use the syntax .[index] to select a single element.'
         )
         parser.add_argument(
             '--full-length', '-f', action='store_true',
@@ -219,7 +221,7 @@ class EchoVerb(VerbExtension):
             for fields in self.fields_list:
                 submsg = msg
                 for field in fields:
-                    is_indexing = re.compile(r"^\[(\d+)\]$")
+                    is_indexing = re.compile(r'^\[(\d+)\]$')
                     match = is_indexing.match(field)
                     try:
                         if match is None:

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -617,6 +617,19 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.wait_for_shutdown(timeout=10)
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_field_array(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--field', 'float32_values_default.[2]'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    '-1.125',
+                    '---',
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_echo_multi_fields_nested(self):
         with self.launch_topic_command(
             arguments=['echo', '/cmd_vel', '--field', 'twist.linear.x',
@@ -632,6 +645,21 @@ class TestROS2TopicCLI(unittest.TestCase):
         assert topic_command.wait_for_shutdown(timeout=10)
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_multi_fields_array(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--field', 'float32_values_default.[2]', '--field',
+                       'string_values_default.[1]'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    '-1.125',
+                    'max value',
+                    '---',
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_topic_echo_field_not_a_member(self):
         with self.launch_topic_command(
             arguments=['echo', '/arrays', '--field', 'not_member'],
@@ -639,6 +667,45 @@ class TestROS2TopicCLI(unittest.TestCase):
             assert topic_command.wait_for_output(functools.partial(
                 launch_testing.tools.expect_output, expected_lines=[
                     "Invalid field 'not_member': 'Arrays' object has no attribute 'not_member'",
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_field_array_not_an_array(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--field', 'float32_values_default.[0].[0]'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    "Invalid field 'float32_values_default.[0].[0]': invalid index to "
+                    'scalar variable.',
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_field_array_index_out_of_bounds(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--field', 'float32_values_default.[3]'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    "Invalid field 'float32_values_default.[3]': index 3 is out of bounds "
+                    'for axis 0 with size 3',
+                ], strict=True
+            ), timeout=10)
+        assert topic_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_topic_echo_field_array_no_index(self):
+        with self.launch_topic_command(
+            arguments=['echo', '/arrays', '--field', 'float32_values_default.[abc]'],
+        ) as topic_command:
+            assert topic_command.wait_for_output(functools.partial(
+                launch_testing.tools.expect_output, expected_lines=[
+                    "Invalid field 'float32_values_default.[abc]': 'numpy.ndarray' object "
+                    "has no attribute '[abc]'",
                 ], strict=True
             ), timeout=10)
         assert topic_command.wait_for_shutdown(timeout=10)


### PR DESCRIPTION
As message fields are iterated through with python's `getattr`, there is currently no possibility to only print e.g. the first entry in a list.

This PR suggests a syntax like `ros2 topic echo <topic> --field <top_level.list_field.[0].bottom_level>` to do so.

One might argue that the dot before the brackets is counter-intuitive, but enabling <top_level.list_field[0].bottom_level> would require larger changes possibly introducing bugs.