### PR TITLE
ros2 param set /node_name <param1 value1 param2 value2...> support.

### DIFF
--- a/ros2param/ros2param/api/__init__.py
+++ b/ros2param/ros2param/api/__init__.py
@@ -104,6 +104,21 @@ def call_set_parameters(*, node, node_name, parameters):
     return response
 
 
+def call_set_parameters_atomically(*, node, node_name, parameters):
+    client = AsyncParameterClient(node, node_name)
+    ready = client.wait_for_services(timeout_sec=5.0)
+    if not ready:
+        raise RuntimeError('Wait for service timed out waiting for '
+                           f'parameter services for node {node_name}')
+    future = client.set_parameters_atomically(parameters)
+    rclpy.spin_until_future_complete(node, future)
+    response = future.result()
+    if response is None:
+        raise RuntimeError('Exception while calling service of node '
+                           f'{node_name}: {future.exception()}')
+    return response
+
+
 def call_list_parameters(*, node, node_name, prefixes=None, spin_timeout_sec=None):
     client = AsyncParameterClient(node, node_name)
     ready = client.wait_for_services(timeout_sec=5.0)

--- a/ros2param/ros2param/verb/set.py
+++ b/ros2param/ros2param/verb/set.py
@@ -24,6 +24,7 @@ from ros2node.api import NodeNameCompleter
 from ros2node.api import wait_for_node
 
 from ros2param.api import call_set_parameters
+from ros2param.api import call_set_parameters_atomically
 from ros2param.api import ParameterNameCompleter
 from ros2param.verb import VerbExtension
 
@@ -63,6 +64,10 @@ class SetVerb(VerbExtension):
                  'Provide one or more name/value pairs to set multiple parameters at once.')
         arg.completer = _NameValueCompleter()
         parser.add_argument(
+            '--atomic', action='store_true',
+            help='Set all parameters atomically using the SetParametersAtomically service. '
+                 'Either all parameters are set successfully or none are changed.')
+        parser.add_argument(
             '--timeout', metavar='N', type=int, default=1,
             help='Wait for N seconds until node becomes available (default %(default)s sec)')
 
@@ -91,25 +96,42 @@ class SetVerb(VerbExtension):
                 parameter.value = get_parameter_value(string_value=param_value_str)
                 parameters.append(parameter)
 
-            response = call_set_parameters(
-                node=node, node_name=args.node_name, parameters=parameters)
+            if args.atomic:
+                # Set all parameters in a single atomic transaction
+                response = call_set_parameters_atomically(
+                    node=node, node_name=args.node_name, parameters=parameters)
 
-            # output response
-            assert len(response.results) == len(parameters)
-            for (param_name, _), result in zip(pairs, response.results):
+                result = response.result
                 if result.successful:
-                    msg = 'Set parameter successful'
+                    msg = 'Set parameters atomically successful'
                     if result.reason:
                         msg += ': ' + result.reason
-                    if multi_param:
-                        print(f'{param_name}: {msg}')
-                    else:
-                        print(msg)
+                    print(msg)
                 else:
-                    msg = 'Setting parameter failed'
+                    msg = 'Setting parameters atomically failed'
                     if result.reason:
                         msg += ': ' + result.reason
-                    if multi_param:
-                        print(f'{param_name}: {msg}', file=sys.stderr)
+                    print(msg, file=sys.stderr)
+            else:
+                response = call_set_parameters(
+                    node=node, node_name=args.node_name, parameters=parameters)
+
+                # output response
+                assert len(response.results) == len(parameters)
+                for (param_name, _), result in zip(pairs, response.results):
+                    if result.successful:
+                        msg = 'Set parameter successful'
+                        if result.reason:
+                            msg += ': ' + result.reason
+                        if multi_param:
+                            print(f'{param_name}: {msg}')
+                        else:
+                            print(msg)
                     else:
-                        print(msg, file=sys.stderr)
+                        msg = 'Setting parameter failed'
+                        if result.reason:
+                            msg += ': ' + result.reason
+                        if multi_param:
+                            print(f'{param_name}: {msg}', file=sys.stderr)
+                        else:
+                            print(msg, file=sys.stderr)

--- a/ros2param/ros2param/verb/set.py
+++ b/ros2param/ros2param/verb/set.py
@@ -30,7 +30,8 @@ from ros2param.verb import VerbExtension
 
 
 class _NameValueCompleter:
