### PR TITLE
Fix arg completion

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -134,6 +134,8 @@ class ParameterNameCompleter:
     """Callable returning a list of parameter names."""
 
     def __call__(self, prefix, parsed_args, **kwargs):
+        if not parsed_args.node_name:
+            return []
         with DirectNode(parsed_args) as node:
             future = call_list_parameters(
                 node=node, node_name=parsed_args.node_name)

--- a/ros2param/ros2param/verb/get.py
+++ b/ros2param/ros2param/verb/get.py
@@ -35,7 +35,7 @@ class GetVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):  # noqa: D102
         add_arguments(parser)
         arg = parser.add_argument(
-            'node_name', nargs='?', default=None,
+            'node_name', nargs='?',
             help='Name of the ROS node (optional). '
                  'If only one argument is provided, it is treated as a parameter name '
                  'to query across all nodes.')
@@ -45,7 +45,7 @@ class GetVerb(VerbExtension):
             '--include-hidden-nodes', action='store_true',
             help='Consider hidden nodes as well')
         arg = parser.add_argument(
-            'parameter_name', nargs='?', default=None,
+            'parameter_name', nargs='?',
             help='Name of the parameter (optional). '
                  'If neither node nor parameter is provided, interactive selection is used.')
         arg.completer = ParameterNameCompleter()

--- a/ros2run/ros2run/api/__init__.py
+++ b/ros2run/ros2run/api/__init__.py
@@ -97,6 +97,9 @@ class ExecutableNameCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         package_name = getattr(parsed_args, self.package_name_key)
+        if not package_name:
+            print('Package name not specified for executable name completion')
+            return []
         try:
             paths = get_executable_paths(package_name=package_name)
         except PackageNotFound:

--- a/ros2run/ros2run/command/run.py
+++ b/ros2run/ros2run/command/run.py
@@ -32,31 +32,34 @@ class RunCommand(CommandExtension):
     """Run a package specific executable."""
 
     def add_arguments(self, parser, cli_name):
+        try:
+            from argcomplete.completers import SuppressCompleter
+        except ImportError:
+            SuppressCompleter = None
+
         arg = parser.add_argument(
             '--prefix',
             help='Prefix command, which should go before the executable. '
                  'Command must be wrapped in quotes if it contains spaces '
                  "(e.g. --prefix 'gdb -ex run --args').")
-        try:
-            from argcomplete.completers import SuppressCompleter
-        except ImportError:
-            pass
-        else:
+        if SuppressCompleter:
             arg.completer = SuppressCompleter()
         arg = parser.add_argument(
-            'package_name', nargs='?', default=None,
+            'package_name', nargs='?',
             help='Name of the ROS package '
                  '(optional, interactive selection if not provided)')
         arg.completer = package_name_completer
         arg = parser.add_argument(
-            'executable_name', nargs='?', default=None,
+            'executable_name', nargs='?',
             help='Name of the executable '
                  '(optional, interactive selection if not provided)')
         arg.completer = ExecutableNameCompleter(
             package_name_key='package_name')
-        parser.add_argument(
+        arg = parser.add_argument(
             'argv', nargs=REMAINDER,
             help='Pass arbitrary arguments to the executable')
+        if SuppressCompleter:
+            arg.completer = SuppressCompleter()
 
     def main(self, *, parser, args):
         # If package not provided, use interactive selection

--- a/ros2service/ros2service/api/__init__.py
+++ b/ros2service/ros2service/api/__init__.py
@@ -120,8 +120,10 @@ class ServiceTypeCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         if self.service_name_key is not None:
+            service_name = getattr(parsed_args, self.service_name_key)
+            if not service_name:
+                return service_type_completer()
             with NodeStrategy(parsed_args) as node:
-                service_name = getattr(parsed_args, self.service_name_key)
                 names_and_types = get_service_names_and_types(
                     node=node, include_hidden_services=True)
                 for n, t in names_and_types:


### PR DESCRIPTION
closes https://github.com/ros2/ros2cli/issues/1181

## Description

Fixes tab completion for commands that were updated in the fzf interactive selection commit (#1151). After that commit, tab completion stopped working for `ros2 run`, `ros2 param get`, and `ros2 service call` because:

1. Arguments were changed from required to optional (`nargs='?'`, `default=None`)
2. When argcomplete tries to complete optional positional arguments, it invokes **all** completers simultaneously
3. Completers that depend on other arguments (e.g., `ExecutableNameCompleter` needs `package_name`) were being called with `None` values
4. These completers crashed silently, causing argcomplete to return no completions

**Changes made:**
- Added `None` checks in dependent completers (`ExecutableNameCompleter`, `ServiceTypeCompleter`, `ParameterNameCompleter`)
- Removed explicit `default=None` (argparse handles this automatically with `nargs='?'`)
- Added `SuppressCompleter` to `argv` REMAINDER argument in `ros2 run` to prevent unwanted file completion

Fixes backward compatibility issue where tab completion worked before fzf changes but was broken after.

### Is this user-facing behavior change?

**Yes** - This restores tab completion functionality:
- `ros2 run <tab><tab>` now shows package names again
- `ros2 run demo_nodes_py <tab><tab>` shows executables for that package
- Same for `ros2 param get` and `ros2 service call`

### Did you use Generative AI?

Yes - GitHub Copilot (Claude Sonnet 4.5)

### Additional Information
