### PR TITLE
fix: Also catch a TimeoutError

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -46,7 +46,7 @@ class DaemonNode:
                 for method in self._proxy.system.listMethods()
                 if not method.startswith('system.')
             ]
-        except (ConnectionRefusedError, ConnectionResetError):
+        except (ConnectionRefusedError, ConnectionResetError, TimeoutError):
             return False
         return True
 


### PR DESCRIPTION
## Description
Also catch a TimeoutError for the Node ServerProxy

### Is this user-facing behavior change?

Not sure, but it should not crash anymore when a timeout happens

### Did you use Generative AI?
No

### Additional Information
Related to https://github.com/ros2/ros2cli/issues/1089#issuecomment-3227564385