### PR TITLE
Make ros2 action info --verbose consistent with topic/service info

### DIFF
--- a/ros2action/ros2action/verb/info.py
+++ b/ros2action/ros2action/verb/info.py
@@ -19,6 +19,25 @@ from ros2action.verb import VerbExtension
 from ros2cli.node.strategy import NodeStrategy
 
 
+def _split_fully_qualified_name(fqn):
+    if not fqn.startswith('/'):
+        return '/', fqn
+    idx = fqn.rfind('/')
+    if idx == 0:
+        return '/', fqn[1:]
+    return fqn[:idx], fqn[idx + 1:]
+
+
+def _format_action_endpoint_block(node_fqn, types, endpoint_label):
+    node_namespace, node_name = _split_fully_qualified_name(node_fqn)
+    return (
+        f'Node name: {node_name}\n'
+        f'Node namespace: {node_namespace}\n'
+        f'Action type: {", ".join(types)}\n'
+        f'Endpoint type: {endpoint_label}'
+    )
+
+
 class InfoVerb(VerbExtension):
     """Print information about an action."""
 
@@ -33,6 +52,12 @@ class InfoVerb(VerbExtension):
         parser.add_argument(
             '-c', '--count', action='store_true',
             help='Only display the number of action clients and action servers')
+        parser.add_argument(
+            '--verbose', '-v', action='store_true',
+            help='Prints detailed information for each action client and action server, '
+                 'including the node name, node namespace, action type, and endpoint type '
+                 '(CLIENT or SERVER). QoS profiles and type hashes are not exposed for '
+                 'action endpoints.')
 
     def main(self, *, args):
         with NodeStrategy(args) as node:
@@ -44,20 +69,38 @@ class InfoVerb(VerbExtension):
             except (ValueError, rclpy.exceptions.InvalidTopicNameException) as e:
                 raise RuntimeError(e)
 
-        print('Action: {}'.format(args.action_name))
-        print('Action clients: {}'.format(len(action_clients)))
+        line_end = '\n\n' if args.verbose else '\n'
+
+        print('Action: {}'.format(args.action_name), end=line_end)
+
+        print('Action clients: {}'.format(len(action_clients)), end=line_end)
         if not args.count:
-            for client_name, client_types in action_clients:
-                if args.show_types:
-                    types_formatted = ', '.join(client_types)
-                    print(f'    {client_name} [{types_formatted}]')
-                else:
-                    print(f'    {client_name}')
-        print('Action servers: {}'.format(len(action_servers)))
+            if args.verbose:
+                for node_fqn, client_types in action_clients:
+                    print(
+                        _format_action_endpoint_block(node_fqn, client_types, 'CLIENT'),
+                        end=line_end,
+                    )
+            else:
+                for client_name, client_types in action_clients:
+                    if args.show_types:
+                        types_formatted = ', '.join(client_types)
+                        print(f'    {client_name} [{types_formatted}]')
+                    else:
+                        print(f'    {client_name}')
+
+        print('Action servers: {}'.format(len(action_servers)), end=line_end)
         if not args.count:
-            for server_name, server_types in action_servers:
-                if args.show_types:
-                    types_formatted = ', '.join(server_types)
-                    print(f'    {server_name} [{types_formatted}]')
-                else:
-                    print(f'    {server_name}')
+            if args.verbose:
+                for node_fqn, server_types in action_servers:
+                    print(
+                        _format_action_endpoint_block(node_fqn, server_types, 'SERVER'),
+                        end=line_end,
+                    )
+            else:
+                for server_name, server_types in action_servers:
+                    if args.show_types:
+                        types_formatted = ', '.join(server_types)
+                        print(f'    {server_name} [{types_formatted}]')
+                    else:
+                        print(f'    {server_name}')

--- a/ros2action/test/test_cli.py
+++ b/ros2action/test/test_cli.py
@@ -214,6 +214,44 @@ class TestROS2ActionCLI(unittest.TestCase):
         )
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_fibonacci_info_verbose(self):
+        with self.launch_action_command(
+                arguments=['info', '-v', '/test/fibonacci']) as action_command:
+            assert action_command.wait_for_shutdown(timeout=10)
+        assert action_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                'Action: /test/fibonacci',
+                'Action clients: 0',
+                'Action servers: 1',
+                'Node name: fibonacci_action_server',
+                'Node namespace: /test',
+                'Action type: test_msgs/action/Fibonacci',
+                'Endpoint type: SERVER',
+            ],
+            text=action_command.output,
+            strict=False
+        )
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
+    def test_fibonacci_info_verbose_count(self):
+        with self.launch_action_command(
+                arguments=['info', '-v', '-c', '/test/fibonacci']) as action_command:
+            assert action_command.wait_for_shutdown(timeout=10)
+        assert action_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert launch_testing.tools.expect_output(
+            expected_lines=[
+                'Action: /test/fibonacci',
+                'Action clients: 0',
+                'Action servers: 1',
+            ],
+            text=action_command.output,
+            strict=False
+        )
+        assert 'Node name:' not in action_command.output
+        assert 'Endpoint type:' not in action_command.output
+
+    @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_list(self):
         with self.launch_action_command(arguments=['list']) as action_command:
             assert action_command.wait_for_shutdown(timeout=10)


### PR DESCRIPTION
## Description

Adds a `--verbose` / `-v` option to `ros2 action info`, matching the output style already provided by `ros2 topic info -v` and `ros2 service info -v`.

Default output is unchanged. With `--verbose`, each action client / server is printed as a block containing:

- Node name
- Node namespace
- Action type
- Endpoint type (`CLIENT` / `SERVER`)

QoS and type hash are intentionally omitted since they are not exposed for action endpoints (per the linked issue).
Addresses the second TODO in [#1210](https://github.com/ros2/ros2cli/issues/1210). 

### Is this user-facing behavior change?

Yes. `ros2 action info` now accepts `--verbose` / `-v`. Previously this flag was rejected as an unknown argument.

Example (new behavior):

    $ ros2 action info -v /fibonacci
    Action: /fibonacci
    Action clients: 0
    Action servers: 1

    Node name: fibonacci_action_server
    Node namespace: /
    Action type: test_msgs/action/Fibonacci
    Endpoint type: SERVER

Without `-v`, output is identical to before.

### Did you use Generative AI?

Yes — Claude Opus 4.7

### Additional Information

- Added two CLI tests in `ros2action/test/test_cli.py`:
  - `test_fibonacci_info_verbose` — asserts the verbose block fields
  - `test_fibonacci_info_verbose_count` — asserts `-v -c` suppresses the per-endpoint block
- No changes to the default (non-verbose) output, so existing users / scripts are unaffected.
- `--verbose` combined with `--count` prints only the counts, matching the behavior of `ros2 topic info -v -c`.