### PR TITLE
Add error handling when parsing package locally

### DIFF
--- a/ros2doctor/ros2doctor/api/package.py
+++ b/ros2doctor/ros2doctor/api/package.py
@@ -83,8 +83,15 @@ def get_local_package_versions() -> dict:
     if package_name_prefixes:
         for name, prefix in package_name_prefixes.items():
             file_path = os.path.join(prefix, 'share', name)
-            package_obj = parse_package(file_path)
-            local_packages[name] = package_obj.version if package_obj.version else ''
+            try:
+                package_obj = parse_package(file_path)
+                local_packages[name] = package_obj.version if package_obj.version else ''
+            except IOError as e:
+                print(f"Warning: Could not read package at {file_path}: {e}")
+                local_packages[name] = ''
+            except Exception as e:
+                print(f"Error parsing {file_path}: {e}")
+                local_packages[name] = ''
     return local_packages
 
 

--- a/ros2doctor/ros2doctor/api/package.py
+++ b/ros2doctor/ros2doctor/api/package.py
@@ -87,10 +87,10 @@ def get_local_package_versions() -> dict:
                 package_obj = parse_package(file_path)
                 local_packages[name] = package_obj.version if package_obj.version else ''
             except IOError as e:
-                print(f"Warning: Could not read package at {file_path}: {e}")
+                print(f'Warning: Could not read package at {file_path}: {e}')
                 local_packages[name] = ''
             except Exception as e:
-                print(f"Error parsing {file_path}: {e}")
+                print(f'Error parsing {file_path}: {e}')
                 local_packages[name] = ''
     return local_packages
 


### PR DESCRIPTION
## Description
When running `ros2 doctor --report`, I encountered the following warning:
```
/opt/ros/rolling/lib/python3.12/site-packages/ros2doctor/api/__init__.py: 262: UserWarning: Fail to call PackageReport class functions.
```
Additionally, none of the packages displayed their versions. This issue appears to be caused by missing package.xml files in several rmf-* packages.  I have already filed a ticket at https://github.com/open-rmf/rmf_traffic/issues/125. 

However, I think we could also improve `ros2 doctor` by catching the exception when parsing packages. https://github.com/ros-infrastructure/catkin_pkg/blob/921fc9e64af6b78fe84cd9dbb92a4d660c3dafa4/src/catkin_pkg/package.py#L571-L584



### Is this user-facing behavior change?


### Did you use Generative AI?

No

### Additional Information

Before this PR, only a warning for package report:
```
/opt/ros/rolling/lib/python3.12/site-packages/ros2doctor/api/__init__.py: 262: UserWarning: Fail to call PackageReport class functions.
```

After this PR, ros2 doctor --report now logs warnings for problematic packages instead of silently failing:
```
Warning: Could not read package at /opt/ros/rolling/share/rmf_task_sequence: Path "/opt/ros/rolling/share/rmf_task_sequence" is neither a directory containing a "package.xml" file nor a file
Warning: Could not read package at /opt/ros/rolling/share/rmf_traffic: Path "/opt/ros/rolling/share/rmf_traffic" is neither a directory containing a "package.xml" file nor a file
Warning: Could not read package at /opt/ros/rolling/share/rmf_task: Path "/opt/ros/rolling/share/rmf_task" is neither a directory containing a "package.xml" file nor a file
Warning: Could not read package at /opt/ros/rolling/share/rmf_utils: Path "/opt/ros/rolling/share/rmf_utils" is neither a directory containing a "package.xml" file nor a file
Warning: Could not read package at /opt/ros/rolling/share/rmf_battery: Path "/opt/ros/rolling/share/rmf_battery" is neither a directory containing a "package.xml" file nor a file
```
For these packages, the local version field is now left blank in the report:
```
rmf_task_sequence                         : latest=2.7.0, local=
rmf_utils                                 : latest=1.7.0, local=
rmf_task                                  : latest=2.7.0, local=
```

