### PR TITLE
fix(ros2pkg): replace deprecated importlib.resources.path with files/as_file

### DIFF
--- a/ros2pkg/ros2pkg/api/create.py
+++ b/ros2pkg/ros2pkg/api/create.py
@@ -83,15 +83,16 @@ def _create_template_file(
         template_subdir, template_file_name, output_directory, output_file_name, template_config
         ):
     full_package = 'ros2pkg.resource.' + template_subdir
-    with resources.path(full_package, template_file_name) as path:
+    ref = resources.files(full_package).joinpath(template_file_name)
+    with resources.as_file(ref) as path:
         template_path = str(path)
-    if not os.path.exists(template_path):
-        raise FileNotFoundError('template not found:', template_path)
+        if not os.path.exists(template_path):
+            raise FileNotFoundError('template not found:', template_path)
 
-    output_file_path = os.path.join(output_directory, output_file_name)
+        output_file_path = os.path.join(output_directory, output_file_name)
 
-    print('creating', output_file_path)
-    _expand_template(template_path, template_config, output_file_path)
+        print('creating', output_file_path)
+        _expand_template(template_path, template_config, output_file_path)
 
 
 def create_package_environment(package, destination_directory):

--- a/ros2pkg/ros2pkg/api/create.py
+++ b/ros2pkg/ros2pkg/api/create.py
@@ -125,6 +125,9 @@ def create_package_environment(package, destination_directory):
     if package.get_build_type() == 'ament_cargo':
         print('creating source folder')
         source_directory = _create_folder('src', package_directory)
+    if package.get_build_type() == 'ament_cmake_python':
+        print('creating Python package folder')
+        source_directory = _create_folder(package.name, package_directory)
     if package.get_build_type() == 'ament_python':
         print('creating source folder')
         source_directory = _create_folder(package.name, package_directory)
@@ -257,6 +260,31 @@ def populate_cmake(package, package_directory, cpp_node_name, cpp_library_name):
             package_directory,
             package.name + 'ConfigVersion.cmake.in',
             version_config)
+
+
+def populate_ament_cmake_python(package, package_directory, source_directory, python_node_name):
+    cmakelists_config = {
+            'project_name': package.name,
+            'dependencies': [str(dep) for dep in package.build_depends],
+            'node_name': python_node_name,
+            }
+    _create_template_file(
+            'ament_cmake_python',
+            'CMakeLists.txt.em',
+            package_directory,
+            'CMakeLists.txt',
+            cmakelists_config)
+
+    _create_template_file('ament_python',
+                          'init.py.em',
+                          source_directory,
+                          '__init__.py',
+                          {})
+    _create_template_file('ament_python',
+                          'py.typed.em',
+                          source_directory,
+                          'py.typed',
+                          {})
 
 
 def populate_ament_cmake(package, package_directory, cpp_node_name, cpp_library_name):

--- a/ros2pkg/ros2pkg/resource/ament_cmake_python/CMakeLists.txt.em
+++ b/ros2pkg/ros2pkg/resource/ament_cmake_python/CMakeLists.txt.em
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.20)
+project(@(project_name))
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+@[if dependencies]@
+@[  for dep in dependencies]@
+find_package(@dep REQUIRED)
+@[  end for]@
+@[else]@
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+@[end if]@
+
+ament_python_install_package(${PROJECT_NAME})
+@[if node_name]@
+
+install(PROGRAMS
+  scripts/@(node_name)
+  DESTINATION lib/${PROJECT_NAME}
+)
+@[end if]@
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros2pkg/ros2pkg/verb/create.py
+++ b/ros2pkg/ros2pkg/verb/create.py
@@ -29,6 +29,7 @@ from catkin_pkg.package import Person
 from ros2pkg.api.create import create_package_environment
 from ros2pkg.api.create import populate_ament_cargo
 from ros2pkg.api.create import populate_ament_cmake
+from ros2pkg.api.create import populate_ament_cmake_python
 from ros2pkg.api.create import populate_ament_python
 from ros2pkg.api.create import populate_cmake
 from ros2pkg.api.create import populate_cpp_library
