### PR TITLE
Output node parameters upon each receipt

### DIFF
--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -75,7 +75,7 @@ class ListVerb(VerbExtension):
                     node=node,
                     node_name=node_name.full_name,
                     prefixes=args.param_prefixes)
-                # print responses
+                # print response
                 if response is None:
                     print(
                         'Wait for service timed out waiting for '

--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -68,15 +68,14 @@ class ListVerb(VerbExtension):
             regex_filter = re.compile(regex_filter[0])
 
         with DirectNode(args) as node:
-            responses = {}
+            # Sort node_names alphabetically
+            node_names = sorted(node_names, key=lambda n: n.full_name)
             for node_name in node_names:
-                responses[node_name] = call_list_parameters(
+                response = call_list_parameters(
                     node=node,
                     node_name=node_name.full_name,
                     prefixes=args.param_prefixes)
-            # print responses
-            for node_name in sorted(responses.keys()):
-                response = responses[node_name]
+                # print responses
                 if response is None:
                     print(
                         'Wait for service timed out waiting for '


### PR DESCRIPTION
## Description

Improve the user experience of `ros2 param list`.   
As soon as the parameter information for a node is received, output it immediately instead of waiting to collect the parameters for all nodes before outputting them together.

Fixes #1158 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

