### PR TITLE
Fujitatomoya/ros2 action send goal timeout

### DIFF
--- a/ros2action/ros2action/verb/send_goal.py
+++ b/ros2action/ros2action/verb/send_goal.py
@@ -124,7 +124,7 @@ def send_goal(action_name, action_type, goal_values, feedback_callback, timeout=
 
         print('Waiting for an action server to become available...')
         if not action_client.wait_for_server(timeout_sec=timeout):
-            print('Action server is not available after waiting {timeout} seconds.')
+            print(f'Action server is not available after waiting {timeout} seconds.')
             return
 
         stamp_now = node.get_clock().now().to_msg()
@@ -179,7 +179,7 @@ def send_goal(action_name, action_type, goal_values, feedback_callback, timeout=
         rclpy.spin_until_future_complete(node, result_future, timeout_sec=timeout)
 
         if not result_future.done():
-            print('Timed out waiting for result after {timeout} seconds.')
+            print(f'Timed out waiting for result after {timeout} seconds.')
             return
 
         result = result_future.result()

--- a/ros2action/ros2action/verb/send_goal.py
+++ b/ros2action/ros2action/verb/send_goal.py
@@ -53,6 +53,12 @@ class SendGoalVerb(VerbExtension):
         parser.add_argument(
             '-f', '--feedback', action='store_true',
             help='Echo feedback messages for the goal')
+        parser.add_argument(
+            '-t', '--timeout', metavar='N', type=int, default=None,
+            help=(
+                'Wait for N seconds until server becomes available and goal is completed '
+                '(default waits indefinitely)'
+            ))
 
     def main(self, *, args):
         feedback_callback = None
@@ -64,7 +70,7 @@ class SendGoalVerb(VerbExtension):
         else:
             goal = args.goal
 
-        return send_goal(args.action_name, args.action_type, goal, feedback_callback)
+        return send_goal(args.action_name, args.action_type, goal, feedback_callback, args.timeout)
 
 
 def _goal_status_to_string(status):
@@ -88,7 +94,7 @@ def _feedback_callback(feedback):
     print('Feedback:\n    {}'.format(message_to_yaml(feedback.feedback)))
 
 
-def send_goal(action_name, action_type, goal_values, feedback_callback):
+def send_goal(action_name, action_type, goal_values, feedback_callback, timeout=None):
     goal_handle = None
     node = None
     action_client = None
@@ -117,7 +123,9 @@ def send_goal(action_name, action_type, goal_values, feedback_callback):
             return 'Failed to populate message fields: {!r}'.format(ex)
 
         print('Waiting for an action server to become available...')
-        action_client.wait_for_server()
+        if not action_client.wait_for_server(timeout_sec=timeout):
+            print('Action server is not available after waiting {timeout} seconds.')
+            return
 
         stamp_now = node.get_clock().now().to_msg()
         for field_setter in timestamp_fields:
@@ -168,7 +176,11 @@ def send_goal(action_name, action_type, goal_values, feedback_callback):
         print('Goal accepted with ID: {}\n'.format(bytes(goal_handle.goal_id.uuid).hex()))
 
         result_future = goal_handle.get_result_async()
-        rclpy.spin_until_future_complete(node, result_future)
+        rclpy.spin_until_future_complete(node, result_future, timeout_sec=timeout)
+
+        if not result_future.done():
+            print('Timed out waiting for result after {timeout} seconds.')
+            return
 
         result = result_future.result()
 

--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -257,6 +257,27 @@ class TestROS2ActionCLI(unittest.TestCase):
         assert int(command_output_lines[0]) == 1
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_send_fibonacci_goal_timeout_server_not_available(self):
+        with self.launch_action_command(
+            arguments=[
+                'send_goal',
+                '-t', '1',
+                '/test/fibonacci_noexist',
+                'test_msgs/action/Fibonacci',
+                '{order: 1}'
+            ],
+        ) as action_command:
+            assert action_command.wait_for_shutdown(timeout=10)
+        assert action_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                'Waiting for an action server to become available...',
+                'Action server is not available after waiting 1 seconds.'
+            ],
+            text=action_command.output, strict=False
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_send_fibonacci_goal(self):
         with self.launch_action_command(
             arguments=[


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1065 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes, it now supports the timeout argument via `ros2 action send_goal`.
default behavior is consistent, it just waits on the future indefinitely.
this is backward compatible, so that we can backport this feature to the downstream branches.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes, for the self-review

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