-    """Completer for interleaved name/value pairs.
+    """
+    Completer for interleaved name/value pairs.
 
     Delegates to ParameterNameCompleter for name positions (even index)
     and returns no completions for value positions (odd index).

--- a/ros2param/ros2param/verb/set.py
+++ b/ros2param/ros2param/verb/set.py
@@ -28,6 +28,22 @@ from ros2param.api import ParameterNameCompleter
 from ros2param.verb import VerbExtension
 
 
+class _NameValueCompleter:
+    """Completer for interleaved name/value pairs.
+
+    Delegates to ParameterNameCompleter for name positions (even index)
+    and returns no completions for value positions (odd index).
+    """
+
+    def __call__(self, prefix, parsed_args, **kwargs):
+        already = getattr(parsed_args, 'params_and_values', None) or []
+        # Even count of already-collected tokens → completing a *name*
+        if len(already) % 2 == 0:
+            return ParameterNameCompleter()(prefix, parsed_args, **kwargs)
+        # Odd count → completing a *value*; no suggestions
+        return []
+
+
 class SetVerb(VerbExtension):
     """Set parameter."""
 
@@ -41,38 +57,59 @@ class SetVerb(VerbExtension):
             '--include-hidden-nodes', action='store_true',
             help='Consider hidden nodes as well')
         arg = parser.add_argument(
-            'parameter_name', help='Name of the parameter')
-        arg.completer = ParameterNameCompleter()
-        parser.add_argument(
-            'value', help='Value of the parameter')
+            'params_and_values', nargs='+',
+            metavar='name value',
+            help='Parameter name and value pair(s): name value [name value ...]. '
+                 'Provide one or more name/value pairs to set multiple parameters at once.')
+        arg.completer = _NameValueCompleter()
         parser.add_argument(
             '--timeout', metavar='N', type=int, default=1,
             help='Wait for N seconds until node becomes available (default %(default)s sec)')
 
     def main(self, *, args):  # noqa: D102
+        # Validate that parameters were provided as name/value pairs
+        if len(args.params_and_values) % 2 != 0:
+            return (
+                'Parameters must be provided as name/value pairs: '
+                'name value [name value ...]. '
+                f'Got {len(args.params_and_values)} argument(s).'
+            )
+
+        pairs = list(zip(args.params_and_values[::2], args.params_and_values[1::2]))
+        multi_param = len(pairs) > 1
+
         node_name = get_absolute_node_name(args.node_name)
         with NodeStrategy(args) as node:
             if not wait_for_node(node, node_name, args.include_hidden_nodes, args.timeout):
                 return 'Node not found'
 
         with DirectNode(args) as node:
-            parameter = Parameter()
-            parameter.name = args.parameter_name
-            parameter.value = get_parameter_value(string_value=args.value)
+            parameters = []
+            for param_name, param_value_str in pairs:
+                parameter = Parameter()
+                parameter.name = param_name
+                parameter.value = get_parameter_value(string_value=param_value_str)
+                parameters.append(parameter)
 
             response = call_set_parameters(
-                node=node, node_name=args.node_name, parameters=[parameter])
+                node=node, node_name=args.node_name, parameters=parameters)
 
             # output response
-            assert len(response.results) == 1
-            result = response.results[0]
-            if result.successful:
-                msg = 'Set parameter successful'
-                if result.reason:
-                    msg += ': ' + result.reason
-                print(msg)
-            else:
-                msg = 'Setting parameter failed'
-                if result.reason:
-                    msg += ': ' + result.reason
-                print(msg, file=sys.stderr)
+            assert len(response.results) == len(parameters)
+            for (param_name, _), result in zip(pairs, response.results):
+                if result.successful:
+                    msg = 'Set parameter successful'
+                    if result.reason:
+                        msg += ': ' + result.reason
+                    if multi_param:
+                        print(f'{param_name}: {msg}')
+                    else:
+                        print(msg)
+                else:
+                    msg = 'Setting parameter failed'
+                    if result.reason:
+                        msg += ': ' + result.reason
+                    if multi_param:
+                        print(f'{param_name}: {msg}', file=sys.stderr)
+                    else:
+                        print(msg, file=sys.stderr)

