### PR TITLE
ros2doctor: add node and parameter info to report

### DIFF
--- a/ros2doctor/package.xml
+++ b/ros2doctor/package.xml
@@ -22,6 +22,8 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2action</exec_depend>
   <exec_depend>ros2cli</exec_depend>
+  <exec_depend>ros2node</exec_depend>
+  <exec_depend>ros2param</exec_depend>
   <exec_depend>ros_environment</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 

--- a/ros2doctor/ros2doctor/api/node.py
+++ b/ros2doctor/ros2doctor/api/node.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from collections import Counter
+
+from ros2node.api import get_node_names
+from ros2cli.node.strategy import NodeStrategy
+from ros2doctor.api import DoctorCheck
+from ros2doctor.api import DoctorReport
+from ros2doctor.api import Report
+from ros2doctor.api import Result
+from ros2doctor.api.format import doctor_warn
+
+
+def find_duplicates(values):
+    """Return values that appear more than once."""
+    counts = Counter(values)
+    return [v for v, c in counts.items() if c > 1]
+
+
+class NodeCheck(DoctorCheck):
+    """Check for duplicate node names."""
+
+    def category(self):
+        return 'node'
+
+    def check(self):
+        result = Result()
+        with NodeStrategy(None) as node:
+            node_list = get_node_names(node=node, include_hidden_nodes=True)
+            node_names = [n.full_name for n in node_list]
+            duplicates = find_duplicates(node_names)
+            for duplicate in duplicates:
+                doctor_warn(f'Duplicate node name: {duplicate}')
+                result.add_warning()
+        return result
+
+
+class NodeReport(DoctorReport):
+    """Report node related information."""
+
+    def category(self):
+        return 'node'
+
+    def report(self):
+        report = Report('NODE LIST')
+        with NodeStrategy(None) as node:
+            node_list = get_node_names(node=node, include_hidden_nodes=True)
+            node_names = [n.full_name for n in node_list]
+            if not node_names:
+                report.add_to_report('node count', 0)
+                report.add_to_report('node', 'none')
+            else:
+                report.add_to_report('node count', len(node_names))
+                for node_name in sorted(node_names):
+                    report.add_to_report('node', node_name)
+        return report

--- a/ros2doctor/ros2doctor/api/parameter.py
+++ b/ros2doctor/ros2doctor/api/parameter.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.parameter import parameter_value_to_python
+from ros2param.api import call_get_parameters
+from ros2param.api import call_list_parameters
+
+from ros2cli.node.direct import DirectNode
+from ros2cli.node.strategy import NodeStrategy
+from ros2doctor.api import DoctorCheck
+from ros2doctor.api import DoctorReport
+from ros2doctor.api import Report
+from ros2doctor.api import Result
+from ros2doctor.api.format import doctor_warn
+
+
+class ParameterReport(DoctorReport):
+    """Report parameter related information."""
+
+    def category(self):
+        return 'parameter'
+
+    def report(self):
+        report = Report('PARAMETER LIST')
+        with NodeStrategy(None) as node:
+            try:
+                node_names_and_namespaces = \
+                    node.get_node_names_and_namespaces()
+            except Exception:
+                node_names_and_namespaces = []
+            if not node_names_and_namespaces:
+                report.add_to_report('total nodes checked', 0)
+                report.add_to_report('total parameter count', 0)
+                report.add_to_report('parameter', 'none')
+                return report
+
+            param_count = 0
+            nodes_checked = 0
+
+            with DirectNode(None) as param_node:
+                for node_name, namespace in sorted(node_names_and_namespaces):
+                    nodes_checked += 1
+                    full_name = f"{namespace.rstrip('/')}/{node_name}"
+                    try:
+                        response = call_list_parameters(
+                            node=param_node.node, node_name=full_name)
+                        if response is None:
+                            continue
+                        elif response.result() is None:
+                            continue
+
+                        param_names = response.result().result.names
+                        if param_names:
+                            param_count += len(param_names)
+                            report.add_to_report('node', full_name)
+                            try:
+                                param_response = call_get_parameters(
+                                    node=param_node.node,
+                                    node_name=full_name,
+                                    parameter_names=param_names
+                                )
+                                param_values = None
+                                if param_response:
+                                    param_values = param_response.values
+                                if param_values and len(param_values) == len(
+                                    param_names
+                                ):
+                                    params_with_values = sorted(
+                                        zip(param_names, param_values)
+                                    )
+                                    for name, value_msg in params_with_values:
+                                        value = parameter_value_to_python(
+                                            value_msg
+                                        )
+                                        report.add_to_report(
+                                            'parameter', f'{name}: {value}')
+                                else:
+                                    for param_name in sorted(param_names):
+                                        report.add_to_report(
+                                            'parameter', param_name
+                                        )
+                            except RuntimeError:
+                                for param_name in sorted(param_names):
+                                    report.add_to_report(
+                                        'parameter', param_name
+                                    )
+                    except RuntimeError:
+                        pass
+
+            report.add_to_report('total nodes checked', nodes_checked)
+            report.add_to_report('total parameter count', param_count)
+        return report

