### PR TITLE
move QoS methods from ros2topic.api to ros2cli.qos.

### DIFF
--- a/ros2action/package.xml
+++ b/ros2action/package.xml
@@ -21,7 +21,6 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2cli</exec_depend>
-  <exec_depend>ros2topic</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2action/ros2action/verb/echo.py
+++ b/ros2action/ros2action/verb/echo.py
@@ -19,7 +19,6 @@ import sys
 import threading
 
 import rclpy
-
 from rclpy.qos import qos_profile_action_status_default
 from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile

--- a/ros2action/ros2action/verb/echo.py
+++ b/ros2action/ros2action/verb/echo.py
@@ -19,6 +19,7 @@ import sys
 import threading
 
 import rclpy
+
 from rclpy.qos import qos_profile_action_status_default
 from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
@@ -33,8 +34,8 @@ from ros2action.verb import VerbExtension
 
 from ros2cli.helpers import unsigned_int
 from ros2cli.node.strategy import NodeStrategy
-
-from ros2topic.api import add_qos_arguments, profile_configure_short_keys
+from ros2cli.qos import add_qos_arguments
+from ros2cli.qos import profile_configure_short_keys
 
 from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_ordereddict

--- a/ros2cli/ros2cli/qos.py
+++ b/ros2cli/ros2cli/qos.py
@@ -16,7 +16,6 @@ from argparse import ArgumentParser
 from typing import Optional
 
 import rclpy
-
 from rclpy.duration import Duration
 from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSPresetProfiles

