### PR TITLE
add osrf_pycommon depend for test_exec.

### DIFF
--- a/ros2action/package.xml
+++ b/ros2action/package.xml
@@ -32,6 +32,7 @@
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>python3-pytest-timeout</test_depend>
+  <test_depend>python3-osrf-pycommon</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

https://github.com/ros2/ros2cli/pull/978 adds the new `python3-osrf-pycommon` dependency for `test_depend`, but missing in the `package.xml`.
This will fail the `colcon test` on this package because of the lack of the test required package.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

No,

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
