### PR TITLE
Backport of always complete feature - #1190 to the jazzy branch.

### DIFF
--- a/ros2cli/ros2cli/cli.py
+++ b/ros2cli/ros2cli/cli.py
@@ -61,7 +61,7 @@ def main(*, script_name='ros2', argv=None, description=None, extension=None):
     except ImportError:
         pass
     else:
-        autocomplete(parser, exclude=['-h', '--help'])
+        autocomplete(parser, exclude=['-h', '--help'], always_complete_options=False)
 
     # parse the command line arguments
     args = parser.parse_args(args=argv)


### PR DESCRIPTION
## Description

* Backport the always-complete feature of YAML strings #1190  to the `jazzy` branch
* Full credit goes to @DLu for this feature :)

## Testing
Tabbing after the message type now suggests the string automatically instead of the earlier suboptions.

### Before

```bash
$ ros2 topic pub /cmd_vel geometry_msgs/msg/Twist <tab>
--keep-alive
--max-wait-time-secs
--node-name
--once
--print
--qos-depth
--qos-durability
--qos-history
--qos-liveliness
--qos-liveliness-lease-duration-seconds
--qos-profile
--qos-reliability
--rate
--spin-time
--stdin
--times
--use-sim-time
--wait-matching-subscriptions
-1
-n
-p
-r
-s
-t
-w
\'linear:\^J\ \ x:\ 0.0\^J\ \ y:\ 0.0\^J\ \ z:\ 0.0\^Jangular:\^J\ \ x:\ 0.0\^J\ \ y:\ 0.0\^J\ \ z:\ 0.0\^J\'
```

### After

```bash
ros2 topic pub /cmd_vel geometry_msgs/msg/Twist <tab> 'linear:
  x: 0.0
  y: 0.0
  z: 0.0
angular:
  x: 0.0
  y: 0.0
  z: 0.0
' 
```


### Did you use Generative AI?
- No

### Additional Information
- N/A
