### PR TITLE
[ros2pkg] Template update for compatibility with virtual environments (#1024)

### DIFF
--- a/ros2pkg/ros2pkg/resource/ament_python/setup.cfg.em
+++ b/ros2pkg/ros2pkg/resource/ament_python/setup.cfg.em
@@ -2,3 +2,5 @@
 script_dir=$base/lib/@(project_name)
 [install]
 install_scripts=$base/lib/@(project_name)
+[build]
+executable=/usr/bin/env python3


### PR DESCRIPTION
Fixes #1024 

Add [build] section with dynamic Python shebang in the setup.cfg file (ament_python template) for compatibility with virtual environments.

This change addresses an issue where build tools were incorrectly embedding a static `/usr/bin/python3` shebang in generated scripts, forcing the use of the system's Python interpreter. This update ensures the use of the dynamic `/usr/bin/env python3` shebang, allowing modules installed in virtual environments to be correctly located.