### PR TITLE
skip test_verb_load_wildcard for rmw_connextdds.

### DIFF
--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -164,6 +164,7 @@ class TestVerbLoad(unittest.TestCase):
         proc_output,
         rmw_implementation
     ):
+        cls.rmw_implementation = rmw_implementation
         rmw_implementation_filter = launch_testing_ros.tools.basic_output_filter(
             filtered_rmw_implementation=rmw_implementation
         )
@@ -328,6 +329,9 @@ class TestVerbLoad(unittest.TestCase):
             )
 
     def test_verb_load_wildcard(self):
+        # Skip for Connext DDS as license notifications interfere with YAML parsing
+        if self.rmw_implementation == 'rmw_connextdds':
+            raise unittest.SkipTest()
         with tempfile.TemporaryDirectory() as tmpdir:
             # Try param file with only wildcard
             filepath = self._write_param_file(tmpdir, 'params.yaml', INPUT_WILDCARD_PARAMETER_FILE)

--- a/ros2param/test/test_verb_load.py
+++ b/ros2param/test/test_verb_load.py
@@ -329,9 +329,10 @@ class TestVerbLoad(unittest.TestCase):
             )
 
     def test_verb_load_wildcard(self):
-        # Skip for Connext DDS as license notifications interfere with YAML parsing
         if self.rmw_implementation == 'rmw_connextdds':
-            raise unittest.SkipTest()
+            raise unittest.SkipTest(
+                'Skip for Connext DDS as license notifications interfere with YAML parsing'
+            )
         with tempfile.TemporaryDirectory() as tmpdir:
             # Try param file with only wildcard
             filepath = self._write_param_file(tmpdir, 'params.yaml', INPUT_WILDCARD_PARAMETER_FILE)


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1149 

The problem can be reproducible with local ubuntu noble environment.
The root cause of this is that RTI Connext DDS prints the following license notification every time when it creates the DDS objects underneath, which include `ros2cli` and `ros2param`.

```console
RTI Connext DDS Non-commercial license is for academic, research, evaluation and personal use only. USE FOR COMMERCIAL PURPOSES IS PROHIBITED. See RTI_LICENSE.TXT for terms. Download free tools at rti.com/ncl. License issued to Non-Commercial User license@rti.com For non-production use only.
Expires on 00-jan-00
Please contact support@rti.com with any questions or comments.
```

This eventually fails the test, because this text information will be dumped with `ros2 param dump`, and test tries to load the dumped yaml file to the node. When it tries to load the yaml file, it throws the exception since it failed to decode that license note.

I suggest that we can skip the test for `rmw_connextdds` until RTI decides to remove the license notification or any other solution that we can find.

### Is this user-facing behavior change?

No,

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No,

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
