### PR TITLE
add ament_cmake_python build type to ros2 pkg create

### DIFF
--- a/ros2pkg/ros2pkg/api/create.py
+++ b/ros2pkg/ros2pkg/api/create.py
@@ -125,6 +125,9 @@ def create_package_environment(package, destination_directory):
     if package.get_build_type() == 'ament_cargo':
         print('creating source folder')
         source_directory = _create_folder('src', package_directory)
+    if package.get_build_type() == 'ament_cmake_python':
+        print('creating Python package folder')
+        source_directory = _create_folder(package.name, package_directory)
     if package.get_build_type() == 'ament_python':
         print('creating source folder')
         source_directory = _create_folder(package.name, package_directory)
@@ -257,6 +260,31 @@ def populate_cmake(package, package_directory, cpp_node_name, cpp_library_name):
             package_directory,
             package.name + 'ConfigVersion.cmake.in',
             version_config)
+
+
+def populate_ament_cmake_python(package, package_directory, source_directory, python_node_name):
+    cmakelists_config = {
+            'project_name': package.name,
+            'dependencies': [str(dep) for dep in package.build_depends],
+            'node_name': python_node_name,
+            }
+    _create_template_file(
+            'ament_cmake_python',
+            'CMakeLists.txt.em',
+            package_directory,
+            'CMakeLists.txt',
+            cmakelists_config)
+
+    _create_template_file('ament_python',
+                          'init.py.em',
+                          source_directory,
+                          '__init__.py',
+                          {})
+    _create_template_file('ament_python',
+                          'py.typed.em',
+                          source_directory,
+                          'py.typed',
+                          {})
 
 
 def populate_ament_cmake(package, package_directory, cpp_node_name, cpp_library_name):

--- a/ros2pkg/ros2pkg/resource/ament_cmake_python/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/ament_cmake_python/CMakeLists.txt.em
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.20)
+project(@(project_name))
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+@[if dependencies]@
+@[  for dep in dependencies]@
+find_package(@dep REQUIRED)
+@[  end for]@
+@[else]@
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+@[end if]@
+
+ament_python_install_package(${PROJECT_NAME})
+@[if node_name]@
+
+install(PROGRAMS
+  scripts/@(node_name)
+  DESTINATION lib/${PROJECT_NAME}
+)
+@[end if]@
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -29,6 +29,7 @@ from catkin_pkg.package import Person
 from ros2pkg.api.create import create_package_environment
 from ros2pkg.api.create import populate_ament_cargo
 from ros2pkg.api.create import populate_ament_cmake
+from ros2pkg.api.create import populate_ament_cmake_python
 from ros2pkg.api.create import populate_ament_python
 from ros2pkg.api.create import populate_cmake
 from ros2pkg.api.create import populate_cpp_library
@@ -71,7 +72,7 @@ class CreateVerb(VerbExtension):
         parser.add_argument(
             '--build-type',
             default='ament_cmake',
-            choices=['cmake', 'ament_cmake', 'ament_cargo', 'ament_python'],
+            choices=['cmake', 'ament_cmake', 'ament_cmake_python', 'ament_cargo', 'ament_python'],
             help='The build type to process the package with')
         parser.add_argument(
             '--dependencies',
@@ -143,11 +144,14 @@ class CreateVerb(VerbExtension):
             else:
                 buildtool_depends = ['ament_cmake']
 
+        if args.build_type == 'ament_cmake_python':
+            buildtool_depends = ['ament_cmake', 'ament_cmake_python']
+
         if args.build_type == 'ament_cargo':
             buildtool_depends = ['ament_cargo']
 
         test_dependencies = []
-        if args.build_type == 'ament_cmake':
+        if args.build_type in ('ament_cmake', 'ament_cmake_python'):
             test_dependencies = ['ament_lint_auto', 'ament_lint_common']
         if args.build_type == 'ament_python':
             test_dependencies = ['ament_copyright', 'ament_flake8', 'ament_mypy', 'ament_pep257',
@@ -170,7 +174,10 @@ class CreateVerb(VerbExtension):
             buildtool_depends=[Dependency(dep) for dep in buildtool_depends],
             build_depends=[Dependency(dep) for dep in args.dependencies],
             test_depends=[Dependency(dep) for dep in test_dependencies],
-            exports=[Export('build_type', content=args.build_type)]
+            exports=[Export('build_type',
+                            content='ament_cmake'
+                            if args.build_type == 'ament_cmake_python'
+                            else args.build_type)]
         )
 
         package_path = os.path.join(args.destination_directory, package.name)
@@ -206,6 +213,15 @@ class CreateVerb(VerbExtension):
 
         if args.build_type == 'ament_cargo':
             populate_ament_cargo(package, package_directory, library_name)
+
+        if args.build_type == 'ament_cmake_python':
+            if not source_directory:
+                return 'unable to create source folder in ' + args.destination_directory
+            populate_ament_cmake_python(package, package_directory, source_directory, node_name)
+            if node_name:
+                scripts_directory = os.path.join(package_directory, 'scripts')
+                os.makedirs(scripts_directory, exist_ok=True)
+                populate_python_node(package, scripts_directory, node_name)
 
         if args.build_type == 'ament_python':
             if not source_directory:


### PR DESCRIPTION
Closes #739

Adds `ament_cmake_python` as a valid `--build-type` option for `ros2 pkg create`, enabling users to scaffold a hybrid C++/Python package without having to manually write boilerplate.

**What changes**

`verb/create.py`
- Added `ament_cmake_python` to the `--build-type` choices
- Sets `buildtool_depends` to `['ament_cmake', 'ament_cmake_python']`
- Reuses `ament_cmake` test dependencies (lint tooling)
- Exports `build_type` as `ament_cmake` in `package.xml` (correct — colcon treats it as a CMake package)
- Calls `populate_ament_cmake_python` and creates a `scripts/` node when `--node-name` is given

`api/create.py`
- Added `populate_ament_cmake_python` — generates `CMakeLists.txt` and seeds the Python package directory with `__init__.py` and `py.typed`
- Extended `create_package_environment` to create the Python package source folder for `ament_cmake_python`

`resource/ament_cmake_python/CMakeLists.txt.em`
- New template: calls `find_package(ament_cmake_python)`, `ament_python_install_package(${PROJECT_NAME})`, and optionally installs a node script

**Usage**
```bash
ros2 pkg create my_pkg --build-type ament_cmake_python --node-name my_node --dependencies rclpy
```

Generates a package with:
- `CMakeLists.txt` using `ament_cmake_python`
- `my_pkg/__init__.py` Python package
- `scripts/my_node` executable node
- Correct `package.xml` with both `ament_cmake` and `ament_cmake_python` buildtool deps