### PR TITLE
Fix stringifying InterfaceFlags when the flags are empty.

### DIFF
--- a/ros2doctor/ros2doctor/api/network.py
+++ b/ros2doctor/ros2doctor/api/network.py
@@ -51,7 +51,7 @@ class InterfaceFlags:
 
     def __str__(self):
         if not self.flags:
-            return
+            return ''
 
         return self.flags.upper()
 


### PR DESCRIPTION
It can be the case (especially on Windows) that the flags for an interface are empty.  In that case, when stringifying, we should return an empty string, not "nothing".  The latter causes an exception and makes the NetworkReport fail to work.

This should be backported to Kilted.

This came out of testing for the Kilted tutorial party in https://github.com/ros2/kilted_tutorial_party/issues/38 .  @cottsay FYI as Kilted boss.