### PR TITLE
Ignore flake8 multi-threaded warning below.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,7 @@
 junit_family=xunit2
 timeout=900
 timeout_method=thread
-# flake8 in Ubuntu 22.04 prints this warning; we ignore it for now
-filterwarnings=ignore:SelectableGroups:DeprecationWarning
+filterwarnings=
+    # flake8 in Ubuntu 22.04 prints this warning; we ignore it for now
+    ignore:SelectableGroups:DeprecationWarning
+    ignore:.*use of fork\(\) may lead to deadlocks in the child.*


### PR DESCRIPTION
## Description

```console
root@tomoyafujita:~/ros2_ws/colcon_ws# colcon test --event-handlers console_direct+ --packages-select ros2cli
Starting >>> ros2cli
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
cachedir: /root/ros2_ws/colcon_ws/build/ros2cli/.pytest_cache
rootdir: /root/ros2_ws/colcon_ws/src/ros2/ros2cli
configfile: pytest.ini
plugins: launch-testing-3.9.0, ament-mypy-0.20.0, ament-xmllint-0.20.0, ament-copyright-0.20.0, ament-pep257-0.20.0, ament-flake8-0.20.0, ament-lint-0.20.0, launch-testing-ros-0.29.0, launch-pytest-3.9.0, anyio-4.3.0, rerunfailures-12.0, cov-4.1.0, None-None, timeout-2.2.0, colcon-core-0.19.0, mock-3.12.0
timeout: 900.0s
timeout method: thread
timeout func_only: False
collecting ...
collected 31 items

test/test_copyright.py .                                                 [  3%]
test/test_flake8.py .                                                    [  6%]
test/test_pep257.py .                                                    [  9%]
test/test_ros2cli_daemon.py ...................                          [ 70%]
test/test_ros2cli_direct.py ....                                         [ 83%]
test/test_strategy.py ....                                               [ 96%]
test/test_xmllint.py .                                                   [100%]

=============================== warnings summary ===============================
ros2cli/test/test_flake8.py: 16 warnings
  Warning: This process (pid=239214) is multi-threaded, use of fork() may lead to deadlocks in the child.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----- generated xml file: /root/ros2_ws/colcon_ws/build/ros2cli/pytest.xml -----
======================= 31 passed, 16 warnings in 6.52s ========================
--- stderr: ros2cli

=============================== warnings summary ===============================
ros2cli/test/test_flake8.py: 16 warnings
  Warning: This process (pid=239214) is multi-threaded, use of fork() may lead to deadlocks in the child.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
---
Finished <<< ros2cli [7.85s]

Summary: 1 package finished [8.92s]
  1 package had stderr output: ros2cli
```

this PR fixes it as,

```console
root@tomoyafujita:~/ros2_ws/colcon_ws# colcon test --event-handlers console_direct+ --packages-select ros2cli
Starting >>> ros2cli
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
cachedir: /root/ros2_ws/colcon_ws/build/ros2cli/.pytest_cache
rootdir: /root/ros2_ws/colcon_ws/src/ros2/ros2cli
configfile: pytest.ini
plugins: launch-testing-3.9.0, ament-mypy-0.20.0, ament-xmllint-0.20.0, ament-copyright-0.20.0, ament-pep257-0.20.0, ament-flake8-0.20.0, ament-lint-0.20.0, launch-testing-ros-0.29.0, launch-pytest-3.9.0, anyio-4.3.0, rerunfailures-12.0, cov-4.1.0, None-None, timeout-2.2.0, colcon-core-0.19.0, mock-3.12.0
timeout: 900.0s
timeout method: thread
timeout func_only: False
collecting ...
collected 31 items

test/test_copyright.py .                                                 [  3%]
test/test_flake8.py .                                                    [  6%]
test/test_pep257.py .                                                    [  9%]
test/test_ros2cli_daemon.py ...................                          [ 70%]
test/test_ros2cli_direct.py ....                                         [ 83%]
test/test_strategy.py ....                                               [ 96%]
test/test_xmllint.py .                                                   [100%]

----- generated xml file: /root/ros2_ws/colcon_ws/build/ros2cli/pytest.xml -----
============================== 31 passed in 6.08s ==============================
Finished <<< ros2cli [7.38s]

Summary: 1 package finished [8.50s]
```

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
