### PR TITLE
add QoS option to ros2service/ros2action echo commands.

### DIFF
--- a/ros2service/package.xml
+++ b/ros2service/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2cli</exec_depend>
+  <exec_depend>ros2topic</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2service/test/test_echo.py
+++ b/ros2service/test/test_echo.py
@@ -34,6 +34,48 @@ import pytest
 
 from rclpy.utilities import get_available_rmw_implementations
 
+EXPECTED_OUTPUT = [
+    'info:',
+    '  event_type: REQUEST_SENT',
+    '  stamp:',
+    re.compile(r'    sec: \d+'),
+    re.compile(r'    nanosec: \d+'),
+    "  client_gid: '<array type: uint8[16]>'",
+    re.compile(r'  sequence_number: \d+'),
+    "request: '<sequence type: test_msgs/srv/BasicTypes_Request[1], length: 1>'",
+    "response: '<sequence type: test_msgs/srv/BasicTypes_Response[1], length: 0>'",
+    '---',
+    'info:',
+    '  event_type: REQUEST_RECEIVED',
+    '  stamp:',
+    re.compile(r'    sec: \d+'),
+    re.compile(r'    nanosec: \d+'),
+    "  client_gid: '<array type: uint8[16]>'",
+    re.compile(r'  sequence_number: \d+'),
+    "request: '<sequence type: test_msgs/srv/BasicTypes_Request[1], length: 1>'",
+    "response: '<sequence type: test_msgs/srv/BasicTypes_Response[1], length: 0>'",
+    '---',
+    'info:',
+    '  event_type: RESPONSE_SENT',
+    '  stamp:',
+    re.compile(r'    sec: \d+'),
+    re.compile(r'    nanosec: \d+'),
+    "  client_gid: '<array type: uint8[16]>'",
+    re.compile(r'  sequence_number: \d+'),
+    "request: '<sequence type: test_msgs/srv/BasicTypes_Request[1], length: 0>'",
+    "response: '<sequence type: test_msgs/srv/BasicTypes_Response[1], length: 1>'",
+    '---',
+    'info:',
+    '  event_type: RESPONSE_RECEIVED',
+    '  stamp:',
+    re.compile(r'    sec: \d+'),
+    re.compile(r'    nanosec: \d+'),
+    "  client_gid: '<array type: uint8[16]>'",
+    re.compile(r'  sequence_number: \d+'),
+    "request: '<sequence type: test_msgs/srv/BasicTypes_Request[1], length: 0>'",
+    "response: '<sequence type: test_msgs/srv/BasicTypes_Response[1], length: 1>'",
+]
+
 
 # Skip cli tests on Windows while they exhibit pathological behavior
 # https://github.com/ros2/build_farmer/issues/248
@@ -113,53 +155,28 @@ class TestROS2ServiceEcho(unittest.TestCase):
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_echo_no_arr(self):
         echo_arguments = ['echo', '/test_introspectable', '--no-arr']
-        expected_output = [
-            'info:',
-            '  event_type: REQUEST_SENT',
-            '  stamp:',
-            re.compile(r'    sec: \d+'),
-            re.compile(r'    nanosec: \d+'),
-            "  client_gid: '<array type: uint8[16]>'",
-            re.compile(r'  sequence_number: \d+'),
-            "request: '<sequence type: test_msgs/srv/BasicTypes_Request[1], length: 1>'",
-            "response: '<sequence type: test_msgs/srv/BasicTypes_Response[1], length: 0>'",
-            '---',
-            'info:',
-            '  event_type: REQUEST_RECEIVED',
-            '  stamp:',
-            re.compile(r'    sec: \d+'),
-            re.compile(r'    nanosec: \d+'),
-            "  client_gid: '<array type: uint8[16]>'",
-            re.compile(r'  sequence_number: \d+'),
-            "request: '<sequence type: test_msgs/srv/BasicTypes_Request[1], length: 1>'",
-            "response: '<sequence type: test_msgs/srv/BasicTypes_Response[1], length: 0>'",
-            '---',
-            'info:',
-            '  event_type: RESPONSE_SENT',
-            '  stamp:',
-            re.compile(r'    sec: \d+'),
-            re.compile(r'    nanosec: \d+'),
-            "  client_gid: '<array type: uint8[16]>'",
-            re.compile(r'  sequence_number: \d+'),
-            "request: '<sequence type: test_msgs/srv/BasicTypes_Request[1], length: 0>'",
-            "response: '<sequence type: test_msgs/srv/BasicTypes_Response[1], length: 1>'",
-            '---',
-            'info:',
-            '  event_type: RESPONSE_RECEIVED',
-            '  stamp:',
-            re.compile(r'    sec: \d+'),
-            re.compile(r'    nanosec: \d+'),
-            "  client_gid: '<array type: uint8[16]>'",
-            re.compile(r'  sequence_number: \d+'),
-            "request: '<sequence type: test_msgs/srv/BasicTypes_Request[1], length: 0>'",
-            "response: '<sequence type: test_msgs/srv/BasicTypes_Response[1], length: 1>'",
-        ],
 
         with self.launch_service_command(arguments=echo_arguments) as service_command:
             assert service_command.wait_for_output(
                 functools.partial(
                     launch_testing.tools.expect_output,
-                    expected_lines=expected_output,
+                    expected_lines=EXPECTED_OUTPUT,
+                    strict=True
+                ),
+                timeout=10,
+            )
+        assert service_command.wait_for_shutdown(timeout=10)
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_echo_no_arr_with_qos(self):
+        echo_arguments = [
+            'echo', '/test_introspectable', '--no-arr', '--qos-profile', 'services_default']
+
+        with self.launch_service_command(arguments=echo_arguments) as service_command:
+            assert service_command.wait_for_output(
+                functools.partial(
+                    launch_testing.tools.expect_output,
+                    expected_lines=EXPECTED_OUTPUT,
                     strict=True
                 ),
                 timeout=10,


### PR DESCRIPTION
## Description

backport of https://github.com/ros2/ros2cli/pull/1036

Since jazzy does not have action introspection most of https://github.com/ros2/ros2cli/pull/1036 cannot be backport to jazzy, so i ended up creating this PR only for jazzy.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
