### PR TITLE
Fix ParameterNameCompleter.

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -135,8 +135,14 @@ class ParameterNameCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         with DirectNode(parsed_args) as node:
-            parameter_names = call_list_parameters(
+            future = call_list_parameters(
                 node=node, node_name=parsed_args.node_name)
+            if future is None:
+                return []
+            result = future.result()
+            if result is None:
+                return []
+            parameter_names = result.result.names
             return [
                 n for n in parameter_names
                 if not prefix or n.startswith(prefix)]

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -119,10 +119,10 @@ def test_parameter_name_completer():
     mock_result = Mock()
     mock_result.result.names = ['param1', 'param2', 'param_test', 'other']
     mock_future.result.return_value = mock_result
-    
+
     # If code tries to iterate the future directly, it will raise TypeError
     mock_future.__iter__ = Mock(side_effect=TypeError('Future object is not iterable'))
-    
+
     with patch('ros2param.api.call_list_parameters', return_value=mock_future):
         with patch('ros2param.api.DirectNode'):
             # Test with no prefix
@@ -130,11 +130,11 @@ def test_parameter_name_completer():
             assert result == ['param1', 'param2', 'param_test', 'other']
             # Verify .result() was called on the future (not iterated directly)
             mock_future.result.assert_called()
-            
+
             # Test with prefix filtering
             result = completer(prefix='param', parsed_args=parsed_args)
             assert result == ['param1', 'param2', 'param_test']
-            
+
             # Test with prefix that matches nothing
             result = completer(prefix='xyz', parsed_args=parsed_args)
             assert result == []

--- a/ros2param/test/test_api.py
+++ b/ros2param/test/test_api.py
@@ -94,3 +94,47 @@ def test_get_parameter_value(string_value, expected_type, value_attribute, expec
     value = get_parameter_value(string_value=string_value)
     assert value.type == expected_type
     assert getattr(value, value_attribute) == expected_value
+
+
+def test_parameter_name_completer():
+    from unittest.mock import Mock, MagicMock
+    from ros2param.api import ParameterNameCompleter
+
+    # Create a mock parsed_args object
+    parsed_args = Mock()
+    parsed_args.node_name = 'test_complete_node'
+
+    completer = ParameterNameCompleter()
+
+    # Test with mock that returns None (no node available)
+    # The completer should return an empty list gracefully
+    from unittest.mock import patch
+    with patch('ros2param.api.call_list_parameters', return_value=None):
+        with patch('ros2param.api.DirectNode'):
+            result = completer(prefix='', parsed_args=parsed_args)
+            assert result == []
+
+    # This ensures the code calls .result() on the future instead of iterating it directly
+    mock_future = MagicMock()
+    mock_result = Mock()
+    mock_result.result.names = ['param1', 'param2', 'param_test', 'other']
+    mock_future.result.return_value = mock_result
+    
+    # If code tries to iterate the future directly, it will raise TypeError
+    mock_future.__iter__ = Mock(side_effect=TypeError('Future object is not iterable'))
+    
+    with patch('ros2param.api.call_list_parameters', return_value=mock_future):
+        with patch('ros2param.api.DirectNode'):
+            # Test with no prefix
+            result = completer(prefix='', parsed_args=parsed_args)
+            assert result == ['param1', 'param2', 'param_test', 'other']
+            # Verify .result() was called on the future (not iterated directly)
+            mock_future.result.assert_called()
+            
+            # Test with prefix filtering
+            result = completer(prefix='param', parsed_args=parsed_args)
+            assert result == ['param1', 'param2', 'param_test']
+            
+            # Test with prefix that matches nothing
+            result = completer(prefix='xyz', parsed_args=parsed_args)
+            assert result == []


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1169

### Is this user-facing behavior change?

Yes, it just fixes the ParameterNameCompleter behavior that should be. (before, it just does not work.)

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No,

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

> [! NOTE]
> Backport this fix to kilted, jazzy and humble