### PR TITLE
fix non standard interface locations. (#1186)

### DIFF
--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -13,8 +13,14 @@
 # limitations under the License.
 
 import argparse
+import os
 import sys
 import typing
+
+from ament_index_python.packages import \
+    get_package_share_directory, \
+    PackageNotFoundError
+from ament_index_python.resources import get_resource
 
 from ros2interface.api import type_completer
 from ros2interface.verb import VerbExtension
@@ -25,7 +31,6 @@ from rosidl_adapter.parser import \
     MessageSpecification, \
     parse_message_string, \
     SERVICE_REQUEST_RESPONSE_SEPARATOR
-from rosidl_runtime_py import get_interface_path
 
 
 class InterfaceTextLine:
@@ -108,9 +113,23 @@ def _get_interface_lines(interface_identifier: str) -> typing.Iterable[Interface
         raise ValueError(
             f"Invalid name '{interface_identifier}'. Expected three parts separated by '/'"
         )
-    pkg_name, _, msg_name = parts
+    pkg_name, msg_type, msg_name = parts
 
-    file_path = get_interface_path(interface_identifier)
+    try:
+        share_dir = get_package_share_directory(pkg_name)
+    except PackageNotFoundError:
+        raise LookupError(f"Unknown package '{pkg_name}'")
+
+    interfaces, _ = get_resource('rosidl_interfaces', pkg_name)
+    interfaces = interfaces.splitlines()
+
+    interface = [f for f in interfaces if f.endswith(msg_name + '.' + msg_type)]
+    if len(interface) == 0:
+        raise LookupError(
+            f"Interface '{msg_type}/{msg_name}' not found in package '{pkg_name}'"
+        )
+
+    file_path = os.path.join(share_dir, interface[0])
     with open(file_path) as file_handler:
         for line in file_handler:
             yield InterfaceTextLine(

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -527,7 +527,7 @@ class TestROS2InterfaceCLI(unittest.TestCase):
         assert interface_command.exit_code == 1
         assert launch_testing.tools.expect_output(
             expected_lines=[re.compile(
-                r"Could not find the interface '.+NotAMessageTypeName\.idl'"
+                r"Interface 'msg/NotAMessageTypeName' not found in package 'test_msgs'"
             )],
             text=interface_command.output,
             strict=True


### PR DESCRIPTION
## Description
Instead of relying on the broken `get_interface_path` function, I use the `rosidl_interfaces` resource directly. (see [explanation](https://github.com/ros2/rosidl/pull/935#issuecomment-4009290632))
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1186

### Is this user-facing behavior change?
No
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
For rolling, this issue will be resolved by changing the behavior of ros2idl in https://github.com/ros2/rosidl/pull/935

This patch can be backported to Jazzy and humble.

I am unsure whether it is correct to fix this in ros2cli or whether the change should happen in `rosidl_runtime_py`. Due to the huge number of packages that depend on `rosidl_runtime_py`, I am hesitant to make that change there, especially since packages rarely rely on the `.msg/.srv/.action` files.
<!--
If applicable, provide any additional context or details about the changes.
-->
