### PR TITLE
Fix 'ros2 topic hz'

### DIFF
--- a/ros2topic/ros2topic/eval/__init__.py
+++ b/ros2topic/ros2topic/eval/__init__.py
@@ -1,24 +1,22 @@
-# MIT License
-
-# Copyright (c) 2022 Yaroslav Polyakov
-
+# Copyright 2022 Yaroslav Polyakov
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 """Safe user-supplied python expression evaluation."""
 
@@ -131,6 +129,7 @@ mult_eval_model.nodes.append('Mul')
 
 
 class Expr():
+
     def __init__(self, expr, model=None, filename=None):
 
         self.expr = expr

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -129,27 +129,24 @@ def _setup_safe_eval(safe_eval_model, msg_class, topic):
 
 def main(args):
     with DirectNode(args) as node:
-        topics = args.topic_name
+        topic = args.topic_name
         filter_expr = None
         # set up custom safe eval model for filter expression
         if args.filter_expr:
             safe_eval_model = _setup_base_safe_eval()
-            for topic in topics:
-                msg_class = get_msg_class(
-                    node, topic, blocking=True, include_hidden_topics=True)
-                if msg_class is None:
-                    continue
-
+            msg_class = get_msg_class(
+                node, topic, blocking=True, include_hidden_topics=True)
+            if msg_class is not None:
                 safe_eval_model = _setup_safe_eval(safe_eval_model, msg_class, topic)
 
-            def expr_eval(expr):
-                def eval_fn(m):
-                    safe_expression = Expr(expr, model=safe_eval_model)
-                    return eval(safe_expression.code)
-                return eval_fn
-            filter_expr = expr_eval(args.filter_expr)
+                def expr_eval(expr):
+                    def eval_fn(m):
+                        safe_expression = Expr(expr, model=safe_eval_model)
+                        return eval(safe_expression.code)
+                    return eval_fn
+                filter_expr = expr_eval(args.filter_expr)
 
-        _rostopic_hz(node.node, topics, qos_args=args, window_size=args.window_size,
+        _rostopic_hz(node.node, topic, window_size=args.window_size,
                      filter_expr=filter_expr, use_wtime=args.use_wtime)
 
 

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -96,6 +96,7 @@ def _get_nested_messages(msg_class):
             all_attributes.extend(nested_messages)
     return all_attributes
 
+
 def _setup_base_safe_eval():
     safe_eval_model = base_eval_model.clone()
 
@@ -116,6 +117,7 @@ def _setup_base_safe_eval():
 
     safe_eval_model.allowed_functions.extend(safe_builtins)
     return safe_eval_model
+
 
 def _setup_safe_eval(safe_eval_model, msg_class, topic):
     # allow-list topic builtins, msg attributes


### PR DESCRIPTION
Fixes #1002

Follow-up to #998, which backported a commit from Rolling to Jazzy that included unrelated changes that Jazzy doesn't have:

1. `_rostopic_hz()` does not expect the `qos_args` arg, since Jazzy doesn't have #935
    - This is the original bug report from #1002
2. `args.topic_name` contains a single topic name, since Jazzy doesn't have #929, which also means that `_rostopic_hz()` only expects a single topic name, and not a list

Run a node:

```console
$ ros2 run examples_rclcpp_minimal_publisher publisher_member_function
```

Before:

```console
$ ros2 topic hz /topic
Traceback (most recent call last):
  File "/home/christophe.bedard/ros2_ws_jazzy/install/ros2cli/bin/ros2", line 33, in <module>
    sys.exit(load_entry_point('ros2cli', 'console_scripts', 'ros2')())
  File "/home/christophe.bedard/ros2_ws_jazzy/build/ros2cli/ros2cli/cli.py", line 91, in main
    rc = extension.main(parser=parser, args=args)
  File "/home/christophe.bedard/ros2_ws_jazzy/build/ros2topic/ros2topic/command/topic.py", line 41, in main
    return extension.main(args=args)
  File "/home/christophe.bedard/ros2_ws_jazzy/build/ros2topic/ros2topic/verb/hz.py", line 87, in main
    return main(args)
  File "/home/christophe.bedard/ros2_ws_jazzy/build/ros2topic/ros2topic/verb/hz.py", line 152, in main
    _rostopic_hz(node.node, topics, qos_args=args, window_size=args.window_size,
TypeError: _rostopic_hz() got an unexpected keyword argument 'qos_args'
```

If I only fix (1) and not (2), the topic name string gets split into single characters:

```console
$ ros2 topic hz topic --filter 'True'
WARNING: topic [t] does not appear to be published yet
```

After:

```console
$ ros2 topic hz topic --filter 'True'
average rate: 2.000
        min: 0.500s max: 0.500s std dev: 0.00011s window: 3
average rate: 2.000
        min: 0.499s max: 0.501s std dev: 0.00058s window: 6
```