### PR TITLE
Add environment variable to override daemon endpoint

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -57,6 +57,9 @@ def make_xmlrpc_server() -> LocalXMLRPCServer:
     """Make local XMLRPC server listening over ros2cli daemon's default port."""
     address = get_address()
 
+    assert urlparse(get_xmlrpc_server_url()).scheme == 'http', \
+        'Only http XMLRPC servers are supported at this time.'
+
     return LocalXMLRPCServer(
         address, logRequests=False,
         requestHandler=RequestHandler,
@@ -143,7 +146,11 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
             shutdown = True
         server.register_function(shutdown_handler, 'system.shutdown')
 
-        print('Serving XML-RPC on ' + get_xmlrpc_server_url(server.server_address))
+        server_path = server.RequestHandlerClass.rpc_paths[0]
+        server_hostname, server_port = server.server_address
+        server_url = f'http://{server_hostname}:{server_port}{server_path}'
+
+        print('Serving XML-RPC on ' + server_url)
         try:
             while rclpy.ok() and not shutdown:
                 server.handle_request()

--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -16,6 +16,7 @@ import argparse
 import os
 import time
 from urllib.parse import urlparse
+from urllib.parse import urlunparse
 import uuid
 
 import rclpy
@@ -32,13 +33,25 @@ from ros2cli.xmlrpc.local_server import LocalXMLRPCServer
 from ros2cli.xmlrpc.local_server import SimpleXMLRPCRequestHandler
 
 
+SERVER_URL_VARIABLE_NAME = 'ROS2_DAEMON_SERVER_URL'
+
+
 def get_xmlrpc_server_url(address=None):
-    if address:
-        host, port = address
-    else:
-        host = '127.0.0.1'
-        port = 11511 + int(os.environ.get('ROS_DOMAIN_ID', 0))
-    return f'http://{host}:{port}/ros2cli/'
+    url = urlparse(
+        os.environ.get(SERVER_URL_VARIABLE_NAME) or '/ros2cli/',
+        scheme='http')
+
+    if address is None:
+        address = (
+            url.hostname or '127.0.0.1',
+            str(
+                url.port
+                if url.port not in (None, '')
+                else (11511 + int(os.environ.get('ROS_DOMAIN_ID', 0)))
+            ),
+        )
+
+    return urlunparse(url._replace(netloc=':'.join(address)))
 
 
 def get_port():

--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -15,6 +15,7 @@
 import argparse
 import os
 import time
+from urllib.parse import urlparse
 import uuid
 
 import rclpy
@@ -31,26 +32,45 @@ from ros2cli.xmlrpc.local_server import LocalXMLRPCServer
 from ros2cli.xmlrpc.local_server import SimpleXMLRPCRequestHandler
 
 
+def get_xmlrpc_server_url(address=None):
+    if address:
+        host, port = address
+    else:
+        host = '127.0.0.1'
+        port = 11511 + int(os.environ.get('ROS_DOMAIN_ID', 0))
+    return f'http://{host}:{port}/ros2cli/'
+
+
 def get_port():
-    base_port = 11511
-    base_port += int(os.environ.get('ROS_DOMAIN_ID', 0))
-    return base_port
+    url = get_xmlrpc_server_url()
+    return urlparse(url).port
 
 
 def get_address():
-    return '127.0.0.1', get_port()
+    url = get_xmlrpc_server_url()
+    parsed_url = urlparse(url)
+    return parsed_url.hostname, parsed_url.port
+
+
+def get_path():
+    url = get_xmlrpc_server_url()
+    return urlparse(url).path
 
 
 class RequestHandler(SimpleXMLRPCRequestHandler):
-    rpc_paths = ('/ros2cli/',)
 
+    class _GetRpcPaths(property):
+        """
+        Getter for the RPC paths value to use on the request handler.
 
-def get_xmlrpc_server_url(address=None):
-    if not address:
-        address = get_address()
-    host, port = address
-    path = RequestHandler.rpc_paths[0]
-    return f'http://{host}:{port}{path}'
+        We need this property to work when accessed from the class reference,
+        so we can't just use ``@property`` here.
+        """
+
+        def __get__(self, instance, owner):
+            return (get_path(),)
+
+    rpc_paths = _GetRpcPaths()
 
 
 def make_xmlrpc_server() -> LocalXMLRPCServer:

--- a/ros2cli/test/test_ros2cli_daemon.py
+++ b/ros2cli/test/test_ros2cli_daemon.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import time
+from unittest.mock import patch
 
 import pytest
 
 import rclpy
 import rclpy.action
 
+from ros2cli.daemon import SERVER_URL_VARIABLE_NAME
 from ros2cli.node.daemon import DaemonNode
 from ros2cli.node.daemon import is_daemon_running
 from ros2cli.node.daemon import shutdown_daemon
@@ -103,8 +105,7 @@ def local_node():
         yield node
 
 
-@pytest.fixture(scope='module')
-def daemon_node():
+def _daemon_node():
     if is_daemon_running(args=[]):
         assert shutdown_daemon(args=[], timeout=5.0)
     assert spawn_daemon(args=[], timeout=5.0)
@@ -126,6 +127,11 @@ def daemon_node():
             )
         yield node
         node.system.shutdown()
+
+
+@pytest.fixture(scope='module')
+def daemon_node():
+    yield from _daemon_node()
 
 
 def test_get_name(daemon_node):
@@ -249,3 +255,25 @@ def test_count_clients(daemon_node):
 
 def test_count_services(daemon_node):
     assert 1 == daemon_node.count_services(TEST_SERVICE_NAME)
+
+
+def test_url_override(daemon_node):
+    # Started by daemon_node
+    assert is_daemon_running(args=[])
+
+    with patch.dict(
+        'ros2cli.daemon.os.environ',
+        {SERVER_URL_VARIABLE_NAME: 'http://127.0.0.1:11744/test/'},
+    ):
+        # No daemon running on that port
+        assert not is_daemon_running(args=[])
+
+        for _ in _daemon_node():
+            # New daemon running on our custom port
+            assert is_daemon_running(args=[])
+
+        # Custom port daemon is shut down
+        assert not is_daemon_running(args=[])
+
+    # Back to the one started by daemon_node
+    assert is_daemon_running(args=[])


### PR DESCRIPTION
## Description

This change adds a new environment variable 'ROS2_DAEMON_SERVER_URL' which can be used to change the expected endpoint for communicating with the ROS 2 daemon process.

Unspecified parts of the URL will be replaced with default values, so it's possible to omit the scheme, host, and port to retain default behavior while still overriding other parts of the URL.

There are two supporting commits in this PR which shouldn't result in any user-facing changes alone, and are separated for review purposes. They may either be squashed upon merging or retained as individuals by a rebase merge.

### Is this user-facing behavior change?

Yes, users can now use the `ROS2_DAEMON_SERVER_URL` environment variable to control the endpoint over which daemon communication occurs.

### Did you use Generative AI?

No

### Additional Information

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=24767)](http://ci.ros2.org/job/ci_linux/24767/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18794)](http://ci.ros2.org/job/ci_linux-aarch64/18794/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=4219)](http://ci.ros2.org/job/ci_linux-rhel/4219/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=25282)](http://ci.ros2.org/job/ci_windows/25282/)

The long-term goal of this work is to support daemon isolation for parallelized testing in other packages.