### PR TITLE
ros2daemon also uses node logger to store log in the file system.

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -21,7 +21,6 @@ import rclpy
 
 from ros2cli.helpers import before_invocation
 from ros2cli.helpers import get_ros_domain_id
-from ros2cli.helpers import pretty_print_call
 
 from ros2cli.node.network_aware import NetworkAwareNode
 
@@ -76,6 +75,7 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
         start_parameter_services=False,
         start_type_description_service=False)
     with NetworkAwareNode(node_args) as node:
+        daemon_logger = node.get_logger()
         functions = [
             node.get_name,
             node.get_namespace,
@@ -117,7 +117,8 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
         def reset_timer_and_pretty_print(func, *args, **kwargs):
             nonlocal last_function_call_time
             last_function_call_time = time.time()
-            pretty_print_call(func, args, kwargs)
+            arguments = ', '.join([f'{v!r}' for v in (args, kwargs)])
+            daemon_logger.info(f'{func.__name__}({arguments})')
 
         server.register_introspection_functions()
         for func in functions:
@@ -131,7 +132,7 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
             nonlocal shutdown
 
             if time.time() - last_function_call_time > timeout:
-                print('Shutdown due to timeout')
+                daemon_logger.info('Shutdown due to timeout')
                 shutdown = True
         server.handle_timeout = timeout_handler
         server.timeout = 0.2
@@ -139,11 +140,12 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
         # function to shutdown daemon remotely
         def shutdown_handler():
             nonlocal shutdown
-            print('Remote shutdown requested')
+            daemon_logger.info('Remote shutdown requested')
             shutdown = True
         server.register_function(shutdown_handler, 'system.shutdown')
 
-        print('Serving XML-RPC on ' + get_xmlrpc_server_url(server.server_address))
+        daemon_logger.info(
+            f'Serving XML-RPC on {get_xmlrpc_server_url(server.server_address)}')
         try:
             while rclpy.ok() and not shutdown:
                 server.handle_request()

--- a/ros2cli/ros2cli/node/network_aware.py
+++ b/ros2cli/ros2cli/node/network_aware.py
@@ -21,9 +21,10 @@ import rclpy
 from ros2cli.node.direct import DirectNode
 
 
-def get_interfaces_ip_addresses():
+def get_interfaces_ip_addresses(logger=None):
     addresses_by_interfaces = psutil.net_if_addrs()
-    print(f'Addresses by interfaces: {addresses_by_interfaces}')
+    if logger is not None:
+        logger.info(f'Addresses by interfaces: {addresses_by_interfaces}')
     return addresses_by_interfaces
 
 
@@ -35,7 +36,7 @@ class NetworkAwareNode:
         # TODO(ivanpauno): A race condition is possible here, since it isn't possible to know
         # exactly which interfaces were available at node creation.
         self.node = DirectNode(args)
-        self.addresses_at_start = get_interfaces_ip_addresses()
+        self.addresses_at_start = get_interfaces_ip_addresses(self.node.get_logger())
 
     def __enter__(self):
         self.node.__enter__()
@@ -59,11 +60,11 @@ class NetworkAwareNode:
         self.node.__exit__(exc_type, exc_value, traceback)
 
     def reset_if_addresses_changed(self):
-        new_addresses = get_interfaces_ip_addresses()
+        new_addresses = get_interfaces_ip_addresses(self.node.get_logger())
         if new_addresses != self.addresses_at_start:
             self.addresses_at_start = new_addresses
             self.node.destroy_node()
             rclpy.shutdown()
             self.node = DirectNode(self.args)
             self.node.__enter__()
-            print('Network interfaces changed, daemon node was reset!')
+            self.node.get_logger().info('Network interfaces changed, daemon node was reset!')


### PR DESCRIPTION
## Description

part of https://github.com/ros2/ros2cli/issues/1236.

with this, ros2daemon can also store log file and put the log data on /rosout topic.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1236 

### Is this user-facing behavior change?

Not really, now user can see ros2daemon logfile in ros log directory.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Claude Opus 4.7

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
