### PR TITLE
Improve test isolation and suppress Connext license noise

### DIFF
--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -57,6 +57,9 @@ def generate_test_description(rmw_implementation):
     path_to_fixtures = os.path.join(os.path.dirname(__file__), 'fixtures')
     additional_env = get_rmw_additional_env(rmw_implementation)
     additional_env['PYTHONUNBUFFERED'] = '1'
+    additional_env['ROS_AUTOMATIC_DISCOVERY_RANGE'] = 'LOCALHOST'
+    # Suppress RTI Connext license header noise
+    additional_env['NDDS_CONFIG_LOG_VERBOSITY'] = 'SILENT'
     set_env_actions = [SetEnvironmentVariable(k, v) for k, v in additional_env.items()]
     path_to_talker_node_script = os.path.join(path_to_fixtures, 'talker_node.py')
     path_to_listener_node_script = os.path.join(path_to_fixtures, 'listener_node.py')
@@ -116,22 +119,21 @@ def generate_test_description(rmw_implementation):
     )
 
     return LaunchDescription([
-        # Always restart daemon to isolate tests.
+        # Establish environment variables.
+        *set_env_actions,
+        # Enable RMW isolation (unique ROS_DOMAIN_ID).
+        EnableRmwIsolation(),
+        # Ensure daemon is stopped in the isolated environment before starting.
         ExecuteProcess(
             cmd=['ros2', 'daemon', 'stop'],
-            name='daemon-stop',
+            name='daemon-stop-isolated-pre',
             on_exit=[
-                *set_env_actions,
-                EnableRmwIsolation(),
+                # Stop daemon in isolated environment upon shutdown.
                 RegisterEventHandler(OnShutdown(on_shutdown=[
-                    # Stop daemon in isolated environment with proper ROS_DOMAIN_ID
                     ExecuteProcess(
                         cmd=['ros2', 'daemon', 'stop'],
-                        name='daemon-stop-isolated',
-                        # Use the same isolated environment
-                        additional_env=dict(additional_env),
+                        name='daemon-stop-isolated-post',
                     ),
-                    # This must be done after stopping the daemon in the isolated environment
                     ResetEnvironment(),
                 ])),
                 ExecuteProcess(


### PR DESCRIPTION
## Description

This PR improves test isolation in `ros2cli` tests (specifically `ros2topic`) to make them more robust across different RMW implementations and environments.

*   Enable RMW isolation earlier in the test lifecycle.
*   Ensure daemon is stopped in the isolated environment before starting.
*   Set `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` for robust isolation.
*   Suppress RTI Connext license header noise.
*   Maintain strict output matching for all RMW implementations.

Fixes https://github.com/ros2/ros2cli/issues/1129

### Is this user-facing behavior change?

### Did you use Generative AI?

Yes. Gemini CLI:2.0-Flash [run_shell_command, replace, git, gh]

### Additional Information

*   Sets `NDDS_CONFIG_LOG_VERBOSITY` to `SILENT` to prevent license noise from interfering with output matching.
*   The CI run (https://ci.ros2.org/job/ci_launcher/19055) shows that these changes fix previous flakes on Linux and Windows.