--- a/ros2cli/ros2cli/qos.py
+++ b/ros2cli/ros2cli/qos.py
@@ -1,0 +1,176 @@
+# Copyright 2025 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import ArgumentParser
+from typing import Optional
+
+import rclpy
+
+from rclpy.duration import Duration
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSPresetProfiles
+from rclpy.qos import QoSReliabilityPolicy
+
+
+def profile_configure_short_keys(
+    profile: rclpy.qos.QoSProfile = None, reliability: Optional[str] = None,
+    durability: Optional[str] = None, depth: Optional[int] = None, history: Optional[str] = None,
+    liveliness: Optional[str] = None, liveliness_lease_duration_s: Optional[int] = None,
+) -> None:
+    """Configure a QoSProfile given a profile, and optional overrides."""
+    if history:
+        profile.history = rclpy.qos.QoSHistoryPolicy.get_from_short_key(history)
+    if durability:
+        profile.durability = rclpy.qos.QoSDurabilityPolicy.get_from_short_key(durability)
+    if reliability:
+        profile.reliability = rclpy.qos.QoSReliabilityPolicy.get_from_short_key(reliability)
+    if liveliness:
+        profile.liveliness = rclpy.qos.QoSLivelinessPolicy.get_from_short_key(liveliness)
+    if liveliness_lease_duration_s and liveliness_lease_duration_s >= 0:
+        profile.liveliness_lease_duration = Duration(seconds=liveliness_lease_duration_s)
+    if depth and depth >= 0:
+        profile.depth = depth
+    else:
+        if (profile.durability == rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL
+                and profile.depth == 0):
+            profile.depth = 1
+
+
+def qos_profile_from_short_keys(
+    preset_profile: str, reliability: Optional[str] = None, durability: Optional[str] = None,
+    depth: Optional[int] = None, history: Optional[str] = None, liveliness: Optional[str] = None,
+    liveliness_lease_duration_s: Optional[float] = None,
+) -> rclpy.qos.QoSProfile:
+    """Construct a QoSProfile given the name of a preset, and optional overrides."""
+    # Build a QoS profile based on user-supplied arguments
+    profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(preset_profile)
+    profile_configure_short_keys(
+        profile, reliability, durability, depth, history, liveliness, liveliness_lease_duration_s)
+    return profile
+
+
+def add_qos_arguments(
+    parser: ArgumentParser, entity_type: str,
+    default_profile_str: str = 'default', extra_message: str = ''
+) -> None:
+    parser.add_argument(
+        '--qos-profile',
+        choices=rclpy.qos.QoSPresetProfiles.short_keys(),
+        help=(
+            f'Quality of service preset profile to {entity_type} with'
+            f' (default: {default_profile_str})'),
+        default=default_profile_str)
+    default_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(default_profile_str)
+    parser.add_argument(
+        '--qos-depth', metavar='N', type=int,
+        help=(
+            f'Queue size setting to {entity_type} with '
+            '(overrides depth value of --qos-profile option, default: '
+            f'{default_profile.depth})'))
+    parser.add_argument(
+        '--qos-history',
+        choices=rclpy.qos.QoSHistoryPolicy.short_keys(),
+        help=(
+            f'History of samples setting to {entity_type} with '
+            '(overrides history value of --qos-profile option, default: '
+            f'{default_profile.history.short_key})'))
+    parser.add_argument(
+        '--qos-reliability',
+        choices=rclpy.qos.QoSReliabilityPolicy.short_keys(),
+        help=(
+            f'Quality of service reliability setting to {entity_type} with '
+            '(overrides reliability value of --qos-profile option, default: '
+            f'{default_profile.reliability.short_key} {extra_message})'))
+    parser.add_argument(
+        '--qos-durability',
+        choices=rclpy.qos.QoSDurabilityPolicy.short_keys(),
+        help=(
+            f'Quality of service durability setting to {entity_type} with '
+            '(overrides durability value of --qos-profile option, default: '
+            f'{default_profile.durability.short_key}  {extra_message})'))
+    parser.add_argument(
+        '--qos-liveliness',
+        choices=rclpy.qos.QoSLivelinessPolicy.short_keys(),
+        help=(
+            f'Quality of service liveliness setting to {entity_type} with '
+            '(overrides liveliness value of --qos-profile option, default '
+            f'{default_profile.liveliness.short_key})'))
+    parser.add_argument(
+        '--qos-liveliness-lease-duration-seconds',
+        type=float,
+        help=(
+            f'Quality of service liveliness lease duration setting to {entity_type} '
+            'with (overrides liveliness lease duration value of --qos-profile option, default: '
+            f'{default_profile.liveliness_lease_duration})'))
+
+
+def choose_qos(node, topic_name: str, qos_args):
+    if (qos_args.qos_reliability is not None or
+            qos_args.qos_durability is not None or
+            qos_args.qos_depth is not None or
+            qos_args.qos_history is not None or
+            qos_args.qos_liveliness is not None or
+            qos_args.qos_liveliness_lease_duration_seconds is not None):
+
+        return qos_profile_from_short_keys(
+            qos_args.qos_profile,
+            reliability=qos_args.qos_reliability,
+            durability=qos_args.qos_durability,
+            depth=qos_args.qos_depth,
+            history=qos_args.qos_history,
+            liveliness=qos_args.qos_liveliness,
+            liveliness_lease_duration_s=qos_args.qos_liveliness_lease_duration_seconds)
+
+    qos_profile = QoSPresetProfiles.get_from_short_key(qos_args.qos_profile)
+    reliability_reliable_endpoints_count = 0
+    durability_transient_local_endpoints_count = 0
+
+    pubs_info = node.get_publishers_info_by_topic(topic_name)
+    publishers_count = len(pubs_info)
+    if publishers_count == 0:
+        return qos_profile
+
+    for info in pubs_info:
+        if (info.qos_profile.reliability == QoSReliabilityPolicy.RELIABLE):
+            reliability_reliable_endpoints_count += 1
+        if (info.qos_profile.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL):
+            durability_transient_local_endpoints_count += 1
+
+    # If all endpoints are reliable, ask for reliable
+    if reliability_reliable_endpoints_count == publishers_count:
+        qos_profile.reliability = QoSReliabilityPolicy.RELIABLE
+    else:
+        if reliability_reliable_endpoints_count > 0:
+            print(
+                'Some, but not all, publishers are offering '
+                'QoSReliabilityPolicy.RELIABLE. Falling back to '
+                'QoSReliabilityPolicy.BEST_EFFORT as it will connect '
+                'to all publishers'
+            )
+        qos_profile.reliability = QoSReliabilityPolicy.BEST_EFFORT
+
+    # If all endpoints are transient_local, ask for transient_local
+    if durability_transient_local_endpoints_count == publishers_count:
+        qos_profile.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
+    else:
+        if durability_transient_local_endpoints_count > 0:
+            print(
+                'Some, but not all, publishers are offering '
+                'QoSDurabilityPolicy.TRANSIENT_LOCAL. Falling back to '
+                'QoSDurabilityPolicy.VOLATILE as it will connect '
+                'to all publishers'
+            )
+        qos_profile.durability = QoSDurabilityPolicy.VOLATILE
+
+    return qos_profile

