### PR TITLE
Fix auto-completed YAML string for `ros2service`

### DIFF
--- a/ros2cli/ros2cli/helpers.py
+++ b/ros2cli/ros2cli/helpers.py
@@ -20,9 +20,10 @@ import shutil
 import subprocess
 import sys
 import time
-
 from typing import Dict
 from typing import Optional
+
+from argcomplete import CompletionFinder
 
 
 def get_ros_domain_id():
@@ -238,3 +239,28 @@ def interactive_select(
     except (OSError, subprocess.SubprocessError) as e:
         print(f'Error during interactive selection: {e}', file=sys.stderr)
         return None
+
+
+class UnescapedCompletionFinder(CompletionFinder):
+
+    def quote_completions(
+        self,
+        completions: list[str],
+        cword_prequote: str,
+        last_wordbreak_pos: Optional[int],
+    ) -> list[str]:
+        """
+        Return completions without shell escaping.
+
+        Overrides the parent method to prevent mangling of YAML tokens
+        (dashes, braces, colons, etc.) that would otherwise be escaped
+        by the default shell quoting logic.
+
+        :param completions: List of completion strings to process.
+        :param cword_prequote: The quote character preceding the word
+            being completed, if any.
+        :param last_wordbreak_pos: Position of the last word-break
+            character in the current word, or None.
+        :return: The completions list, unmodified.
+        """
+        return completions

--- a/ros2service/ros2service/api/__init__.py
+++ b/ros2service/ros2service/api/__init__.py
@@ -140,4 +140,5 @@ class ServicePrototypeCompleter:
 
     def __call__(self, prefix, parsed_args, **kwargs):
         service = get_service(getattr(parsed_args, self.service_type_key))
-        return [message_to_yaml(service.Request())]
+        yaml_snippet = "'" + message_to_yaml(service.Request()) + "'"
+        return [yaml_snippet]

--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -15,11 +15,13 @@
 import time
 from typing import Optional
 
+import argcomplete
+
 import rclpy
 from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
 
-from ros2cli.helpers import collect_stdin
+from ros2cli.helpers import collect_stdin, UnescapedCompletionFinder
 from ros2cli.node import NODE_NAME_PREFIX
 from ros2cli.qos import add_qos_arguments
 from ros2cli.qos import profile_configure_short_keys
@@ -67,6 +69,10 @@ class CallVerb(VerbExtension):
             '--timeout', metavar='N', type=float,
             help='Maximum time to wait for service response in seconds. '
                  'If not specified, waits indefinitely.')
+
+        # Prevent argcomplete from escaping special characters in the YAML string
+        argcomplete.autocomplete = UnescapedCompletionFinder(parser)
+
         add_qos_arguments(parser, 'service client', 'services_default')
 
     def main(self, *, args):
