### PR TITLE
Remove "rclrs" duplicate dependency

### DIFF
--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -145,7 +145,6 @@ class CreateVerb(VerbExtension):
 
         if args.build_type == 'ament_cargo':
             buildtool_depends = ['ament_cargo']
-            args.dependencies.append('rclrs')
 
         test_dependencies = []
         if args.build_type == 'ament_cmake':


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

There is already `rclrs` dependency defined in [`Cargo.toml.em`](https://github.com/ros2/ros2cli/blob/rolling/ros2pkg/ros2pkg/resource/ament_cargo/Cargo.toml.em) template file. Currently when trying to build package user gets duplication error:
```
error: duplicate key
  --> Cargo.toml:18:1
   |
18 | rclrs = "*"
   | ^^^^^
```

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Correct `Cargo.toml` file.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

GPT-5-mini for codebase exploration.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
