### PR TITLE
fix(test_ros2cli_daemon): add RMW isolation fixture for zenoh router

### DIFF
--- a/ros2cli/package.xml
+++ b/ros2cli/package.xml
@@ -23,6 +23,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>fzf</exec_depend>
 
+  <test_depend>rmw_test_fixture_implementation</test_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ros2cli/test/test_ros2cli_daemon.py
+++ b/ros2cli/test/test_ros2cli_daemon.py
@@ -27,6 +27,13 @@ from ros2cli.node.daemon import is_daemon_running
 from ros2cli.node.daemon import shutdown_daemon
 from ros2cli.node.daemon import spawn_daemon
 
+try:
+    from rmw_test_fixture_implementation import rmw_test_isolation_start
+    from rmw_test_fixture_implementation import rmw_test_isolation_stop
+    _HAS_RMW_ISOLATION = True
+except ImportError:
+    _HAS_RMW_ISOLATION = False
+
 import test_msgs.action
 import test_msgs.msg
 import test_msgs.srv
@@ -54,6 +61,16 @@ TEST_SERVICE_NAME = '/test/service'
 TEST_SERVICE_TYPE = 'test_msgs/srv/Empty'
 TEST_ACTION_NAME = '/test/action'
 TEST_ACTION_TYPE = 'test_msgs/action/Fibonacci'
+
+
+@pytest.fixture(autouse=True, scope='session')
+def rmw_isolation():
+    """Start RMW isolation before spawning the daemon."""
+    if _HAS_RMW_ISOLATION:
+        rmw_test_isolation_start()
+    yield
+    if _HAS_RMW_ISOLATION:
+        rmw_test_isolation_stop()
 
 
 @pytest.fixture(autouse=True, scope='module')


### PR DESCRIPTION
## Summary
`test_ros2cli_daemon` fails in the `Rci__nightly-zenoh_ubuntu_noble_amd64` CI because the ROS 2 CLI daemon and the test node cannot discover each other — no isolated network is set up for the test, so cross-process node discovery fails.

## Key Changes
- Add an `autouse` session-scoped fixture `rmw_isolation` that calls `rmw_test_isolation_start()` / `rmw_test_isolation_stop()` around the entire test session, before `spawn_daemon()` is called
- Import is wrapped in `try/except ImportError` so the fixture is a no-op on non-Zenoh RMW implementations where the package is absent
- Add `rmw_test_fixture_implementation` as a test dependency in `package.xml`

## Breaking Changes
None

## Deep Dive

[`rmw_test_isolation_start()`](https://github.com/ros2/rmw_zenoh/blob/944a8715f5af6f58e74e318d31510409f69a5e6e/rmw_zenoh_cpp/src/rmw_test_fixture.cpp#L87) starts an in-process Zenoh router on a random port and sets `ZENOH_CONFIG_OVERRIDE=connect/endpoints=[tcp/127.0.0.1:<port>]` in the current process environment ([line 136–139](https://github.com/ros2/rmw_zenoh/blob/944a8715f5af6f58e74e318d31510409f69a5e6e/rmw_zenoh_cpp/src/rmw_test_fixture.cpp#L136-L139)). Any subprocess that inherits `os.environ` will have rmw_zenoh_cpp connect to that router and share the same discovery graph.

`spawn_daemon()` calls `subprocess.Popen()` with no explicit `env=`, so the daemon naturally inherits `os.environ`. Starting isolation before `spawn_daemon()` is therefore sufficient — the daemon picks up the router endpoint from the environment and connects to the same network as the test node.

Closes ros2/rmw_zenoh#932
