### PR TITLE
Check socket is actually freed and reusable during shutdown daemon.

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -75,6 +75,21 @@ def is_daemon_running(args):
         return node.connected
 
 
+def _is_daemon_address_free():
+    # Mirror LocalXMLRPCServer.allow_reuse_address: SO_REUSEADDR on
+    # non-Windows so TIME_WAIT doesn't make us falsely report busy.
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            if os.name != 'nt':
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(daemon.get_address())
+        return True
+    except socket.error as e:
+        if e.errno == errno.EADDRINUSE:
+            return False
+        raise
+
+
 def shutdown_daemon(args, timeout=None):
     """
     Shut down daemon node if it's running.
@@ -92,7 +107,11 @@ def shutdown_daemon(args, timeout=None):
             return False
         node.system.shutdown()
         if timeout is not None:
-            predicate = (lambda: not node.connected)
+            # Both conditions matter: a caller spawning a new daemon
+            # right after this returns needs the address to be free.
+            predicate = (
+                lambda: not node.connected and _is_daemon_address_free()
+            )
             if not wait_for(predicate, timeout):
                 raise RuntimeError(
                     'Timed out waiting for '

--- a/ros2cli/test/test_ros2cli_daemon.py
+++ b/ros2cli/test/test_ros2cli_daemon.py
@@ -149,7 +149,8 @@ def daemon_node():
                 f'daemon failed to discover {TEST_NODE_NAMESPACE}/{TEST_NODE_NAME}'
             )
         yield node
-        node.system.shutdown()
+    # Wait for full teardown so the next module's fixture can rebind.
+    shutdown_daemon(args=[], timeout=5.0)
 
 
 def test_get_name(daemon_node):


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Closes https://github.com/ros2/ros2cli/issues/1229

### Is this user-facing behavior change?

Not really, only when the daemon is shutdown, it guarantees that the socket is reusable on the address/port. (only for windows.)

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, partially Claude Opus 4.7

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
