### PR TITLE
add "--all/-a" option to "ros2 topic hz" with screen refresh.

### DIFF
--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -33,7 +33,6 @@ from collections import defaultdict
 
 import functools
 import math
-import os
 import threading
 import time
 

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -33,6 +33,7 @@ from collections import defaultdict
 
 import functools
 import math
+import os
 import threading
 import time
 
@@ -48,6 +49,7 @@ from ros2cli.qos import add_qos_arguments
 from ros2cli.qos import choose_qos
 
 from ros2topic.api import get_msg_class
+from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
@@ -68,10 +70,14 @@ class HzVerb(VerbExtension):
         )
         arg = parser.add_argument(
             'topic_name',
-            nargs='+',
+            nargs='*',
             help="Names of the ROS topic to listen to (e.g. '/chatter')")
         arg.completer = TopicNameCompleter(
             include_hidden_topics_key='include_hidden_topics')
+        parser.add_argument(
+            '--all', '-a',
+            dest='all_topics', default=False, action='store_true',
+            help='subscribe to all available topics')
         add_qos_arguments(parser, 'subscribe', 'sensor_data')
         parser.add_argument(
             '--window', '-w',
@@ -94,6 +100,11 @@ class HzVerb(VerbExtension):
 
 
 def main(args):
+    if not args.all_topics and not args.topic_name:
+        raise RuntimeError('Either specify topic names or use --all/-a option')
+    if args.all_topics and args.topic_name:
+        raise RuntimeError('Cannot specify both --all/-a and topic names')
+
     topics = args.topic_name
     if args.filter_expr:
         def expr_eval(expr):
@@ -105,8 +116,20 @@ def main(args):
         filter_expr = None
 
     with DirectNode(args) as node:
+        # Get all available topics at this moment
+        if args.all_topics:
+            topic_names_and_types = get_topic_names_and_types(
+                node=node.node,
+                include_hidden_topics=args.include_hidden_topics)
+            topics = [name for name, _ in topic_names_and_types]
+            if not topics:
+                print('No topics available')
+                return
+            print(f'Subscribing to all {len(topics)} available topics...')
+
         _rostopic_hz(node.node, topics, qos_args=args, window_size=args.window_size,
-                     filter_expr=filter_expr, use_wtime=args.use_wtime)
+                     filter_expr=filter_expr, use_wtime=args.use_wtime,
+                     all_topics=args.all_topics)
 
 
 class ROSTopicHz(object):
@@ -236,11 +259,15 @@ class ROSTopicHz(object):
 
         return rate, min_delta, max_delta, std_dev, n
 
-    def print_hz(self, topics=None):
+    def print_hz(self, topics=None, clear_screen=False):
         """Print the average publishing rate to screen."""
 
         def get_format_hz(stat):
             return stat[0] * 1e9, stat[1] * 1e-9, stat[2] * 1e-9, stat[3] * 1e-9, stat[4]
+
+        # Clear screen if requested (useful when monitoring all topics)
+        if clear_screen:
+            os.system('clear' if os.name != 'nt' else 'cls')
 
         if len(topics) == 1:
             ret = self.get_hz(topics[0])
@@ -290,7 +317,7 @@ def _get_ascii_table(header, cols):
 
 
 def _rostopic_hz(node, topics, qos_args, window_size=DEFAULT_WINDOW_SIZE, filter_expr=None,
-                 use_wtime=False):
+                 use_wtime=False, all_topics=False):
     """
     Periodically print the publishing rate of a topic to console until shutdown.
 
@@ -298,6 +325,7 @@ def _rostopic_hz(node, topics, qos_args, window_size=DEFAULT_WINDOW_SIZE, filter
     :param qos_args: qos arguments used to pick the qos profile of the subscriber
     :param window_size: number of messages to average over, -1 for infinite, ``int``
     :param filter_expr: Python filter expression that is called with m, the message instance
+    :param all_topics: whether all topics are being monitored, ``bool``
     """
     # pause hz until topic is published
     rt = ROSTopicHz(node, window_size, filter_expr=filter_expr, use_wtime=use_wtime)
@@ -334,7 +362,7 @@ def _rostopic_hz(node, topics, qos_args, window_size=DEFAULT_WINDOW_SIZE, filter
     try:
         def thread_func():
             while rclpy.ok():
-                rt.print_hz(topics)
+                rt.print_hz(topics, clear_screen=all_topics)
                 time.sleep(1.0)
 
         print_thread = threading.Thread(target=thread_func)

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -53,6 +53,7 @@ from ros2topic.api import get_topic_names_and_types
 from ros2topic.api import positive_int
 from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
+from ros2topic.verb.echo import clear_terminal
 
 DEFAULT_WINDOW_SIZE = 10000
 
@@ -267,7 +268,7 @@ class ROSTopicHz(object):
 
         # Clear screen if requested (useful when monitoring all topics)
         if clear_screen:
-            os.system('clear' if os.name != 'nt' else 'cls')
+            clear_terminal()
 
         if len(topics) == 1:
             ret = self.get_hz(topics[0])

--- a/ros2topic/test/test_bw_delay_hz.py
+++ b/ros2topic/test/test_bw_delay_hz.py
@@ -235,3 +235,136 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
             'hz',
             r'^average rate: [0-9\.]+$'
         )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_hz_all_topics(self, launch_service, proc_info, proc_output):
