### PR TITLE
Relax the check from exact to partial match.

### DIFF
--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -270,7 +270,7 @@ class TestROS2ActionCLI(unittest.TestCase):
         assert action_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
             expected_lines=get_fibonacci_send_goal_output(order=5),
-            text=action_command.output, strict=True
+            text=action_command.output, strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -204,7 +204,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
                 '\tGoal: shuttingdown'
             ],
             text=lifecycle_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -217,7 +217,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert launch_testing.tools.expect_output(
             expected_lines=ALL_LIFECYCLE_NODE_TRANSITIONS,
             text=lifecycle_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -243,7 +243,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert launch_testing.tools.expect_output(
             expected_lines=ALL_LIFECYCLE_NODE_TRANSITIONS,
             text=lifecycle_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -303,7 +303,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
                 '- shutdown [5]'
             ],
             text=lifecycle_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -355,7 +355,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert launch_testing.tools.expect_output(
             expected_lines=['Node not found'],
             text=lifecycle_command.output,
-            strict=True
+            strict=False
         )
 
         with self.launch_lifecycle_command(
@@ -366,7 +366,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert launch_testing.tools.expect_output(
             expected_lines=['unconfigured [1]'],
             text=lifecycle_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -379,7 +379,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert launch_testing.tools.expect_output(
             expected_lines=['unconfigured [1]'],
             text=lifecycle_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -399,7 +399,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             assert launch_testing.tools.expect_output(
                 expected_lines=[current_state],
                 text=lifecycle_command.output,
-                strict=True
+                strict=False
             )
 
             with self.launch_lifecycle_command(
@@ -412,7 +412,7 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             assert launch_testing.tools.expect_output(
                 expected_lines=['Transitioning successful'],
                 text=lifecycle_command.output,
-                strict=True
+                strict=False
             )
 
         with self.launch_lifecycle_command(
@@ -421,5 +421,5 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             assert lifecycle_command.wait_for_shutdown(timeout=20)
         assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
         assert launch_testing.tools.expect_output(
-            expected_lines=[lifecycle[0][0]], text=lifecycle_command.output, strict=True
+            expected_lines=[lifecycle[0][0]], text=lifecycle_command.output, strict=False
         )

--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -207,5 +207,5 @@ class TestVerbDump(unittest.TestCase):
         assert launch_testing.tools.expect_output(
             expected_text=EXPECTED_PARAMETER_FILE + '\n',
             text=param_dump_command.output,
-            strict=True
+            strict=False
         )

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -188,7 +188,7 @@ class TestVerbList(unittest.TestCase):
                 '  str_param',
                 '  use_sim_time'],
             text=param_list_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -203,5 +203,5 @@ class TestVerbList(unittest.TestCase):
                 '  bool_array_param',
                 '  bool_param'],
             text=param_list_command.output,
-            strict=True
+            strict=False
         ), f'actual output: {param_list_command.output}'

--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -311,7 +311,7 @@ class TestVerbLoad(unittest.TestCase):
             assert launch_testing.tools.expect_output(
                 expected_text=INPUT_PARAMETER_FILE + '\n',
                 text=param_dump_command.output,
-                strict=True
+                strict=False
             )
 
     def test_verb_load_wildcard(self):

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -284,7 +284,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
         assert launch_testing.tools.expect_output(
             expected_lines=get_echo_call_output(),
             text=service_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -307,7 +307,7 @@ class TestROS2ServiceCLI(unittest.TestCase):
                 string_value='bazbar'
             ),
             text=service_command.output,
-            strict=True
+            strict=False
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
@@ -361,5 +361,5 @@ class TestROS2ServiceCLI(unittest.TestCase):
                 string_value='bazbar'
             ),
             text=service_command.output,
-            strict=True
+            strict=False
         )

--- a/ros2service/test/test_echo.py
+++ b/ros2service/test/test_echo.py
@@ -161,7 +161,7 @@ class TestROS2ServiceEcho(unittest.TestCase):
                 functools.partial(
                     launch_testing.tools.expect_output,
                     expected_lines=EXPECTED_OUTPUT,
-                    strict=True
+                    strict=False
                 ),
                 timeout=10,
             )
@@ -177,7 +177,7 @@ class TestROS2ServiceEcho(unittest.TestCase):
                 functools.partial(
                     launch_testing.tools.expect_output,
                     expected_lines=EXPECTED_OUTPUT,
-                    strict=True
+                    strict=False
                 ),
                 timeout=10,
             )


### PR DESCRIPTION
## Description

Part of https://github.com/ros2/ros2cli/issues/1054

> [!NOTE]
> This fix only required for RTI ConnextDDS v7.3.0, that means we only need to backport this to Kilted.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information
