### PR TITLE
Fix handling of empty ROS_DOMAIN_ID in ros2cli

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -33,7 +33,7 @@ from ros2cli.xmlrpc.local_server import SimpleXMLRPCRequestHandler
 
 def get_port():
     base_port = 11511
-    base_port += int(os.environ.get('ROS_DOMAIN_ID', 0))
+    base_port += int(os.environ.get('ROS_DOMAIN_ID') or 0)
     return base_port
 
 


### PR DESCRIPTION
## Description

For better cross-compatibility with Windows, we generally treat an "empty" environment variable the same as one which isn't set at all.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

Backtrace:

<details>

```
Traceback (most recent call last):
  File "~/rolling_ws/install/ros2cli/bin/ros2", line 33, in <module>
    sys.exit(load_entry_point('ros2cli==0.40.1', 'console_scripts', 'ros2')())
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/rolling_ws/install/ros2cli/lib/python3.14/site-packages/ros2cli/cli.py", line 91, in main
    rc = extension.main(parser=parser, args=args)
  File "~/rolling_ws/install/ros2cli/lib/python3.14/site-packages/ros2cli/command/daemon.py", line 38, in main
    return extension.main(args=args)
           ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "~/rolling_ws/install/ros2cli/lib/python3.14/site-packages/ros2cli/verb/daemon/stop.py", line 23, in main
    if shutdown_daemon(args, timeout=10.0):
       ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "~/rolling_ws/install/ros2cli/lib/python3.14/site-packages/ros2cli/node/daemon.py", line 90, in shutdown_daemon
    with DaemonNode(args) as node:
         ~~~~~~~~~~^^^^^^
  File "~/rolling_ws/install/ros2cli/lib/python3.14/site-packages/ros2cli/node/daemon.py", line 37, in __init__
    daemon.get_xmlrpc_server_url(),
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/rolling_ws/install/ros2cli/lib/python3.14/site-packages/ros2cli/daemon/__init__.py", line 50, in get_xmlrpc_server_url
    address = get_address()
  File "~/rolling_ws/install/ros2cli/lib/python3.14/site-packages/ros2cli/daemon/__init__.py", line 41, in get_address
    return '127.0.0.1', get_port()
                        ~~~~~~~~^^
  File "~/rolling_ws/install/ros2cli/lib/python3.14/site-packages/ros2cli/daemon/__init__.py", line 36, in get_port
    base_port += int(os.environ.get('ROS_DOMAIN_ID', 0))
                 ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: ''
```
</details>