+        topics = [
+            f'/{TEST_NAMESPACE}/test_topic_1',
+            f'/{TEST_NAMESPACE}/test_topic_2',
+            f'/{TEST_NAMESPACE}/test_topic_3',
+        ]
+        publishers = []
+        timers = []
+
+        for topic in topics:
+            publisher = self.node.create_publisher(PointStamped, topic, 10)
+            publishers.append(publisher)
+
+            def publish_message(pub=publisher):
+                msg = PointStamped()
+                pub.publish(msg)
+
+            timer = self.node.create_timer(0.5, publish_message)
+            timers.append(timer)
+
+        # Wait for all the publishers to be discovered
+        timeout_count = 0
+        all_discovered = False
+        while not all_discovered and timeout_count < 30:
+            self.executor.spin_once(timeout_sec=0.1)
+            all_discovered = all(
+                self.node.count_publishers(topic) > 0 for topic in topics
+            )
+            timeout_count += 1
+        assert all_discovered, 'Not all publishers were discovered'
+
+        try:
+            command_action = ExecuteProcess(
+                cmd=['ros2', 'topic', 'hz', '--all'],
+                additional_env={
+                    'PYTHONUNBUFFERED': '1'
+                },
+                output='screen'
+            )
+            with launch_testing.tools.launch_process(
+                launch_service, command_action, proc_info, proc_output,
+                output_filter=launch_testing_ros.tools.basic_output_filter(
+                    filtered_rmw_implementation=get_rmw_implementation_identifier()
+                )
+            ) as command:
+                # Let it run for a few seconds to collect statistics
+                self.executor.spin_until_future_complete(
+                    rclpy.task.Future(), timeout_sec=5
+                )
+            command.wait_for_shutdown(timeout=10)
+
+            assert command.output, 'hz --all CLI printed no output'
+            assert re.search(
+                r'Subscribing to all \d+ available topics',
+                command.output
+            ), 'hz --all did not print subscription message'
+
+            for topic in topics:
+                assert topic in command.output, (
+                    f'Topic {topic} not found in hz --all output'
+                )
+
+            # Check that the output contains rate information (table format for multiple topics)
+            # The table should have headers: topic, rate, min_delta, max_delta, std_dev, window
+            assert 'topic' in command.output, 'Output missing topic header'
+            assert 'rate' in command.output, 'Output missing rate header'
+
+        finally:
+            # Cleanup
+            for timer in timers:
+                self.node.destroy_timer(timer)
+            for publisher in publishers:
+                self.node.destroy_publisher(publisher)
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_hz_no_arguments_error(self, launch_service, proc_info, proc_output):
+        """Test that hz fails when neither --all nor topic names are provided."""
+        command_action = ExecuteProcess(
+            cmd=['ros2', 'topic', 'hz'],
+            additional_env={
+                'PYTHONUNBUFFERED': '1'
+            },
+            output='screen'
+        )
+        with launch_testing.tools.launch_process(
+            launch_service, command_action, proc_info, proc_output,
+            output_filter=launch_testing_ros.tools.basic_output_filter(
+                filtered_rmw_implementation=get_rmw_implementation_identifier()
+            )
+        ) as command:
+            command.wait_for_shutdown(timeout=10)
+
+        # Should fail with non-zero exit code
+        assert command.exit_code != launch_testing.asserts.EXIT_OK, (
+            'hz command should fail when no arguments provided'
+        )
+
+        # Should print the error message
+        assert command.output, 'hz command printed no output'
+        assert 'Either specify topic names or use --all/-a option' in command.output, (
+            'hz command did not print expected error message'
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5)
+    def test_hz_both_all_and_topics_error(self, launch_service, proc_info, proc_output):
+        """Test that hz fails when both --all and topic names are provided."""
+        command_action = ExecuteProcess(
+            cmd=['ros2', 'topic', 'hz', '--all', '/some_topic'],
+            additional_env={
+                'PYTHONUNBUFFERED': '1'
+            },
+            output='screen'
+        )
+        with launch_testing.tools.launch_process(
+            launch_service, command_action, proc_info, proc_output,
+            output_filter=launch_testing_ros.tools.basic_output_filter(
+                filtered_rmw_implementation=get_rmw_implementation_identifier()
+            )
+        ) as command:
+            command.wait_for_shutdown(timeout=10)
+
+        # Should fail with non-zero exit code
+        assert command.exit_code != launch_testing.asserts.EXIT_OK, (
+            'hz command should fail when both --all and topic names provided'
+        )
+
+        # Should print the error message
+        assert command.output, 'hz command printed no output'
+        assert 'Cannot specify both --all/-a and topic names' in command.output, (
+            'hz command did not print expected error message'
+        )


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1121 

### Is this user-facing behavior change?

Yes, only if user issues the new option `--all/-a` to `ros2 topic hz`.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Copilot Claude Sonnet 4.5

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