--- a/ros2cli/test/test_qos_conversions.py
+++ b/ros2cli/test/test_qos_conversions.py
@@ -15,7 +15,7 @@
 import rclpy
 from rclpy.duration import Duration
 
-from ros2topic.api import qos_profile_from_short_keys
+from ros2cli.qos import qos_profile_from_short_keys
 
 
 def test_profile_conversion():

--- a/ros2service/package.xml
+++ b/ros2service/package.xml
@@ -20,7 +20,6 @@
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2cli</exec_depend>
-  <exec_depend>ros2topic</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -16,17 +16,23 @@ import time
 from typing import Optional
 
 import rclpy
+
 from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
+
 from ros2cli.helpers import collect_stdin
 from ros2cli.node import NODE_NAME_PREFIX
+from ros2cli.qos import add_qos_arguments
+from ros2cli.qos import profile_configure_short_keys
+
 from ros2service.api import ServiceNameCompleter
 from ros2service.api import ServicePrototypeCompleter
 from ros2service.api import ServiceTypeCompleter
 from ros2service.verb import VerbExtension
-from ros2topic.api import add_qos_arguments, profile_configure_short_keys
+
 from rosidl_runtime_py import set_message_fields
 from rosidl_runtime_py.utilities import get_service
+
 import yaml
 
 

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -16,7 +16,6 @@ import time
 from typing import Optional
 
 import rclpy
-
 from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
 

--- a/ros2service/ros2service/verb/echo.py
+++ b/ros2service/ros2service/verb/echo.py
@@ -19,13 +19,17 @@ from typing import TypeVar
 import rclpy
 
 from rclpy.qos import QoSPresetProfiles
+
 from ros2cli.helpers import unsigned_int
 from ros2cli.node.strategy import NodeStrategy
+from ros2cli.qos import add_qos_arguments
+from ros2cli.qos import profile_configure_short_keys
+
 from ros2service.api import get_service_class
 from ros2service.api import ServiceNameCompleter
 from ros2service.api import ServiceTypeCompleter
 from ros2service.verb import VerbExtension
-from ros2topic.api import add_qos_arguments, profile_configure_short_keys
+
 from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_ordereddict
 from rosidl_runtime_py.utilities import get_service

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -17,18 +17,18 @@ from argparse import ArgumentTypeError
 from time import sleep
 from typing import Optional
 
+import warnings
+
 from argcomplete import CompletionFinder
 
 import rclpy
 
-from rclpy.duration import Duration
 from rclpy.expand_topic_name import expand_topic_name
-from rclpy.qos import QoSDurabilityPolicy
-from rclpy.qos import QoSPresetProfiles
-from rclpy.qos import QoSReliabilityPolicy
 from rclpy.topic_or_service_is_hidden import topic_or_service_is_hidden
 from rclpy.validate_full_topic_name import validate_full_topic_name
+
 from ros2cli.node.strategy import NodeStrategy
+
 from rosidl_runtime_py import get_message_interfaces
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message
@@ -191,23 +191,13 @@ def profile_configure_short_keys(
     durability: Optional[str] = None, depth: Optional[int] = None, history: Optional[str] = None,
     liveliness: Optional[str] = None, liveliness_lease_duration_s: Optional[int] = None,
 ) -> None:
