### PR TITLE
fix deprecated warning for action graph APIs.

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -18,10 +18,8 @@ import time
 import uuid
 
 import rclpy
-import rclpy.action
 
 from ros2cli.helpers import before_invocation
-from ros2cli.helpers import bind
 from ros2cli.helpers import get_ros_domain_id
 from ros2cli.helpers import pretty_print_call
 
@@ -85,7 +83,7 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
             node.get_node_names_and_namespaces_with_enclaves,
             node.get_topic_names_and_types,
             node.get_service_names_and_types,
-            bind(rclpy.action.get_action_names_and_types, node),
+            node.get_action_names_and_types,
             node.get_publisher_names_and_types_by_node,
             node.get_publishers_info_by_topic,
             node.get_subscriber_names_and_types_by_node,
@@ -94,8 +92,8 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
             node.get_servers_info_by_service,
             node.get_clients_info_by_service,
             node.get_client_names_and_types_by_node,
-            bind(rclpy.action.get_action_server_names_and_types_by_node, node),
-            bind(rclpy.action.get_action_client_names_and_types_by_node, node),
+            node.get_action_server_names_and_types_by_node,
+            node.get_action_client_names_and_types_by_node,
             node.count_publishers,
             node.count_subscribers,
             node.count_clients,

--- a/ros2cli/ros2cli/node/direct.py
+++ b/ros2cli/ros2cli/node/direct.py
@@ -16,7 +16,6 @@ import os
 from typing import Optional
 
 import rclpy
-import rclpy.action
 
 from rclpy.parameter import Parameter
 from ros2cli.helpers import check_discovery_configuration
@@ -69,19 +68,16 @@ class DirectNode:
     def __enter__(self):
         return self
 
-    # TODO(hidmic): generalize/standardize rclpy graph API
-    #               to not have to make a special case for
-    #               rclpy.action
     def get_action_names_and_types(self) -> list[tuple[str, list[str]]]:
-        return rclpy.action.get_action_names_and_types(self.node)
+        return self.node.get_action_names_and_types()
 
     def get_action_client_names_and_types_by_node(self, remote_node_name, remote_node_namespace):
-        return rclpy.action.get_action_client_names_and_types_by_node(
-            self.node, remote_node_name, remote_node_namespace)
+        return self.node.get_action_client_names_and_types_by_node(
+            remote_node_name, remote_node_namespace)
 
     def get_action_server_names_and_types_by_node(self, remote_node_name, remote_node_namespace):
-        return rclpy.action.get_action_server_names_and_types_by_node(
-            self.node, remote_node_name, remote_node_namespace)
+        return self.node.get_action_server_names_and_types_by_node(
+            remote_node_name, remote_node_namespace)
 
     def __getattr__(self, name):
         if not rclpy.ok():


### PR DESCRIPTION
## Description

follow up of https://github.com/ros2/rclpy/pull/1574

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1187 

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
