### PR TITLE
Conditional deserialization of message for `ros2 topic hz`

### DIFF
--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -316,7 +316,8 @@ def _rostopic_hz(node, topics, qos_args, window_size=DEFAULT_WINDOW_SIZE, filter
             msg_class,
             topic,
             functools.partial(rt.callback_hz, topic=topic),
-            qos_profile)
+            qos_profile,
+            raw=True if filter_expr is None else False)
         if topics_len > 1:
             print('Subscribed to [%s]' % topic)
 

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -317,7 +317,7 @@ def _rostopic_hz(node, topics, qos_args, window_size=DEFAULT_WINDOW_SIZE, filter
             topic,
             functools.partial(rt.callback_hz, topic=topic),
             qos_profile,
-            raw=True if filter_expr is None else False)
+            raw=filter_expr is None)
         if topics_len > 1:
             print('Subscribed to [%s]' % topic)
 


### PR DESCRIPTION
Fixes #983 

1. Added a conditional statement to set the `raw` flag when creating subscriptions for topics based on the value of `filter_expr`. If the `--filter` flag is used, `filter_expr` is not None and deserializing subscriptions are created. Otherwise `filter_expr` is None and 'raw' subscriptions are created.

2. As for the `bw` verb, it already uses 'raw' subscriptions and there is no case where desrialization of topics is required. Hence no changes made there.

## Manual Testing
1. Run an example publisher:
```bash
$ ros2 run examples_rclcpp_minimal_publisher publisher_member_function
[INFO] [1744209999.094889429] [minimal_publisher]: Publishing: 'Hello, world! 0'
[INFO] [1744209999.594917828] [minimal_publisher]: Publishing: 'Hello, world! 1'
[INFO] [1744210000.094935314] [minimal_publisher]: Publishing: 'Hello, world! 2'
[INFO] [1744210000.594921529] [minimal_publisher]: Publishing: 'Hello, world! 3'
[INFO] [1744210001.094927741] [minimal_publisher]: Publishing: 'Hello, world! 4'
```

2. Run simple topic hz:
```bash
$ ros2 topic hz /topic
average rate: 2.002
        min: 0.500s max: 0.500s std dev: 0.00000s window: 1
average rate: 2.000
        min: 0.499s max: 0.501s std dev: 0.00105s window: 3
average rate: 2.000
        min: 0.499s max: 0.501s std dev: 0.00084s window: 5
```

3. Run topic hz with filter that only selects messages with even numbers:
```bash
$ ros2 topic hz /topic --filter 'int(m.data.rpartition(\"! \")[-1]) % 2 == 0'
average rate: 1.000
        min: 1.000s max: 1.000s std dev: 0.00000s window: 1
average rate: 1.000
        min: 0.999s max: 1.000s std dev: 0.00024s window: 2
average rate: 1.000
        min: 0.999s max: 1.001s std dev: 0.00065s window: 3
```

4. Verifying the message deserialization directly with:
```bash
$ ros2 topic hz /topic --filter 'print(type(m.data))'
<class 'str'>
<class 'str'>
<class 'str'>
```