### PR TITLE
remove unnecessary '/' from ros2 action info.

### DIFF
--- a/ros2action/ros2action/api/__init__.py
+++ b/ros2action/ros2action/api/__init__.py
@@ -35,7 +35,7 @@ def get_action_clients_and_servers(*, node, action_name):
     node_names_and_ns = node.get_node_names_and_namespaces()
     for node_name, node_ns in node_names_and_ns:
         # Construct fully qualified name
-        node_fqn = '/'.join([node_ns, node_name])
+        node_fqn = (node_ns.rstrip('/') + '/' + node_name.lstrip('/')) if node_ns else node_name
 
         # Get any action clients associated with the node
         client_names_and_types = node.get_action_client_names_and_types_by_node(


### PR DESCRIPTION
## Description

- before

```console
root@tomoyafujita:~/ros2_ws/colcon_ws# ros2 action info /fibonacci
Action: /fibonacci
Action clients: 1
    //fibonacci_action_client
Action servers: 1
    //fibonacci_action_server
```

- after

```console
root@tomoyafujita:~/ros2_ws/colcon_ws# ros2 action info /fibonacci
Action: /fibonacci
Action clients: 1
    /fibonacci_action_client
Action servers: 1
    /fibonacci_action_server
```

### Is this user-facing behavior change?

Yes, this PR fixes the output of `ros2 action info` into what it should be without unnecessary `/`.

### Did you use Generative AI?

No

### Additional Information

No