@@ -99,7 +105,16 @@ def requester(service_type: str, service_name: str, values, period: Optional[flo
     except (AttributeError, ModuleNotFoundError):
         raise RuntimeError('The passed service type is invalid')
 
-    values_dictionary = yaml.safe_load(values)
+    try:
+        # Handle cases where the user pastes the autocompleted bash safe string
+        if '^J' in values:
+            values = values.replace("'", '')
+            values = values.replace('^J', '\n')
+
+        values_dictionary = yaml.safe_load(values)
+
+    except (yaml.parser.ParserError, yaml.scanner.ScannerError):
+        return 'The passed value needs to be in YAML string or a dictionary'
 
     with rclpy.init():
         node = rclpy.create_node(NODE_NAME_PREFIX + '_requester_%s_%s' % (package_name, srv_name))

--- a/ros2topic/ros2topic/api/__init__.py
+++ b/ros2topic/ros2topic/api/__init__.py
@@ -19,8 +19,6 @@ from typing import Optional
 
 import warnings
 
-from argcomplete import CompletionFinder
-
 import rclpy
 
 from rclpy.expand_topic_name import expand_topic_name
@@ -161,17 +159,6 @@ def _get_msg_class(node, topic, include_hidden_topics):
         return get_message(message_type)
     except (AttributeError, ModuleNotFoundError, ValueError):
         raise RuntimeError("The message type '%s' is invalid" % message_type)
-
-
-class YamlCompletionFinder(CompletionFinder):
-    def quote_completions(
-        self, completions: list[str],
-            cword_prequote: str, last_wordbreak_pos: Optional[int]):
-
-        # For YAML content, return as-is without escaping
-        if not any('-' in c for c in completions):
-            return completions
-        return super().quote_completions(completions, cword_prequote, last_wordbreak_pos)
 
 
 class TopicMessagePrototypeCompleter:

--- a/ros2topic/ros2topic/verb/pub.py
+++ b/ros2topic/ros2topic/verb/pub.py
@@ -22,14 +22,14 @@ import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
 
-from ros2cli.helpers import collect_stdin
+from ros2cli.helpers import collect_stdin, UnescapedCompletionFinder
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2cli.qos import add_qos_arguments
 from ros2cli.qos import profile_configure_short_keys
 
 from ros2topic.api import positive_float
-from ros2topic.api import TopicMessagePrototypeCompleter, YamlCompletionFinder
+from ros2topic.api import TopicMessagePrototypeCompleter
 from ros2topic.api import TopicNameCompleter
 from ros2topic.api import TopicTypeCompleter
 from ros2topic.verb import VerbExtension
@@ -115,8 +115,8 @@ class PubVerb(VerbExtension):
             '-n', '--node-name',
             help='Name of the created publishing node')
 
-        # Use the custom completion finder
-        argcomplete.autocomplete = YamlCompletionFinder(parser)
+        # Prevent argcomplete from escaping special characters in the YAML string
+        argcomplete.autocomplete = UnescapedCompletionFinder(parser)
 
         add_qos_arguments(parser, 'publish', 'default')
         add_direct_node_arguments(parser)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Closes #1194 ; Related #995  |
| Primary OS tested on | Ubuntu |

## Description

* Renamed `YamlCompletionFinder` to `UnescapedCompletionFinder` to better indicate intent.

   This function is further simplified to return the unedited completions to the terminal on all conditions, which would otherwise be filled with special characters from `argcomplete`.
   
* Moved `UnescapedCompletionFinder` to the [`helpers.py`](https://github.com/ros2/ros2cli/compare/rolling...leander-dsouza:ros2cli:rolling?expand=1#diff-6c6d58d7e8447eb33ff5efda6d4886a82aabb875060052c8e4dd33e9ea93cd34R244) script for reusability with other methods.

* Configured `ros2service` to use this custom completion finder in the same way as configured in #995 for `ros2topic`.
   
## How to test

* Run an example node that hosts a demo service - `/add_two_ints`:

   **`demo_service.py`**:

   ```python
   import rclpy
   from rclpy.executors import ExternalShutdownException
   from rclpy.node import Node

   from example_interfaces.srv import AddTwoInts


   class DemoService(Node):

       def __init__(self):
           super().__init__('demo_service')
           self.srv = self.create_service(AddTwoInts, 'add_two_ints', self.add_two_ints_callback)
           self.get_logger().info("Service 'add_two_ints' is ready.")

       def add_two_ints_callback(self, request, response):
           response.sum = request.a + request.b
           self.get_logger().info(f'Incoming request: a={request.a}, b={request.b} -> sum={response.sum}')
           return response


   def main(args=None):
       rclpy.init(args=args)
       try:
           node = DemoService()
           rclpy.spin(node)
       except (KeyboardInterrupt, ExternalShutdownException):
           print('Service node stopped cleanly')
       finally:
           node.destroy_node()
           rclpy.shutdown()


   if __name__ == '__main__':
       main()
   ```
   On a separate terminal, execute the test script:
   
   ```bash
   python3 demo_service.py
   ```
* Before this addition, the autocomplete would fail as follows:

   ```bash
   $ ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts \'a:\ 0b:\ 0\'
   Failed to populate field: Value 'a: 0b: 0' is expected to be a dictionary but is a str
   ```
* After the addition of this PR, this is the expected output:

   ```bash
   $ ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts 'a: 0
   b: 0
   '
   waiting for service to become available...
   requester: making request: example_interfaces.srv.AddTwoInts_Request(a=0, b=0)

   response:
   example_interfaces.srv.AddTwoInts_Response(sum=0) 
   ```

### Is this user-facing behavior change?

Yes, the user-facing behavior change is described in the testing section.

### Did you use Generative AI?

No

### Additional Information
For distros semantically lower than `rolling`, a [check](https://github.com/ros2/ros2cli/pull/1201/changes#diff-df32ab2eb45331ee7853b55a731c9180dec5d5b99768dcc07e11e2d047593bdaR128) for `^J` is still needed:
For instance, tabbing the given example in `kilted` or `jazzy` results in the following:

```bash
$ ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts <tab>
'a: 0^Jb: 0^J'  --rate          --stdin         -r 
```