--- a/ros2param/test/test_verb_set.py
+++ b/ros2param/test/test_verb_set.py
@@ -369,4 +369,3 @@ class TestVerbSet(unittest.TestCase):
         assert 'Setting parameters atomically failed' in param_set_command.output
         # The successful param name must NOT appear as individually set
         assert 'bool_param: Set parameter' not in param_set_command.output
-

--- a/ros2param/test/test_verb_set.py
+++ b/ros2param/test/test_verb_set.py
@@ -283,7 +283,8 @@ class TestVerbSet(unittest.TestCase):
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_verb_set_multiple_params_one_nonexistent(self):
-        """Test setting multiple params where one is not declared on the node.
+        """
+        Test setting multiple params where one is not declared on the node.
 
         set_parameters returns one result per parameter.  For an undeclared
         parameter the service sets successful=False with a reason string.
@@ -348,7 +349,8 @@ class TestVerbSet(unittest.TestCase):
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_verb_set_atomic_one_nonexistent(self):
-        """Test atomic set where one parameter is undeclared.
+        """
+        Test atomic set where one parameter is undeclared.
 
         SetParametersAtomically is all-or-nothing: if any parameter fails the
         entire transaction is rejected and no parameters are changed.  The

--- a/ros2param/test/test_verb_set.py
+++ b/ros2param/test/test_verb_set.py
@@ -306,3 +306,67 @@ class TestVerbSet(unittest.TestCase):
         # Undeclared parameter reports failure
         assert 'nonexistent_param: Setting parameter failed' in output
 