@@ -71,7 +72,7 @@ class CreateVerb(VerbExtension):
         parser.add_argument(
             '--build-type',
             default='ament_cmake',
-            choices=['cmake', 'ament_cmake', 'ament_cargo', 'ament_python'],
+            choices=['cmake', 'ament_cmake', 'ament_cmake_python', 'ament_cargo', 'ament_python'],
             help='The build type to process the package with')
         parser.add_argument(
             '--dependencies',
@@ -143,11 +144,14 @@ class CreateVerb(VerbExtension):
             else:
                 buildtool_depends = ['ament_cmake']
 
+        if args.build_type == 'ament_cmake_python':
+            buildtool_depends = ['ament_cmake', 'ament_cmake_python']
+
         if args.build_type == 'ament_cargo':
             buildtool_depends = ['ament_cargo']
 
         test_dependencies = []
-        if args.build_type == 'ament_cmake':
+        if args.build_type in ('ament_cmake', 'ament_cmake_python'):
             test_dependencies = ['ament_lint_auto', 'ament_lint_common']
         if args.build_type == 'ament_python':
             test_dependencies = ['ament_copyright', 'ament_flake8', 'ament_mypy', 'ament_pep257',
@@ -170,7 +174,10 @@ class CreateVerb(VerbExtension):
             buildtool_depends=[Dependency(dep) for dep in buildtool_depends],
             build_depends=[Dependency(dep) for dep in args.dependencies],
             test_depends=[Dependency(dep) for dep in test_dependencies],
-            exports=[Export('build_type', content=args.build_type)]
+            exports=[Export('build_type',
+                            content='ament_cmake'
+                            if args.build_type == 'ament_cmake_python'
+                            else args.build_type)]
         )
 
         package_path = os.path.join(args.destination_directory, package.name)
@@ -206,6 +213,15 @@ class CreateVerb(VerbExtension):
 
         if args.build_type == 'ament_cargo':
             populate_ament_cargo(package, package_directory, library_name)
+
+        if args.build_type == 'ament_cmake_python':
+            if not source_directory:
+                return 'unable to create source folder in ' + args.destination_directory
+            populate_ament_cmake_python(package, package_directory, source_directory, node_name)
+            if node_name:
+                scripts_directory = os.path.join(package_directory, 'scripts')
+                os.makedirs(scripts_directory, exist_ok=True)
+                populate_python_node(package, scripts_directory, node_name)
 
         if args.build_type == 'ament_python':
             if not source_directory:


### PR DESCRIPTION
## Problem

`importlib.resources.path()` has been deprecated since Python 3.11 and emits `DeprecationWarning` on Python 3.12, which is the interpreter used by ROS 2 Jazzy and Rolling. This means every `ros2 pkg create` invocation currently prints a deprecation warning on current Ubuntu 24.04 systems.

There is also a latent correctness bug: the existing code exits the `with resources.path(...)` context manager before using `template_path`, then calls `os.path.exists()` and `_expand_template()` on a path that may already be invalid. For resources packaged inside a zip (e.g. installed wheels), the temporary extracted file is deleted when the context manager exits, making the subsequent `os.path.exists()` check and `_expand_template()` call operate on a stale path.

## Fix

Replace `resources.path()` with `resources.files().joinpath()` + `resources.as_file()`, the API recommended since Python 3.9. Move all path-dependent calls inside the `as_file()` context manager so the extracted file remains valid for the duration of template expansion.

```python
# before
with resources.path(full_package, template_file_name) as path:
    template_path = str(path)
if not os.path.exists(template_path):          # path may be stale here
    raise FileNotFoundError(...)
_expand_template(template_path, ...)           # and here

# after
ref = resources.files(full_package).joinpath(template_file_name)
with resources.as_file(ref) as path:
    template_path = str(path)
    if not os.path.exists(template_path):      # path is valid inside the block
        raise FileNotFoundError(...)
    _expand_template(template_path, ...)       # and here
```

## Test Plan

- [ ] `ros2 pkg create --build-type ament_cmake my_pkg` — no `DeprecationWarning` on Python 3.12
- [ ] `ros2 pkg create --build-type ament_python my_pkg` — all template files generated correctly
- [ ] `ros2 pkg create --build-type ament_cmake --node-name my_node my_pkg` — node stub created correctly
- [ ] Verify no regression on Python 3.10 (Humble)