-    """Configure a QoSProfile given a profile, and optional overrides."""
-    if history:
-        profile.history = rclpy.qos.QoSHistoryPolicy.get_from_short_key(history)
-    if durability:
-        profile.durability = rclpy.qos.QoSDurabilityPolicy.get_from_short_key(durability)
-    if reliability:
-        profile.reliability = rclpy.qos.QoSReliabilityPolicy.get_from_short_key(reliability)
-    if liveliness:
-        profile.liveliness = rclpy.qos.QoSLivelinessPolicy.get_from_short_key(liveliness)
-    if liveliness_lease_duration_s and liveliness_lease_duration_s >= 0:
-        profile.liveliness_lease_duration = Duration(seconds=liveliness_lease_duration_s)
-    if depth and depth >= 0:
-        profile.depth = depth
-    else:
-        if (profile.durability == rclpy.qos.QoSDurabilityPolicy.TRANSIENT_LOCAL
-                and profile.depth == 0):
-            profile.depth = 1
+    warnings.warn(
+        "'qos_profile_from_short_keys()' is deprecated. "
+        "use 'ros2cli.qos.qos_profile_from_short_keys()' instead.",
+        DeprecationWarning)
+    from ros2cli.qos import profile_configure_short_keys as _profile_configure_short_keys
+    return _profile_configure_short_keys(profile, reliability, durability, depth, history,
+                                         liveliness, liveliness_lease_duration_s)
 
 
 def qos_profile_from_short_keys(
@@ -215,125 +205,32 @@ def qos_profile_from_short_keys(
     depth: Optional[int] = None, history: Optional[str] = None, liveliness: Optional[str] = None,
     liveliness_lease_duration_s: Optional[float] = None,
 ) -> rclpy.qos.QoSProfile:
-    """Construct a QoSProfile given the name of a preset, and optional overrides."""
-    # Build a QoS profile based on user-supplied arguments
-    profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(preset_profile)
-    profile_configure_short_keys(
-        profile, reliability, durability, depth, history, liveliness, liveliness_lease_duration_s)
-    return profile
+    warnings.warn(
+        "'qos_profile_from_short_keys()' is deprecated. "
+        "use 'ros2cli.qos.qos_profile_from_short_keys()' instead.",
+        DeprecationWarning)
+    from ros2cli.qos import qos_profile_from_short_keys as _qos_profile_from_short_keys
+    return _qos_profile_from_short_keys(
+        preset_profile, reliability, durability,
+        depth, history, liveliness, liveliness_lease_duration_s)
 
 
 def add_qos_arguments(
     parser: ArgumentParser, entity_type: str,
     default_profile_str: str = 'default', extra_message: str = ''
 ) -> None:
-    parser.add_argument(
-        '--qos-profile',
-        choices=rclpy.qos.QoSPresetProfiles.short_keys(),
-        help=(
-            f'Quality of service preset profile to {entity_type} with'
-            f' (default: {default_profile_str})'),
-        default=default_profile_str)
-    default_profile = rclpy.qos.QoSPresetProfiles.get_from_short_key(default_profile_str)
-    parser.add_argument(
-        '--qos-depth', metavar='N', type=int,
-        help=(
-            f'Queue size setting to {entity_type} with '
-            '(overrides depth value of --qos-profile option, default: '
-            f'{default_profile.depth})'))
-    parser.add_argument(
-        '--qos-history',
-        choices=rclpy.qos.QoSHistoryPolicy.short_keys(),
-        help=(
-            f'History of samples setting to {entity_type} with '
-            '(overrides history value of --qos-profile option, default: '
-            f'{default_profile.history.short_key})'))
-    parser.add_argument(
-        '--qos-reliability',
-        choices=rclpy.qos.QoSReliabilityPolicy.short_keys(),
-        help=(
-            f'Quality of service reliability setting to {entity_type} with '
-            '(overrides reliability value of --qos-profile option, default: '
-            f'{default_profile.reliability.short_key} {extra_message})'))
-    parser.add_argument(
-        '--qos-durability',
-        choices=rclpy.qos.QoSDurabilityPolicy.short_keys(),
-        help=(
-            f'Quality of service durability setting to {entity_type} with '
-            '(overrides durability value of --qos-profile option, default: '
-            f'{default_profile.durability.short_key}  {extra_message})'))
-    parser.add_argument(
-        '--qos-liveliness',
-        choices=rclpy.qos.QoSLivelinessPolicy.short_keys(),
-        help=(
-            f'Quality of service liveliness setting to {entity_type} with '
-            '(overrides liveliness value of --qos-profile option, default '
-            f'{default_profile.liveliness.short_key})'))
-    parser.add_argument(
-        '--qos-liveliness-lease-duration-seconds',
-        type=float,
-        help=(
-            f'Quality of service liveliness lease duration setting to {entity_type} '
-            'with (overrides liveliness lease duration value of --qos-profile option, default: '
-            f'{default_profile.liveliness_lease_duration})'))
+    warnings.warn(
+        "'add_qos_arguments()' is deprecated. "
+        "use 'ros2cli.qos.add_qos_arguments()' instead.",
+        DeprecationWarning)
+    from ros2cli.qos import add_qos_arguments as _add_qos_arguments
+    return _add_qos_arguments(parser, entity_type, default_profile_str, extra_message)
 
 
 def choose_qos(node, topic_name: str, qos_args):
-    if (qos_args.qos_reliability is not None or
-            qos_args.qos_durability is not None or
-            qos_args.qos_depth is not None or
-            qos_args.qos_history is not None or
-            qos_args.qos_liveliness is not None or
-            qos_args.qos_liveliness_lease_duration_seconds is not None):
-
-        return qos_profile_from_short_keys(
-            qos_args.qos_profile,
-            reliability=qos_args.qos_reliability,
-            durability=qos_args.qos_durability,
-            depth=qos_args.qos_depth,
-            history=qos_args.qos_history,
-            liveliness=qos_args.qos_liveliness,
-            liveliness_lease_duration_s=qos_args.qos_liveliness_lease_duration_seconds)
-
-    qos_profile = QoSPresetProfiles.get_from_short_key(qos_args.qos_profile)
-    reliability_reliable_endpoints_count = 0
-    durability_transient_local_endpoints_count = 0
-
-    pubs_info = node.get_publishers_info_by_topic(topic_name)
-    publishers_count = len(pubs_info)
-    if publishers_count == 0:
-        return qos_profile
-
-    for info in pubs_info:
-        if (info.qos_profile.reliability == QoSReliabilityPolicy.RELIABLE):
-            reliability_reliable_endpoints_count += 1
-        if (info.qos_profile.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL):
-            durability_transient_local_endpoints_count += 1
-
-    # If all endpoints are reliable, ask for reliable
-    if reliability_reliable_endpoints_count == publishers_count:
-        qos_profile.reliability = QoSReliabilityPolicy.RELIABLE
-    else:
-        if reliability_reliable_endpoints_count > 0:
-            print(
-                'Some, but not all, publishers are offering '
-                'QoSReliabilityPolicy.RELIABLE. Falling back to '
-                'QoSReliabilityPolicy.BEST_EFFORT as it will connect '
-                'to all publishers'
-            )
-        qos_profile.reliability = QoSReliabilityPolicy.BEST_EFFORT
-
-    # If all endpoints are transient_local, ask for transient_local
-    if durability_transient_local_endpoints_count == publishers_count:
-        qos_profile.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
-    else:
-        if durability_transient_local_endpoints_count > 0:
-            print(
-                'Some, but not all, publishers are offering '
-                'QoSDurabilityPolicy.TRANSIENT_LOCAL. Falling back to '
-                'QoSDurabilityPolicy.VOLATILE as it will connect '
-                'to all publishers'
-            )
-        qos_profile.durability = QoSDurabilityPolicy.VOLATILE
-
-    return qos_profile
+    warnings.warn(
+        "'choose_qos()' is deprecated. "
+        "use 'ros2cli.qos.choose_qos()' instead.",
+        DeprecationWarning)
+    from ros2cli.qos import choose_qos as _choose_qos
+    return _choose_qos(node, topic_name, qos_args)

--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -34,10 +34,12 @@ import threading
 import traceback
 
 import rclpy
+
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
-from ros2topic.api import add_qos_arguments
-from ros2topic.api import choose_qos
+from ros2cli.qos import add_qos_arguments
+from ros2cli.qos import choose_qos
+
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter

--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -34,10 +34,12 @@ import math
 import rclpy
 
 from rclpy.time import Time
+
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
-from ros2topic.api import add_qos_arguments
-from ros2topic.api import choose_qos
+from ros2cli.qos import add_qos_arguments
+from ros2cli.qos import choose_qos
+
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -17,20 +17,24 @@ from typing import Optional
 from typing import TypeVar
 
 import rclpy
+
 from rclpy.event_handler import SubscriptionEventCallbacks
 from rclpy.event_handler import UnsupportedEventTypeError
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 from rclpy.task import Future
+
 from ros2cli.helpers import unsigned_int
 from ros2cli.node.strategy import add_arguments as add_strategy_node_arguments
 from ros2cli.node.strategy import NodeStrategy
-from ros2topic.api import add_qos_arguments
-from ros2topic.api import choose_qos
+from ros2cli.qos import add_qos_arguments
+from ros2cli.qos import choose_qos
+
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_float
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
+
 from rosidl_runtime_py import message_to_csv
 from rosidl_runtime_py import message_to_yaml
 from rosidl_runtime_py.utilities import get_message

--- a/ros2topic/ros2topic/verb/echo.py
+++ b/ros2topic/ros2topic/verb/echo.py
@@ -17,7 +17,6 @@ from typing import Optional
 from typing import TypeVar
 
 import rclpy
-
 from rclpy.event_handler import SubscriptionEventCallbacks
 from rclpy.event_handler import UnsupportedEventTypeError
 from rclpy.node import Node

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -41,10 +41,12 @@ import rclpy
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
 from rclpy.executors import ExternalShutdownException
+
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
-from ros2topic.api import add_qos_arguments
-from ros2topic.api import choose_qos
+from ros2cli.qos import add_qos_arguments
+from ros2cli.qos import choose_qos
+
 from ros2topic.api import get_msg_class
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -21,18 +21,22 @@ import argcomplete
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
+
 from ros2cli.helpers import collect_stdin
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
-from ros2topic.api import add_qos_arguments
+from ros2cli.qos import add_qos_arguments
+from ros2cli.qos import profile_configure_short_keys
+
 from ros2topic.api import positive_float
-from ros2topic.api import profile_configure_short_keys
 from ros2topic.api import TopicMessagePrototypeCompleter, YamlCompletionFinder
 from ros2topic.api import TopicNameCompleter
 from ros2topic.api import TopicTypeCompleter
 from ros2topic.verb import VerbExtension
+
 from rosidl_runtime_py import set_message_fields
 from rosidl_runtime_py.utilities import get_message
+
 import yaml
 
 MsgType = TypeVar('MsgType')

--- a/ros2topic/test/fixtures/listener_node.py
+++ b/ros2topic/test/fixtures/listener_node.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import rclpy
+
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
-from ros2topic.api import qos_profile_from_short_keys
+
+from ros2cli.qos import qos_profile_from_short_keys
 
 from std_msgs.msg import String
 

--- a/ros2topic/test/fixtures/listener_node.py
+++ b/ros2topic/test/fixtures/listener_node.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import rclpy
-
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 


### PR DESCRIPTION
## Description

Move QoS related methods from `ros2topic/ros2topic/api/__init__.py` to `ros2cli/ros2cli/qos.py`, because these are general methods and used in many places in CLI packages, not dedicated methods for ros2topic package anymore.

### Is this user-facing behavior change?

Yes, QoS methods under `ros2topic/api` has been deprecated and internally call `ros2cli/ros2cli/qos.py`.
That means user application does not need to change the application, but with this PR it starts generating the deprecation message to suggest to use `ros2cli/ros2cli/qos.py` instead.

### Did you use Generative AI?

No

### Additional Information

N.A