+    # -------------------------------------------------------------------------
+    # Atomic tests (--atomic flag)
+    # -------------------------------------------------------------------------
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_atomic_single_param(self):
+        """Test setting a single parameter atomically."""
+        with self.launch_param_set_command(
+            arguments=[
+                f'{TEST_NAMESPACE}/{TEST_NODE}', 'bool_param', 'false', '--atomic'
+            ]
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Set parameters atomically successful'],
+            text=param_set_command.output,
+            strict=False
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_atomic_multiple_params(self):
+        """Test setting multiple parameters atomically (all declared)."""
+        with self.launch_param_set_command(
+            arguments=[
+                f'{TEST_NAMESPACE}/{TEST_NODE}',
+                'bool_param', 'true',
+                'int_param', '42',
+                'str_param', 'Hello World',
+                '--atomic',
+            ]
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Set parameters atomically successful'],
+            text=param_set_command.output,
+            strict=False
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_atomic_one_nonexistent(self):
+        """Test atomic set where one parameter is undeclared.
+
+        SetParametersAtomically is all-or-nothing: if any parameter fails the
+        entire transaction is rejected and no parameters are changed.  The
+        command prints a single failure message and exits cleanly (exit 0)
+        because the service call itself completed.
+        """
+        with self.launch_param_set_command(
+            arguments=[
+                f'{TEST_NAMESPACE}/{TEST_NODE}',
+                'bool_param', 'false',
+                'nonexistent_param', 'some_value',
+                '--atomic',
+            ]
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        # A single failure message is printed (not per-parameter)
+        assert 'Setting parameters atomically failed' in param_set_command.output
+        # The successful param name must NOT appear as individually set
+        assert 'bool_param: Set parameter' not in param_set_command.output
+

--- a/ros2param/test/test_verb_set.py
+++ b/ros2param/test/test_verb_set.py
@@ -1,0 +1,308 @@
+# Copyright 2026 Sony Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+from pathlib import Path
+import sys
+import time
+import unittest
+import xmlrpc
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.actions import ResetEnvironment
+from launch.actions import SetEnvironmentVariable
+from launch.event_handlers import OnShutdown
+from launch_ros.actions import Node
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import launch_testing.tools
+from launch_testing_ros.actions import EnableRmwIsolation
+import launch_testing_ros.tools
+
+import pytest
+
+import rclpy
+from rclpy.utilities import get_available_rmw_implementations
+
+from ros2cli.helpers import get_rmw_additional_env
+from ros2cli.node.strategy import NodeStrategy
+
+
+TEST_NODE = 'test_node1'
+TEST_NAMESPACE = '/test'
+
+TEST_TIMEOUT = 20.0
+
+# Skip cli tests on Windows while they exhibit pathological behavior
+# https://github.com/ros2/build_farmer/issues/248
+if sys.platform.startswith('win'):
+    pytest.skip(
+            'CLI tests can block for a pathological amount of time on Windows.',
+            allow_module_level=True)
+
+
+@pytest.mark.rostest
+@launch_testing.parametrize('rmw_implementation', get_available_rmw_implementations())
+def generate_test_description(rmw_implementation):
+    path_to_fixtures = Path(__file__).parent / 'fixtures'
+    additional_env = get_rmw_additional_env(rmw_implementation)
+    set_env_actions = [SetEnvironmentVariable(k, v) for k, v in additional_env.items()]
+
+    path_to_parameter_node_script = path_to_fixtures / 'parameter_node.py'
+    parameter_node = Node(
+        executable=sys.executable,
+        name=TEST_NODE,
+        namespace=TEST_NAMESPACE,
+        arguments=[str(path_to_parameter_node_script)],
+    )
+
+    return LaunchDescription([
+        ExecuteProcess(
+            cmd=['ros2', 'daemon', 'stop'],
+            name='daemon-stop',
+            on_exit=[
+                *set_env_actions,
+                EnableRmwIsolation(),
+                RegisterEventHandler(OnShutdown(on_shutdown=[
+                    ExecuteProcess(
+                        cmd=['ros2', 'daemon', 'stop'],
+                        name='daemon-stop-isolated',
+                        additional_env=dict(additional_env),
+                    ),
+                    ResetEnvironment(),
+                ])),
+                ExecuteProcess(
+                    cmd=['ros2', 'daemon', 'start'],
+                    name='daemon-start',
+                    on_exit=[
+                        parameter_node,
+                        launch_testing.actions.ReadyToTest(),
+                    ],
+                )
+            ]
+        ),
+    ])
+
+
+class TestVerbSet(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(
+        cls,
+        launch_service,
+        proc_info,
+        proc_output,
+        rmw_implementation
+    ):
+        rmw_implementation_filter = launch_testing_ros.tools.basic_output_filter(
+            filtered_rmw_implementation=rmw_implementation
+        )
+
+        @contextlib.contextmanager
+        def launch_param_set_command(self, arguments):
+            param_set_command_action = ExecuteProcess(
+                cmd=['ros2', 'param', 'set', *arguments],
+                name='ros2param-set-cli',
+                output='screen'
+            )
+            with launch_testing.tools.launch_process(
+                launch_service, param_set_command_action, proc_info, proc_output,
+                output_filter=rmw_implementation_filter
+            ) as param_set_command:
+                yield param_set_command
+        cls.launch_param_set_command = launch_param_set_command
+
+    def setUp(self):
+        start_time = time.time()
+        timed_out = True
+        with NodeStrategy(None) as node:
+            while (time.time() - start_time) < TEST_TIMEOUT:
+                try:
+                    services = node.get_service_names_and_types_by_node(
+                        TEST_NODE, TEST_NAMESPACE)
+                except rclpy.node.NodeNameNonExistentError:
+                    continue
+                except ConnectionRefusedError:
+                    continue
+                except xmlrpc.client.Fault as e:
+                    if 'NodeNameNonExistentError' in e.faultString:
+                        continue
+                    raise
+
+                service_names = [name_type_tuple[0] for name_type_tuple in services]
+                if (
+                    len(service_names) > 0
+                    and f'{TEST_NAMESPACE}/{TEST_NODE}/set_parameters' in service_names
+                ):
+                    timed_out = False
+                    break
+        if timed_out:
+            self.fail(f'CLI daemon failed to find test node after {TEST_TIMEOUT} seconds')
+
+    # -------------------------------------------------------------------------
+    # Single-parameter tests
+    # -------------------------------------------------------------------------
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_single_param_bool(self):
+        """Test setting a single boolean parameter (existing behavior)."""
+        with self.launch_param_set_command(
+            arguments=[f'{TEST_NAMESPACE}/{TEST_NODE}', 'bool_param', 'false']
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Set parameter successful'],
+            text=param_set_command.output,
+            strict=False
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_single_param_int(self):
+        """Test setting a single integer parameter (existing behavior)."""
+        with self.launch_param_set_command(
+            arguments=[f'{TEST_NAMESPACE}/{TEST_NODE}', 'int_param', '99']
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Set parameter successful'],
+            text=param_set_command.output,
+            strict=False
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_single_param_string(self):
+        """Test setting a single string parameter (existing behavior)."""
+        with self.launch_param_set_command(
+            arguments=[f'{TEST_NAMESPACE}/{TEST_NODE}', 'str_param', 'new_value']
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Set parameter successful'],
+            text=param_set_command.output,
+            strict=False
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_node_not_found(self):
+        """Test that 'Node not found' is reported for a nonexistent node."""
+        with self.launch_param_set_command(
+            arguments=['/nonexistent_node', 'bool_param', 'true']
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code != launch_testing.asserts.EXIT_OK
+        assert 'Node not found' in param_set_command.output
+
+    # -------------------------------------------------------------------------
+    # Multiple-parameter tests (new feature)
+    # -------------------------------------------------------------------------
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_multiple_params(self):
+        """Test setting two parameters at once."""
+        with self.launch_param_set_command(
+            arguments=[
+                f'{TEST_NAMESPACE}/{TEST_NODE}',
+                'bool_param', 'false',
+                'int_param', '7',
+            ]
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        output = param_set_command.output
+        # Multi-param output is prefixed with each parameter name
+        assert 'bool_param: Set parameter successful' in output
+        assert 'int_param: Set parameter successful' in output
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_multiple_params_three(self):
+        """Test setting three parameters at once."""
+        with self.launch_param_set_command(
+            arguments=[
+                f'{TEST_NAMESPACE}/{TEST_NODE}',
+                'bool_param', 'true',
+                'int_param', '42',
+                'str_param', 'Hello World',
+            ]
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        output = param_set_command.output
+        assert 'bool_param: Set parameter successful' in output
+        assert 'int_param: Set parameter successful' in output
+        assert 'str_param: Set parameter successful' in output
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_multiple_params_mixed_types(self):
+        """Test setting parameters of different types at once."""
+        with self.launch_param_set_command(
+            arguments=[
+                f'{TEST_NAMESPACE}/{TEST_NODE}',
+                'bool_param', 'false',
+                'double_param', '9.99',
+                'str_param', 'updated',
+            ]
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        output = param_set_command.output
+        assert 'bool_param: Set parameter successful' in output
+        assert 'double_param: Set parameter successful' in output
+        assert 'str_param: Set parameter successful' in output
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_odd_number_of_args(self):
+        """Test that an odd number of positional arguments is rejected."""
+        with self.launch_param_set_command(
+            arguments=[
+                f'{TEST_NAMESPACE}/{TEST_NODE}',
+                'bool_param', 'false', 'int_param',  # missing value for int_param
+            ]
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        # An odd number of name/value arguments must produce an error exit
+        assert param_set_command.exit_code != launch_testing.asserts.EXIT_OK
+        assert 'name/value pairs' in param_set_command.output
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_verb_set_multiple_params_one_nonexistent(self):
+        """Test setting multiple params where one is not declared on the node.
+
+        set_parameters returns one result per parameter.  For an undeclared
+        parameter the service sets successful=False with a reason string.
+        The declared parameter should be set successfully, the undeclared one
+        should report failure; the overall exit code is 0 because the service
+        call itself completed without error.
+        """
+        with self.launch_param_set_command(
+            arguments=[
+                f'{TEST_NAMESPACE}/{TEST_NODE}',
+                'bool_param', 'true',
+                'nonexistent_param', 'some_value',
+            ]
+        ) as param_set_command:
+            assert param_set_command.wait_for_shutdown(timeout=TEST_TIMEOUT)
+        assert param_set_command.exit_code == launch_testing.asserts.EXIT_OK
+        output = param_set_command.output
+        # Declared parameter succeeds
+        assert 'bool_param: Set parameter successful' in output
+        # Undeclared parameter reports failure
+        assert 'nonexistent_param: Setting parameter failed' in output
+


### PR DESCRIPTION
## Description

this PR adds the two features.

- `ros2 param set <node_name> <param1 value param2 value...>` with multiple parameters
- add `--atomic` optional argument to support atomic behavior for `ros2 param set` with multiple paramters.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

closes https://github.com/ros2/ros2cli/issues/721, https://github.com/ros2/ros2cli/pull/728 and https://github.com/ros2/ros2cli/pull/727

### Is this user-facing behavior change?

Yes, but only gets better.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes Claude Sonnext 4.6

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
