### PR TITLE
CMakeLists.txt.em: Reduce boilerplate in install(TARGETS for library

### DIFF
--- a/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/cmake/CMakeLists.txt.em
@@ -55,9 +55,7 @@ install(
 install(
   TARGETS @(cpp_library_name)
   EXPORT export_@(project_name)
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
+)
 @[end if]@
 @[if cpp_node_name]@
 


### PR DESCRIPTION
## Description

Since CMake 3.14, the install(TARGETS signature had default install destination that work well, without requiring for the user the need to set any boilerplate (see https://cmake.org/cmake/help/v3.14/command/install.html#installing-targets). As since https://github.com/ros2/ros2cli/pull/969 the minimum version of CMake is 3.16, we can remove all the `DESTINATION` arguments from the library `install(TARGETS` call, and the libraries will still be installed in the correct location. 

Note that the `install(TARGETS` call that install the node executable will still keep its `DESTINATION` arguments, as in that case the `DESTINATION` is non-standard.

### Is this user-facing behavior change?

The generated CMakeLists.txt will change from containing:

~~~
install(
  TARGETS <cpp_library_name>
  EXPORT export_<project_name>
  ARCHIVE DESTINATION lib
  LIBRARY DESTINATION lib
  RUNTIME DESTINATION bin)
~~~

to:

~~~
install(
  TARGETS <cpp_library_name>
  EXPORT export_<project_name>
)
~~~

while keeping the same behavior, reducing the generated boilerplate.

### Did you use Generative AI?

No.

### Additional Information

Triggered by https://github.com/ros-misc-utilities/apriltag_detector/pull/7 .