--- a/ros2doctor/setup.py
+++ b/ros2doctor/setup.py
@@ -47,6 +47,8 @@ setup(
             'TopicCheck = ros2doctor.api.topic:TopicCheck',
             'QoSCompatibilityCheck = ros2doctor.api.qos_compatibility:QoSCompatibilityCheck',
             'PackageCheck = ros2doctor.api.package:PackageCheck',
+            'NodeCheck = ros2doctor.api.node:NodeCheck',
+            'ParameterCheck = ros2doctor.api.parameter:ParameterCheck',
         ],
         'ros2doctor.report': [
             'PlatformReport = ros2doctor.api.platform:PlatformReport',
@@ -58,7 +60,9 @@ setup(
             'ActionReport = ros2doctor.api.action:ActionReport',
             'QoSCompatibilityReport = ros2doctor.api.qos_compatibility:QoSCompatibilityReport',
             'PackageReport = ros2doctor.api.package:PackageReport',
-            'EnvironmentReport = ros2doctor.api.environment:EnvironmentReport'
+            'EnvironmentReport = ros2doctor.api.environment:EnvironmentReport',
+            'NodeReport = ros2doctor.api.node:NodeReport',
+            'ParameterReport = ros2doctor.api.parameter:ParameterReport'
         ],
         'ros2cli.extension_point': [
             'ros2doctor.verb = ros2doctor.verb:VerbExtension',

--- a/ros2doctor/test/common.py
+++ b/ros2doctor/test/common.py
@@ -33,3 +33,32 @@ def generate_expected_service_report(services: Iterable[str], serv_counts: Itera
         expected_report.add_to_report('service count', serv_count)
         expected_report.add_to_report('client count', cli_count)
     return expected_report
+
+
+def generate_expected_node_report(node_count: int, nodes: Iterable[str]) -> Report:
+    expected_report = Report('NODE LIST')
+    if node_count == 0:
+        expected_report.add_to_report('node count', 0)
+        expected_report.add_to_report('node', 'none')
+    else:
+        expected_report.add_to_report('node count', node_count)
+        for node in nodes:
+            expected_report.add_to_report('node', node)
+    return expected_report
+
+
+def generate_expected_parameter_report(nodes_checked: int, param_count: int,
+                                       node_params: Iterable[tuple]) -> Report:
+    expected_report = Report('PARAMETER LIST')
+    if nodes_checked == 0:
+        expected_report.add_to_report('total nodes checked', 0)
+        expected_report.add_to_report('total parameter count', 0)
+        expected_report.add_to_report('parameter', 'none')
+    else:
+        for node_name, params in node_params:
+            expected_report.add_to_report('node', node_name)
+            for param in params:
+                expected_report.add_to_report('parameter', param)
+        expected_report.add_to_report('total nodes checked', nodes_checked)
+        expected_report.add_to_report('total parameter count', param_count)
+    return expected_report

--- a/ros2doctor/test/fixtures/complex_node.py
+++ b/ros2doctor/test/fixtures/complex_node.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.action import ActionServer
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+from rclpy.qos import qos_profile_system_default
+
+from test_msgs.action import Fibonacci
+from test_msgs.msg import Arrays
+from test_msgs.msg import Strings
+from test_msgs.srv import BasicTypes
+
+
+class ComplexNode(Node):
+
+    def __init__(self):
+        super().__init__('complex_node')
+        self.publisher = self.create_publisher(
+            Arrays, 'arrays', qos_profile_system_default
+        )
+        self.subscription = self.create_subscription(
+            Strings, 'strings', lambda msg: None, qos_profile_system_default
+        )
+        self.server = self.create_service(BasicTypes, 'basic', lambda req, res: res)
+        self.action_server = ActionServer(
+            self, Fibonacci, 'fibonacci', self.action_callback
+        )
+        self.timer = self.create_timer(1.0, self.pub_callback)
+
+    def destroy_node(self):
+        self.timer.destroy()
+        self.publisher.destroy()
+        self.subscription.destroy()
+        self.server.destroy()
+        self.action_server.destroy()
+        super().destroy_node()
+
+    def pub_callback(self):
+        self.publisher.publish(Arrays())
+
+    def action_callback(self, goal_handle):
+        goal_handle.succeed()
+        return Fibonacci.Result()
+
+
+def main(args=None):
+    try:
+        with rclpy.init(args=args):
+            node = ComplexNode()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        print('node stopped cleanly')
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2doctor/test/fixtures/parameter_fixtures_node.py
+++ b/ros2doctor/test/fixtures/parameter_fixtures_node.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test fixture node with parameters for ros2doctor testing."""
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.parameter import PARAMETER_SEPARATOR_STRING
+
+
+def main():
+    try:
+        with rclpy.init():
+            node = rclpy.create_node('parameter_node')
+            # Declare various parameter types for testing
+            node.declare_parameter('bool_param', True)
+            node.declare_parameter('int_param', 42)
+            node.declare_parameter('double_param', 3.14)
+            node.declare_parameter('str_param', 'hello')
+            node.declare_parameter('bool_array_param', [True, False])
+            node.declare_parameter('int_array_param', [1, 2, 3])
+            node.declare_parameter('double_array_param', [1.0, 2.0])
+            node.declare_parameter('str_array_param', ['foo', 'bar'])
+            node.declare_parameter(
+                'nested' + PARAMETER_SEPARATOR_STRING + 'param', 'nested_value'
+            )
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        print('parameter_node stopped cleanly')
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2doctor/test/test_api.py
+++ b/ros2doctor/test/test_api.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+from common import generate_expected_node_report
 from common import generate_expected_service_report
 from common import generate_expected_topic_report
 
@@ -25,6 +26,9 @@ import launch_testing.markers
 
 import pytest
 
+from ros2doctor.api.node import NodeCheck
+from ros2doctor.api.node import NodeReport
+from ros2doctor.api.parameter import ParameterReport
 from ros2doctor.api.service import ServiceReport
 from ros2doctor.api.topic import TopicCheck
 from ros2doctor.api.topic import TopicReport
@@ -74,3 +78,23 @@ class TestROS2DoctorAPI(unittest.TestCase):
         self.assertEqual(report.name, expected_report.name)
         self.assertEqual(report.items, expected_report.items)
         self.assertEqual(report, expected_report)
+
+    def test_node_check(self):
+        """Assume no duplicate nodes exist in a clean environment."""
+        node_check = NodeCheck()
+        check_result = node_check.check()
+        self.assertEqual(check_result.error, 0)
+        self.assertEqual(check_result.warning, 0)
+
+    def test_no_node_report(self):
+        """Assume no nodes are running in a clean environment."""
+        report = NodeReport().report()
+        expected_report = generate_expected_node_report(0, [])
+        self.assertEqual(report.name, expected_report.name)
+        self.assertEqual(report.name, 'NODE LIST')
+
+    def test_no_parameter_report(self):
+        """Assume no parameters in a clean environment."""
+        report = ParameterReport().report()
+        self.assertEqual(report.name, 'PARAMETER LIST')
+        self.assertIsNotNone(report)

--- a/ros2doctor/test/test_node.py
+++ b/ros2doctor/test/test_node.py
@@ -1,0 +1,184 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import os
+import sys
+import unittest
+
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
+from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
+
+from launch_ros.actions import Node
+
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+from launch_testing_ros.actions import EnableRmwIsolation
+import launch_testing_ros.tools
+
+import pytest
+
+from rclpy.utilities import get_available_rmw_implementations
+from ros2cli.helpers import get_rmw_additional_env
+from ros2doctor.api.node import find_duplicates
+from ros2doctor.api.node import NodeCheck
+from ros2doctor.api.node import NodeReport
+
+
+def test_find_duplicates():
+    assert not find_duplicates([])
+    assert not find_duplicates(['ns_foo/foo', 'ns_foo/bar'])
+    assert find_duplicates(['ns_foo/foo'] * 2) == ['ns_foo/foo']
+    assert find_duplicates(['ns_foo/foo'] * 3) == ['ns_foo/foo']
+    assert find_duplicates(['ns_foo/foo', 'ns_foo/foo', 'ns_foo/bar']) == ['ns_foo/foo']
+
+
+@pytest.mark.rostest
+@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+def generate_test_description(rmw_implementation):
+    path_to_complex_node_script = os.path.join(
+        os.path.dirname(__file__), 'fixtures', 'complex_node.py'
+    )
+    additional_env = get_rmw_additional_env(rmw_implementation)
+    set_env_actions = [SetEnvironmentVariable(k, v) for k, v in additional_env.items()]
+    return LaunchDescription([
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                *set_env_actions,
+                EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        additional_env=dict(additional_env),
+                    ),
+                    # Run after stopping the daemon in the isolated environment
+                    ResetEnvironment(),
+                ])),
+                ExecuteProcess(
+                    cmd=['ros2', 'daemon', 'start'],
+                    name='daemon-start',
+                    on_exit=[
+                        Node(
+                            executable=sys.executable,
+                            arguments=[path_to_complex_node_script],
+                            name='complex_node',
+                        ),
+                        Node(
+                            executable=sys.executable,
+                            arguments=[path_to_complex_node_script],
+                            name='complex_node',
+                        ),
+                        Node(
+                            executable=sys.executable,
+                            arguments=[path_to_complex_node_script],
+                            name='_hidden_complex_node',
+                        ),
+                        launch_testing.actions.ReadyToTest(),
+                    ],
+                )
+            ]
+        ),
+    ])
+
+
+class TestROS2DoctorNodeAPI(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(
+        cls,
+        launch_service,
+        proc_info,
+        proc_output,
+        rmw_implementation
+    ):
+        @contextlib.contextmanager
+        def launch_doctor_command(self, arguments):
+            additional_env = {
+                'PYTHONUNBUFFERED': '1',
+            }
+            doctor_command_action = ExecuteProcess(
+                cmd=['ros2', 'doctor', *arguments],
+                additional_env=additional_env,
+                name='ros2doctor-cli',
+                output='screen'
+            )
+            with launch_testing.tools.launch_process(
+                launch_service, doctor_command_action, proc_info, proc_output,
+                output_filter=launch_testing_ros.tools.basic_output_filter(
+                    filtered_patterns=['.*launch_ros.*', '.*ros2cli.*'],
+                    filtered_rmw_implementation=rmw_implementation
+                )
+            ) as doctor_command:
+                yield doctor_command
+        cls.launch_doctor_command = launch_doctor_command
+
+    # Test the Node api
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_node_report(self):
+        """Test NodeReport lists all nodes including hidden ones."""
+        report = NodeReport().report()
+        assert report.name == 'NODE LIST'
+
+        reported_nodes = [v for k, v in report.items if k == 'node']
+
+        # Verify nodes are listed as per creation
+        assert '/complex_node' in reported_nodes
+        assert '/_hidden_complex_node' in reported_nodes
+
+        # Verify node count
+        items_dict = {item[0]: item[1] for item in report.items}
+        node_count = items_dict.get('node count')
+        assert node_count is not None
+        # We launched: 2 complex_node, 1 _hidden_complex_node = 3 nodes
+        assert node_count >= 3
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_node_check_duplicates(self):
+        """Test NodeCheck detects and issues warnings for duplicates node names."""
+        node_check = NodeCheck()
+        check_result = node_check.check()
+
+        # We launched two nodes with the same name "complex_node" , so 1 warning issued
+        assert check_result.error == 0
+        assert check_result.warning >= 1
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_doctor_check_cli(self):
+        """Test ros2 doctor CLI runs check without errors."""
+        with self.launch_doctor_command(arguments=[]) as doctor_command:
+            assert doctor_command.wait_for_shutdown(timeout=20)
+        # Check may print warnings due to duplicates, but should not fail
+        assert doctor_command.output
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_doctor_report_cli(self):
+        """Test ros2 doctor --report CLI includes node information."""
+        with self.launch_doctor_command(arguments=['--report']) as doctor_command:
+            assert doctor_command.wait_for_shutdown(timeout=20)
+        assert doctor_command.exit_code == launch_testing.asserts.EXIT_OK
+
+        # Verify NODE LIST section is present in report
+        assert 'NODE LIST' in doctor_command.output or 'node count' in doctor_command.output

--- a/ros2doctor/test/test_parameter.py
+++ b/ros2doctor/test/test_parameter.py
@@ -1,0 +1,270 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import array
+from pathlib import Path
+import sys
+import time
+import unittest
+import xmlrpc.client
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
+from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+from launch_testing_ros.actions import EnableRmwIsolation
+
+import pytest
+
+from rcl_interfaces.msg import ParameterType
+import rclpy
+from rclpy.parameter import get_parameter_value
+from rclpy.utilities import get_available_rmw_implementations
+from ros2cli.helpers import get_rmw_additional_env
+from ros2cli.node.strategy import NodeStrategy
+from ros2doctor.api.parameter import ParameterReport
+
+
+TEST_NODE = 'test_node'
+TEST_NAMESPACE = '/foo'
+
+TEST_TIMEOUT = 20.0
+
+
+def test_get_parameter_value():
+    """Test get_parameter_value with various inputs."""
+    test_cases = [
+        ('true', ParameterType.PARAMETER_BOOL, 'bool_value', True),
+        ('false', ParameterType.PARAMETER_BOOL, 'bool_value', False),
+        ('1', ParameterType.PARAMETER_INTEGER, 'integer_value', 1),
+        ('0', ParameterType.PARAMETER_INTEGER, 'integer_value', 0),
+        ('-1', ParameterType.PARAMETER_INTEGER, 'integer_value', -1),
+        ('1.0', ParameterType.PARAMETER_DOUBLE, 'double_value', 1.0),
+        ('0.0', ParameterType.PARAMETER_DOUBLE, 'double_value', 0.0),
+        ('-1.0', ParameterType.PARAMETER_DOUBLE, 'double_value', -1.0),
+        ('1.1234', ParameterType.PARAMETER_DOUBLE, 'double_value', 1.1234),
+        ('foo', ParameterType.PARAMETER_STRING, 'string_value', 'foo'),
+        (
+            '[false, true]',
+            ParameterType.PARAMETER_BOOL_ARRAY,
+            'bool_array_value',
+            [False, True],
+        ),
+        (
+            '[-1, 0, 1]',
+            ParameterType.PARAMETER_INTEGER_ARRAY,
+            'integer_array_value',
+            array.array('q', (-1, 0, 1)),
+        ),
+        (
+            '[-1.0, 0.0, 1.0, 1.1234]',
+            ParameterType.PARAMETER_DOUBLE_ARRAY,
+            'double_array_value',
+            array.array('d', (-1.0, 0.0, 1.0, 1.1234)),
+        ),
+        (
+            '["foo", "bar", "buzz"]',
+            ParameterType.PARAMETER_STRING_ARRAY,
+            'string_array_value',
+            ['foo', 'bar', 'buzz'],
+        ),
+        (
+            '["foo", "bar", "buzz"',
+            ParameterType.PARAMETER_STRING,
+            'string_value',
+            '["foo", "bar", "buzz"',
+        ),
+        ('off', ParameterType.PARAMETER_BOOL, 'bool_value', False),
+        ('!!str off', ParameterType.PARAMETER_STRING, 'string_value', 'off'),
+        (
+            '[true,0.1,1]',
+            ParameterType.PARAMETER_STRING,
+            'string_value',
+            '[true,0.1,1]',
+        ),
+    ]
+    for (
+        string_value, expected_type, value_attribute, expected_value
+    ) in test_cases:
+        value = get_parameter_value(string_value=string_value)
+        assert value.type == expected_type
+        assert getattr(value, value_attribute) == expected_value
+
+
+@pytest.mark.rostest
+@launch_testing.parametrize(
+    'rmw_implementation', get_available_rmw_implementations()
+)
+def generate_test_description(rmw_implementation):
+    path_to_fixtures = Path(__file__).parent / 'fixtures'
+    additional_env = get_rmw_additional_env(rmw_implementation)
+    additional_env['PYTHONUNBUFFERED'] = '1'
+    set_env_actions = [
+        SetEnvironmentVariable(k, v) for k, v in additional_env.items()
+    ]
+
+    return LaunchDescription(
+        [
+            ExecuteProcess(
+                cmd=['ros2', 'daemon', 'stop'],
+                name='daemon-stop',
+                on_exit=[
+                    *set_env_actions,
+                    EnableRmwIsolation(),
+                    RegisterEventHandler(
+                        OnShutdown(
+                            on_shutdown=[
+                                ExecuteProcess(
+                                    cmd=['ros2', 'daemon', 'stop'],
+                                    name='daemon-stop-isolated',
+                                    additional_env=dict(additional_env),
+                                ),
+                                ResetEnvironment(),
+                            ]
+                        )
+                    ),
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'start'],
+                        name='daemon-start',
+                        on_exit=[
+                            Node(
+                                executable=sys.executable,
+                                arguments=[str(
+                                    path_to_fixtures /
+                                    'parameter_fixtures_node.py'
+                                )],
+                                name=TEST_NODE,
+                                namespace=TEST_NAMESPACE,
+                            ),
+                            launch_testing.actions.ReadyToTest(),
+                        ],
+                    ),
+                ],
+            )
+        ]
+    )
+
+
+class TestParameterAPI(unittest.TestCase):
+    """Test ros2doctor ParameterReport with running nodes."""
+
+    @classmethod
+    def setUpClass(
+        cls, launch_service, proc_info, proc_output, rmw_implementation
+    ):
+        # Skip zenoh because it requires a router for node discovery
+        if rmw_implementation == 'rmw_zenoh_cpp':
+            raise unittest.SkipTest(
+                'rmw_zenoh_cpp requires router for discovery'
+            )
+        cls.rmw_implementation = rmw_implementation
+
+    def setUp(self):
+        """Wait for test nodes to be discovered."""
+        start_time = time.time()
+        timed_out = True
+        with NodeStrategy(None) as node:
+            while (time.time() - start_time) < TEST_TIMEOUT:
+                try:
+                    services = node.get_service_names_and_types_by_node(
+                        TEST_NODE, TEST_NAMESPACE
+                    )
+                except rclpy.node.NodeNameNonExistentError:
+                    continue
+                except ConnectionRefusedError:
+                    continue
+                except xmlrpc.client.Fault as e:
+                    if 'NodeNameNonExistentError' in e.faultString:
+                        continue
+                    raise
+
+                service_names = [
+                    name_type_tuple[0] for name_type_tuple in services
+                ]
+                list_params = f'{TEST_NAMESPACE}/{TEST_NODE}/list_parameters'
+                if (
+                    len(service_names) > 0
+                    and list_params in service_names
+                ):
+                    timed_out = False
+                    break
+        if timed_out:
+            self.fail(
+                f'CLI daemon failed to find test node after '
+                f'{TEST_TIMEOUT} seconds'
+            )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_parameter_report(self):
+        """Test ParameterReport lists parameters from running nodes."""
+        report = ParameterReport().report()
+        self.assertEqual(report.name, 'PARAMETER LIST')
+
+        # Parse items to find parameters for our test node
+        node_params = {}
+        current_node = None
+        for key, value in report.items:
+            if key == 'node':
+                current_node = value
+                node_params[current_node] = []
+            elif key == 'parameter' and current_node:
+                node_params[current_node].append(value)
+
+        target_node = f'{TEST_NAMESPACE}/{TEST_NODE}'
+        self.assertIn(target_node, node_params)
+
+        params = node_params[target_node]
+
+        param_dict = {}
+        for p in params:
+            if ': ' in p:
+                name, val = p.split(': ', 1)
+                param_dict[name] = val
+            else:
+                param_dict[p] = None
+
+        expected_values = {
+            'bool_param': 'True',
+            'int_param': '42',
+            'double_param': '3.14',
+            'str_param': 'hello',
+            'nested.param': 'nested_value',
+            'use_sim_time': 'False',
+        }
+
+        for name, val in expected_values.items():
+            self.assertIn(name, param_dict)
+            self.assertEqual(param_dict[name], val)
+
+        array_params = [
+            'bool_array_param',
+            'int_array_param',
+            'double_array_param',
+            'str_array_param',
+        ]
+        for name in array_params:
+            self.assertIn(name, param_dict)
+            self.assertIsNotNone(param_dict[name])
+
+        items_dict = {item[0]: item[1] for item in report.items}
+        self.assertIn('total nodes checked', items_dict)
+        self.assertGreaterEqual(items_dict['total nodes checked'], 1)


### PR DESCRIPTION
## Description

Add NodeCheck/NodeReport and ParameterCheck/ParameterReport so the ros2doctor report shows active nodes and their parameters.

- Add `ros2doctor/api/node.py` (node discovery, NodeCheck, NodeReport)
- Add `ros2doctor/api/parameter.py` (parameter discovery, ParameterCheck, ParameterReport)
- Update  entry points in `ros2doctor/setup.py`:
  - `ros2doctor.checks: NodeCheck` and `ParameterCheck`
  - `ros2doctor.report: NodeReport` and `ParameterReport`

Why:
This enhancement provides valuable insights into the active nodes and their parameters within a ROS 2 system. By including this information in the `ros2 doctor` report sections in the `ros2 doctor --report` output, giving users better visibility into the runtime ROS 2 system configuration.

Fixes: ros2/ros2cli#1090




<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


### Is this user-facing behavior change?

Yes
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
