### PR TITLE
return explicitly from internal functions. (backport #1128)

### DIFF
--- a/ros2topic/ros2topic/verb/bw.py
+++ b/ros2topic/ros2topic/verb/bw.py
@@ -84,7 +84,8 @@ class BwVerb(VerbExtension):
     def main(self, *, args):
         with DirectNode(args) as node:
             qos_profile = choose_qos(node.node, topic_name=args.topic_name, qos_args=args)
-            _rostopic_bw(node.node, args.topic_name, qos_profile, window_size=args.window_size)
+            return _rostopic_bw(
+                node.node, args.topic_name, qos_profile, window_size=args.window_size)
 
 
 class ROSTopicBandwidth(object):
@@ -166,7 +167,7 @@ def _rostopic_bw(node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE):
     msg_class = get_msg_class(node, topic, blocking=True, include_hidden_topics=True)
     if msg_class is None:
         node.destroy_node()
-        return
+        return 1
 
     rt = ROSTopicBandwidth(node, window_size)
     node.create_subscription(
@@ -185,3 +186,4 @@ def _rostopic_bw(node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE):
     node.destroy_timer(timer)
     node.destroy_node()
     rclpy.shutdown()
+    return 0

--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -69,7 +69,8 @@ class DelayVerb(VerbExtension):
 def main(args):
     with DirectNode(args) as node:
         qos_profile = choose_qos(node.node, topic_name=args.topic_name, qos_args=args)
-        _rostopic_delay(node.node, args.topic_name, qos_profile, window_size=args.window_size)
+        return _rostopic_delay(
+            node.node, args.topic_name, qos_profile, window_size=args.window_size)
 
 
 class ROSTopicDelay(object):
@@ -171,7 +172,7 @@ def _rostopic_delay(node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE):
 
     if msg_class is None:
         node.destroy_node()
-        return
+        return 1
 
     rt = ROSTopicDelay(node, window_size)
     node.create_subscription(
@@ -187,3 +188,4 @@ def _rostopic_delay(node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE):
     node.destroy_timer(timer)
     node.destroy_node()
     rclpy.shutdown()
+    return 0

--- a/ros2topic/ros2topic/verb/hz.py
+++ b/ros2topic/ros2topic/verb/hz.py
@@ -103,8 +103,9 @@ def main(args):
         filter_expr = None
 
     with DirectNode(args) as node:
-        _rostopic_hz(node.node, topics, qos_args=args, window_size=args.window_size,
-                     filter_expr=filter_expr, use_wtime=args.use_wtime)
+        return _rostopic_hz(
+            node.node, topics, qos_args=args, window_size=args.window_size,
+            filter_expr=filter_expr, use_wtime=args.use_wtime)
 
 
 class ROSTopicHz(object):
@@ -327,7 +328,7 @@ def _rostopic_hz(node, topics, qos_args, window_size=DEFAULT_WINDOW_SIZE, filter
     if len(topics) == 0:
         node.destroy_node()
         rclpy.try_shutdown()
-        return
+        return 1
 
     try:
         def thread_func():
@@ -344,3 +345,4 @@ def _rostopic_hz(node, topics, qos_args, window_size=DEFAULT_WINDOW_SIZE, filter
         node.destroy_node()
         rclpy.try_shutdown()
         print_thread.join()
+    return 0


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Backport of https://github.com/ros2/ros2cli/pull/1128

replaces the following backport PRs because of conflicts,

- https://github.com/ros2/ros2cli/pull/1131
- https://github.com/ros2/ros2cli/pull/1132
- https://github.com/ros2/ros2cli/pull/1133

> [!NOTE]
> Backport requested to humble and jazzy

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
