### PR TITLE
Restore environment variables after launch tests

### DIFF
--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -20,7 +20,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 
 import launch_testing
 import launch_testing.actions
@@ -60,6 +63,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2action/test/test_echo.py
+++ b/ros2action/test/test_echo.py
@@ -21,7 +21,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 
 import launch_testing
 import launch_testing.actions
@@ -230,6 +233,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2doctor/test/test_qos_compatibility.py
+++ b/ros2doctor/test/test_qos_compatibility.py
@@ -19,7 +19,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 
 from launch_ros.actions import Node
 
@@ -88,6 +91,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -18,7 +18,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 from launch_ros.actions import Node
 
 import launch_testing
@@ -133,6 +136,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -21,7 +21,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 
 from launch_ros.actions import Node
 
@@ -61,6 +64,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2node/test/test_cli_duplicate_node_names.py
+++ b/ros2node/test/test_cli_duplicate_node_names.py
@@ -19,7 +19,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 
 from launch_ros.actions import Node
 
@@ -60,6 +63,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -21,7 +21,10 @@ import xmlrpc
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 from launch_ros.actions import Node
 import launch_testing
 import launch_testing.actions
@@ -105,6 +108,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -21,7 +21,10 @@ import xmlrpc
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 from launch_ros.actions import Node
 import launch_testing
 import launch_testing.actions
@@ -75,6 +78,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -22,7 +22,10 @@ import xmlrpc
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 from launch_ros.actions import Node
 import launch_testing
 import launch_testing.actions
@@ -125,6 +128,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -21,7 +21,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 from launch_ros.actions import Node
 
 import launch_testing
@@ -78,6 +81,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2service/test/test_echo.py
+++ b/ros2service/test/test_echo.py
@@ -21,7 +21,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 from launch_ros.actions import Node
 
 import launch_testing
@@ -102,6 +105,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -22,7 +22,10 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 
 from launch_ros.actions import Node
 
@@ -118,6 +121,7 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(


### PR DESCRIPTION
## Description

These tests change the process environment variables using the SetEnvironmentVariable action. We should reset the variables when the test concludes to avoid stepping on other tests that execute in the same pytest process.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=24548)](http://ci.ros2.org/job/ci_linux/24548/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18590)](http://ci.ros2.org/job/ci_linux-aarch64/18590/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=3998)](http://ci.ros2.org/job/ci_linux-rhel/3998/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=25084)](http://ci.ros2.org/job/ci_windows/25084/)