### PR TITLE
fails the test properly to avoid TypeError exception.

### DIFF
--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -344,8 +344,13 @@ class TestVerbLoad(unittest.TestCase):
             ) as param_dump_command:
                 assert param_dump_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
             assert param_dump_command.exit_code == launch_testing.asserts.EXIT_OK
-            loaded_params = yaml.safe_load(param_dump_command.output)
-            params = loaded_params[f'{TEST_NAMESPACE}/{TEST_NODE}']['ros__parameters']
+            try:
+                loaded_params = yaml.safe_load(param_dump_command.output)
+                if not isinstance(loaded_params, dict):
+                    self.fail('Invalid YAML output: Expected a dictionary')
+                params = loaded_params[f'{TEST_NAMESPACE}/{TEST_NODE}']['ros__parameters']
+            except yaml.YAMLError as e:
+                self.fail(f'Failed to parse YAML output: {e}')
             assert params['str_param'] == 'Wildcard'
             assert params['int_param'] == 12345
 
@@ -365,8 +370,13 @@ class TestVerbLoad(unittest.TestCase):
             ) as param_dump_command:
                 assert param_dump_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
             assert param_dump_command.exit_code == launch_testing.asserts.EXIT_OK
-            loaded_params = yaml.safe_load(param_dump_command.output)
-            params = loaded_params[f'{TEST_NAMESPACE}/{TEST_NODE}']['ros__parameters']
+            try:
+                loaded_params = yaml.safe_load(param_dump_command.output)
+                if not isinstance(loaded_params, dict):
+                    self.fail('Invalid YAML output: Expected a dictionary')
+                params = loaded_params[f'{TEST_NAMESPACE}/{TEST_NODE}']['ros__parameters']
+            except yaml.YAMLError as e:
+                self.fail(f'Failed to parse YAML output: {e}')
             assert params['str_param'] == 'Override'  # Overriden
             assert params['int_param'] == 12345  # Wildcard namespace
 
@@ -386,7 +396,12 @@ class TestVerbLoad(unittest.TestCase):
             ) as param_dump_command:
                 assert param_dump_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
             assert param_dump_command.exit_code == launch_testing.asserts.EXIT_OK
-            loaded_params = yaml.safe_load(param_dump_command.output)
-            params = loaded_params[f'{TEST_NAMESPACE}/{TEST_NODE}']['ros__parameters']
+            try:
+                loaded_params = yaml.safe_load(param_dump_command.output)
+                if not isinstance(loaded_params, dict):
+                    self.fail('Invalid YAML output: Expected a dictionary')
+                params = loaded_params[f'{TEST_NAMESPACE}/{TEST_NODE}']['ros__parameters']
+            except yaml.YAMLError as e:
+                self.fail(f'Failed to parse YAML output: {e}')
             assert params['str_param'] == 'Override'  # Overriden
             assert params['int_param'] == 12345  # Wildcard namespace


### PR DESCRIPTION
see,

https://ci.ros2.org/job/ci_linux/23292/testReport/junit/ros2param.ros2param.test/test_verb_load/test_verb_load/
https://ci.ros2.org/job/ci_linux-rhel/2762/testReport/junit/ros2param.ros2param.test/test_verb_load/test_verb_load/

i think we should fail the test in proper check and message.

this PR does not solve the failure, but gives us more clear message what went wrong.