### PR TITLE
fix setuptools deprecations

### DIFF
--- a/ros2action/setup.py
+++ b/ros2action/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The action command for ROS 2 command line tools.',
     long_description="""\
 The package provides the action command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'action = ros2action.command.action:ActionCommand',

--- a/ros2cli/setup.py
+++ b/ros2cli/setup.py
@@ -7,6 +7,9 @@ setup(
     packages=find_packages(exclude=['test']),
     extras_require={
         'completion': ['argcomplete'],
+        'test': [
+            'pytest',
+        ],
     },
     data_files=[
         ('share/ament_index/resource_index/packages', [
@@ -33,7 +36,6 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='Framework for ROS 2 command line tools.',
@@ -41,7 +43,6 @@ setup(
 The framework provides a single command line script which can be extended with
 commands and verbs.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
     entry_points={
         'ros2cli.command': [
             'daemon = ros2cli.command.daemon:DaemonCommand',

--- a/ros2component/setup.py
+++ b/ros2component/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The component command for ROS 2 command line tools.',
     long_description="""\
 The package provides the component command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'component = ros2component.command.component:ComponentCommand',

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The doctor command for ROS 2 command line tools',
     long_description="""\
     The package provides a cli tool to check potential issues in a ROS 2 system""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'doctor = ros2doctor.command.doctor:DoctorCommand',

--- a/ros2interface/setup.py
+++ b/ros2interface/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The interface command for ROS 2 command line tools.',
     long_description="""\
 The package provides the interface command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'interface = ros2interface.command.interface:InterfaceCommand',

--- a/ros2lifecycle/setup.py
+++ b/ros2lifecycle/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The lifecycle command for ROS 2 command line tools.',
     long_description="""\
 The package provides the lifecycle command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'lifecycle = ros2lifecycle.command.lifecycle:LifecycleCommand',

--- a/ros2multicast/setup.py
+++ b/ros2multicast/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The multicast command for ROS 2 command line tools.',
     long_description="""\
 The package provides the multicast command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'multicast = ros2multicast.command.multicast:MulticastCommand',

--- a/ros2node/setup.py
+++ b/ros2node/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The node command for ROS 2 command line tools.',
     long_description="""\
 The package provides the node command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'node = ros2node.command.node:NodeCommand',

--- a/ros2param/setup.py
+++ b/ros2param/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The param command for ROS 2 command line tools.',
     long_description="""\
 The package provides the param command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'param = ros2param.command.param:ParamCommand',

--- a/ros2pkg/ros2pkg/resource/ament_python/setup.py.em
+++ b/ros2pkg/ros2pkg/resource/ament_python/setup.py.em
@@ -17,7 +17,11 @@ setup(
     maintainer_email='@maintainer_email',
     description='@package_description',
     license='@package_license',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'console_scripts': [
 @[if node_name]@

--- a/ros2pkg/setup.py
+++ b/ros2pkg/setup.py
@@ -24,14 +24,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The pkg command for ROS 2 command line tools.',
     long_description="""\
 The package provides the pkg command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'pkg = ros2pkg.command.pkg:PkgCommand',

--- a/ros2run/setup.py
+++ b/ros2run/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The run command for ROS 2 command line tools.',
     long_description="""\
 The package provides the run command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'run = ros2run.command.run:RunCommand',

--- a/ros2service/setup.py
+++ b/ros2service/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The service command for ROS 2 command line tools.',
     long_description="""\
 The package provides the service command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'service = ros2service.command.service:ServiceCommand',

--- a/ros2topic/setup.py
+++ b/ros2topic/setup.py
@@ -25,14 +25,17 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The topic command for ROS 2 command line tools.',
     long_description="""\
 The package provides the topic command for the ROS 2 command line tools.""",
     license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
     entry_points={
         'ros2cli.command': [
             'topic = ros2topic.command.topic:TopicCommand',


### PR DESCRIPTION


## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: Apache Software License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************
### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
