### PR TITLE
add warning notice for ros2 doctor --report.

### DIFF
--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -176,11 +176,12 @@ def print_warning_notice() -> None:
     print('\n' + '='*80)
     print('!!! WARNING !!!'.center(80))
     print('='*80)
-    print(
-        'The report includes all ROS 2 endpoint information and system platform information.\n'
+    warning_message = [
+        'The report includes all ROS 2 endpoint information and system platform information.',
         'Please review the report before sharing, as it may contain sensitive or private data.'
-        .center(80)
-    )
+    ]
+    for line in warning_message:
+        print(line.center(80))
     print('='*80 + '\n')
 
 

--- a/ros2doctor/ros2doctor/api/__init__.py
+++ b/ros2doctor/ros2doctor/api/__init__.py
@@ -172,6 +172,18 @@ def generate_reports(*, categories=None, exclude_packages=False) -> List[Report]
     return reports
 
 
+def print_warning_notice() -> None:
+    print('\n' + '='*80)
+    print('!!! WARNING !!!'.center(80))
+    print('='*80)
+    print(
+        'The report includes all ROS 2 endpoint information and system platform information.\n'
+        'Please review the report before sharing, as it may contain sensitive or private data.'
+        .center(80)
+    )
+    print('='*80 + '\n')
+
+
 def get_topic_names(skip_topics: List[str] = []) -> List[str]:
     """Get all topic names using rclpy API."""
     topics: List[str] = []

--- a/ros2doctor/ros2doctor/command/doctor.py
+++ b/ros2doctor/ros2doctor/command/doctor.py
@@ -15,6 +15,7 @@
 from ros2cli.command import add_subparsers_on_demand
 from ros2cli.command import CommandExtension
 from ros2doctor.api import generate_reports
+from ros2doctor.api import print_warning_notice
 from ros2doctor.api import run_checks
 from ros2doctor.api.format import format_print
 
@@ -57,6 +58,8 @@ class DoctorCommand(CommandExtension):
             all_reports = generate_reports(exclude_packages=ep)
             for report_obj in all_reports:
                 format_print(report_obj)
+            # Warn user about sensitive data in the report
+            print_warning_notice()
             return
 
         # `ros2 doctor


### PR DESCRIPTION
## Description

I sometimes see that some users do not want to post the `ros2 doctor –report` full report, because it includes the sensitive and private data in the report. (this is known because some issue author describes that they do not post the report because of the private data.)
It would be probably nice to add the warning that says “report includes the all ROS 2 endpoint information and system platform information” to let the user know what they are reporting.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes, if we call `ros2 doctor --report`, it includes the following warning notice.

```console
...<snip>
   TOPIC LIST
topic               : none
publisher count     : 0
subscriber count    : 0

================================================================================
                                !!! WARNING !!!
================================================================================
The report includes all ROS 2 endpoint information and system platform information.
Please review the report before sharing, as it may contain sensitive or private data.
================================================================================

```

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
