### PR TITLE
Make sure to install py.typed files

### DIFF
--- a/ros2action/setup.py
+++ b/ros2action/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Jacob Perron',

--- a/ros2cli/setup.py
+++ b/ros2cli/setup.py
@@ -21,6 +21,7 @@ setup(
             'completion/ros2-argcomplete.zsh'
         ]),
     ],
+    package_data={'': ['py.typed']},
     zip_safe=False,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',

--- a/ros2component/setup.py
+++ b/ros2component/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Michel Hidalgo',

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Claire Wang',

--- a/ros2interface/setup.py
+++ b/ros2interface/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Siddharth Kucheria, Jacob Perron',

--- a/ros2lifecycle/setup.py
+++ b/ros2lifecycle/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ros2multicast/setup.py
+++ b/ros2multicast/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ros2node/setup.py
+++ b/ros2node/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ros2param/setup.py
+++ b/ros2param/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ros2pkg/setup.py
+++ b/ros2pkg/setup.py
@@ -50,6 +50,7 @@ The package provides the pkg command for the ROS 2 command line tools.""",
     package_data={
         'ros2pkg': [
             'resource/**/*',
+            'py.typed'
         ],
     },
 )

--- a/ros2run/setup.py
+++ b/ros2run/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Dirk Thomas',

--- a/ros2service/setup.py
+++ b/ros2service/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='William Woodall',

--- a/ros2topic/setup.py
+++ b/ros2topic/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     install_requires=['ros2cli'],
     zip_safe=True,
     author='Dirk Thomas',


### PR DESCRIPTION
## Description

Similar to https://github.com/ros2/launch/pull/886, see https://github.com/ros2/launch/issues/885.

### Is this user-facing behavior change?

This will make `mypy` (e.g., through `ament_mypy`) be stricter about type annotation for downstream users of the packages with a `py.typed` file, such as `ros2cli`. For example, see https://github.com/ros2/ros2_tracing/issues/160#issuecomment-2971204451. This could be considered a breaking change. This is probably only a concern for `ros2cli`, since the other packages are leaf-y. However, the `ros2cli` API is pretty simple, so this shouldn't be a big headache.

### Did you use Generative AI?

No.

### Additional Information

It's important to test all core packages downstream of these.
