### PR TITLE
Enable always complete argument

### DIFF
--- a/ros2cli/ros2cli/cli.py
+++ b/ros2cli/ros2cli/cli.py
@@ -61,7 +61,7 @@ def main(*, script_name='ros2', argv=None, description=None, extension=None):
     except ImportError:
         pass
     else:
-        autocomplete(parser, exclude=['-h', '--help'])
+        autocomplete(parser, exclude=['-h', '--help'], always_complete_options=False)
 
     # parse the command line arguments
     args = parser.parse_args(args=argv)


### PR DESCRIPTION
## Description

Adds a single argument to `argcomplete.autocomplete` to only complete some options, namely not completing dash options unless a dash is typed.

Ported from [`ros_command`](https://github.com/MetroRobots/ros_command/blob/26dee917396ebccf6f6902d830bb17d7af41a5b8/src/ros_command/commands/roslaunch.py#L20)

Fixes https://github.com/ros2/launch_ros/issues/507

### Is this user-facing behavior change?

Yes, this should result in cleaner tab-complete usage across many ROS CLI. 

### Did you use Generative AI?

No!

### Additional Information

I'm unclear of the easiest way to test this locally. 

I don't know if this should be configurable. 