### PR TITLE
Fujitatomoya/clearup isolated ros2daemon

### DIFF
--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -63,9 +63,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2action/test/test_echo.py
+++ b/ros2action/test/test_echo.py
@@ -233,9 +233,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2doctor/test/test_environment_report.py
+++ b/ros2doctor/test/test_environment_report.py
@@ -22,7 +22,11 @@ import unittest
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
+
 import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
@@ -63,6 +67,17 @@ def generate_test_description(rmw_implementation: str) -> tuple[LaunchDescriptio
             on_exit=[
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2doctor/test/test_qos_compatibility.py
+++ b/ros2doctor/test/test_qos_compatibility.py
@@ -91,9 +91,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2doctor/test/test_report.py
+++ b/ros2doctor/test/test_report.py
@@ -24,6 +24,7 @@ import unittest
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess
+from launch.actions import SetEnvironmentVariable
 
 from launch_ros.actions import Node
 
@@ -32,6 +33,7 @@ import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.markers
 import launch_testing.tools
+from launch_testing_ros.actions import EnableRmwIsolation
 import launch_testing_ros.tools
 
 import pytest
@@ -55,21 +57,22 @@ def generate_test_description(rmw_implementation: str) -> Tuple[LaunchDescriptio
     path_to_fixtures = os.path.join(os.path.dirname(__file__), 'fixtures')
     additional_env = get_rmw_additional_env(rmw_implementation)
     additional_env['PYTHONUNBUFFERED'] = '1'
+    set_env_actions = [SetEnvironmentVariable(k, v) for k, v in additional_env.items()]
 
     return LaunchDescription([
         ExecuteProcess(
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                *set_env_actions,
+                EnableRmwIsolation(),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',
-                    additional_env=additional_env,
                     on_exit=[
                         Node(
                             executable=sys.executable,
                             arguments=[os.path.join(path_to_fixtures, 'report_node.py')],
-                            additional_env=additional_env
                         ),
                         launch_testing.actions.ReadyToTest()
                     ]
@@ -100,11 +103,8 @@ class TestROS2DoctorReport(unittest.TestCase):
             self,
             arguments
         ) -> Generator[launch_testing.tools.process.ProcessProxy, None, None]:
-            additional_env = get_rmw_additional_env(rmw_implementation)
-            additional_env['PYTHONUNBUFFERED'] = '1'
             doctor_command_action = ExecuteProcess(
                 cmd=['ros2', 'doctor', *arguments],
-                additional_env=additional_env,
                 name='ros2doctor-cli',
                 output='screen'
             )

--- a/ros2doctor/test/test_report.py
+++ b/ros2doctor/test/test_report.py
@@ -67,9 +67,19 @@ def generate_test_description(rmw_implementation: str) -> Tuple[LaunchDescriptio
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2doctor/test/test_report.py
+++ b/ros2doctor/test/test_report.py
@@ -24,7 +24,10 @@ import unittest
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
 from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
 
 from launch_ros.actions import Node
 
@@ -64,6 +67,7 @@ def generate_test_description(rmw_implementation: str) -> Tuple[LaunchDescriptio
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
+                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
                 ExecuteProcess(
@@ -130,11 +134,6 @@ class TestROS2DoctorReport(unittest.TestCase):
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_report(self) -> None:
-        # TODO(@fujitatomoya): rmw_zenoh_cpp is instable to find the endpoints, it does not
-        # matter if DaemonNode or DirectNode is used. For now, skip the test for rmw_zenoh_cpp.
-        if self.rmw_implementation == 'rmw_zenoh_cpp':
-            raise unittest.SkipTest()
-
         for argument in ['-r', '--report']:
             with self.launch_doctor_command(
                     arguments=[argument]

--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -136,9 +136,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2node/test/test_cli.py
+++ b/ros2node/test/test_cli.py
@@ -64,9 +64,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2node/test/test_cli_duplicate_node_names.py
+++ b/ros2node/test/test_cli_duplicate_node_names.py
@@ -63,9 +63,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2param/test/test_verb_dump.py
+++ b/ros2param/test/test_verb_dump.py
@@ -108,9 +108,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -78,9 +78,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -128,9 +128,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2service/test/test_cli.py
+++ b/ros2service/test/test_cli.py
@@ -81,9 +81,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2service/test/test_echo.py
+++ b/ros2service/test/test_echo.py
@@ -105,9 +105,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2topic/test/test_bw_delay_hz.py
+++ b/ros2topic/test/test_bw_delay_hz.py
@@ -20,6 +20,9 @@ from geometry_msgs.msg import PointStamped  # Used because delay requires a mess
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
+from launch.event_handlers import OnShutdown
 
 import launch_testing
 import launch_testing.actions
@@ -63,6 +66,15 @@ def generate_test_description():
             name='daemon-stop',
             on_exit=[
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -121,9 +121,19 @@ def generate_test_description(rmw_implementation):
             cmd=['ros2', 'daemon', 'stop'],
             name='daemon-stop',
             on_exit=[
-                RegisterEventHandler(OnShutdown(on_shutdown=ResetEnvironment())),
                 *set_env_actions,
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        # Use the same isolated environment
+                        additional_env=dict(additional_env),
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2topic/test/test_echo_pub.py
+++ b/ros2topic/test/test_echo_pub.py
@@ -20,6 +20,9 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
+from launch.event_handlers import OnShutdown
 
 import launch_testing
 import launch_testing.actions
@@ -67,6 +70,15 @@ def generate_test_description():
             name='daemon-stop',
             on_exit=[
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',

--- a/ros2topic/test/test_use_sim_time.py
+++ b/ros2topic/test/test_use_sim_time.py
@@ -20,6 +20,9 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
+from launch.event_handlers import OnShutdown
 
 import launch_testing
 import launch_testing.actions
@@ -61,6 +64,15 @@ def generate_test_description():
             name='daemon-stop',
             on_exit=[
                 EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                    ),
+                    # This must be done after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
                 ExecuteProcess(
                     cmd=['ros2', 'daemon', 'start'],
                     name='daemon-start',


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/ros2cli/issues/1097

Possible fix for https://github.com/ros2/ros2cli/issues/1088, at least my local environment test results are all green and stable.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

No, only test cleanup process is fixed.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This PR includes https://github.com/ros2/ros2cli/pull/1096