### PR TITLE
Fix ros2 topic pub --stdin

### DIFF
--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -138,7 +138,7 @@ def main(args):
         times = 1
 
     if args.stdin:
-        values = collect_stdin()
+        values = collect_stdin().decode()
     else:
         values = args.values
 


### PR DESCRIPTION
## Description

Running the following command currently fails:

    ros2 topic pub --stdin /test std_msgs/Bool <<< "{data: true}"

The error is:

    Traceback (most recent call last):
      File "/python3.12-ros-jazzy-ros2cli-0.32.6-r1/bin/ros2", line 34, in <module>
        sys.exit(load_entry_point('ros2cli==0.32.6', 'console_scripts', 'ros2')())
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/ros-env/lib/python3.12/site-packages/ros2cli/cli.py", line 91, in main
        rc = extension.main(parser=parser, args=args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/ros-env/lib/python3.12/site-packages/ros2topic/command/topic.py", line 41, in main
        return extension.main(args=args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/ros-env/lib/python3.12/site-packages/ros2topic/verb/pub.py", line 117, in main
        return main(args)
               ^^^^^^^^^^
      File "/ros-env/lib/python3.12/site-packages/ros2topic/verb/pub.py", line 138, in main
        return publisher(
               ^^^^^^^^^^
      File "/ros-env/lib/python3.12/site-packages/ros2topic/verb/pub.py", line 174, in publisher
        if '^J' in values:
           ^^^^^^^^^^^^^^
    TypeError: a bytes-like object is required, not 'str'

We fix it by decoding stdin to utf8 string to match the type of values passed via a command line argument.

### Is this user-facing behavior change?

yes

### Did you use Generative AI?

no

