### PR TITLE
Add per-node timeout option to ros2 param list

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -104,13 +104,13 @@ def call_set_parameters(*, node, node_name, parameters):
     return response
 
 
-def call_list_parameters(*, node, node_name, prefixes=None):
+def call_list_parameters(*, node, node_name, prefixes=None, spin_timeout_sec=None):
     client = AsyncParameterClient(node, node_name)
     ready = client.wait_for_services(timeout_sec=5.0)
     if not ready:
         return None
     future = client.list_parameters(prefixes=prefixes)
-    rclpy.spin_until_future_complete(node, future)
+    rclpy.spin_until_future_complete(node, future, timeout_sec=spin_timeout_sec)
     return future
 
 

--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -91,7 +91,8 @@ class ListVerb(VerbExtension):
                     # Future did not complete within timeout
                     print(
                         'Timed out waiting for list_parameters response '
-                        f'from node {node_name}')
+                        f'from node {node_name} '
+                        f'(timeout: {args.per_node_timeout}s)')
                     continue
                 elif response.result() is None:
                     e = response.exception()

--- a/ros2param/ros2param/verb/list.py
+++ b/ros2param/ros2param/verb/list.py
@@ -50,6 +50,11 @@ class ListVerb(VerbExtension):
         parser.add_argument(
             '--param-type', action='store_true',
             help='Print parameter types with parameter names')
+        parser.add_argument(
+            '--per-node-timeout', metavar='N', type=float, default=5.0,
+            help=(
+                'Maximum wait time per node for list_parameters service call '
+                'in seconds (default: %(default)s)'))
 
     def main(self, *, args):  # noqa: D102
         with NodeStrategy(args) as node:
@@ -74,12 +79,19 @@ class ListVerb(VerbExtension):
                 response = call_list_parameters(
                     node=node,
                     node_name=node_name.full_name,
-                    prefixes=args.param_prefixes)
+                    prefixes=args.param_prefixes,
+                    spin_timeout_sec=args.per_node_timeout)
                 # print response
                 if response is None:
                     print(
                         'Wait for service timed out waiting for '
                         f'parameter services for node {node_name}')
+                    continue
+                elif not response.done():
+                    # Future did not complete within timeout
+                    print(
+                        'Timed out waiting for list_parameters response '
+                        f'from node {node_name}')
                     continue
                 elif response.result() is None:
                     e = response.exception()

--- a/ros2param/test/fixtures/param_list_hang_node.py
+++ b/ros2param/test/fixtures/param_list_hang_node.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import time
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.node import Node
+
+
+class ParamListHangNode(Node):
+    """A node that hangs on list_parameters service calls."""
+
+    def __init__(self):
+        super().__init__('param_list_hang_node')
+        # Sleep indefinitely to simulate a non-responsive service
+        while rclpy.ok():
+            time.sleep(1.0)
+
+
+def main(args=None):
+    try:
+        with rclpy.init(args=args):
+            node = ParamListHangNode()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        print('param_list_hang_node stopped cleanly')
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2param/test/test_verb_list.py
+++ b/ros2param/test/test_verb_list.py
@@ -46,6 +46,9 @@ from ros2cli.node.strategy import NodeStrategy
 TEST_NODE = 'test_node'
 TEST_NAMESPACE = '/foo'
 
+HANG_NODE = 'param_list_hang_node'
+HANG_NAMESPACE = '/'
+
 TEST_TIMEOUT = 20.0
 
 # Skip cli tests on Windows while they exhibit pathological behavior
@@ -72,6 +75,15 @@ def generate_test_description(rmw_implementation):
         arguments=[str(path_to_parameter_node_script)],
     )
 
+    # Hang node test fixture (does not respond to list_parameters)
+    path_to_hang_node_script = path_to_fixtures / 'param_list_hang_node.py'
+    hang_node = Node(
+        executable=sys.executable,
+        name=HANG_NODE,
+        namespace=HANG_NAMESPACE,
+        arguments=[str(path_to_hang_node_script)],
+    )
+
     return LaunchDescription([
         # TODO(jacobperron): Provide a common RestartCliDaemon launch action in ros2cli
         ExecuteProcess(
@@ -96,6 +108,7 @@ def generate_test_description(rmw_implementation):
                     name='daemon-start',
                     on_exit=[
                         parameter_node,
+                        hang_node,
                         launch_testing.actions.ReadyToTest(),
                     ],
                 )
@@ -204,6 +217,27 @@ class TestVerbList(unittest.TestCase):
                 '  use_sim_time'],
             text=param_list_command.output,
             strict=False
+        )
+
+    def test_verb_list_timeout(self):
+        # Test that param list doesn't hang when a node doesn't respond,
+        # and completes within the specified per-node-timeout.
+        per_node_timeout = 2.0
+        timeout_buffer = 5.0
+        expected_max_duration = per_node_timeout + timeout_buffer
+        start_time = time.time()
+        with self.launch_param_list_command(
+            arguments=[
+                f'{HANG_NAMESPACE}{HANG_NODE}',
+                '--per-node-timeout', str(per_node_timeout)
+            ]
+        ) as param_list_command:
+            assert param_list_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        elapsed_time = time.time() - start_time
+        assert param_list_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert elapsed_time < expected_max_duration, (
+            f'Command took {elapsed_time:.1f}s, expected to complete within '
+            f'{expected_max_duration}s (per-node-timeout={per_node_timeout}s)'
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This PR adds a `--per-node-timeout` option to the `ros2 param list` command.

Currently, when listing parameters from multiple nodes, the command can hang indefinitely if a node does not respond to the `list_parameters` service call. This change introduces a configurable timeout (default: 5.0 seconds) per node, allowing the command to skip unresponsive nodes and continue processing the remaining ones.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1159

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes.   
Users can use `--per-node-timeout <seconds>` option with `ros2 param list` to set how long to wait for each node's response. 

Example:
ros2 param list --per-node-timeout 2.0


### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Claude Opus 4.5

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

- The `call_list_parameters()` function can be called with `spin_timeout_sec=None`, in which case it will wait indefinitely as before.

- The `call_list_parameters()` is also called from the `dump` verb and `ParameterNameCompleter`. In particular, `ParameterNameCompleter` may hang under the same conditions as `ros2 param list` when attempting tab completion during commands like `ros2 param get /node`. This may require a separate fix after further discussion.