### PR TITLE
Allow configuring the daemon inactivity timeout

### DIFF
--- a/ros2cli/ros2cli/daemon/__init__.py
+++ b/ros2cli/ros2cli/daemon/__init__.py
@@ -61,14 +61,20 @@ def make_xmlrpc_server() -> LocalXMLRPCServer:
     )
 
 
-def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
+def serve(server: LocalXMLRPCServer, *, timeout: float = 2 * 60 * 60):
     """
     Serve the ros2cli daemon API using the given `server`.
 
     :param server: an XMLRPC server instance
-    :param timeout: how long to wait before shutting
-      down the server due to inactivity.
+    :param timeout: how long, in seconds, to wait before shutting
+      down the server due to inactivity. A negative value disables
+      the timeout (it becomes ``float('inf')``), so the server runs
+      until explicitly stopped.
     """
+    # A negative timeout means "never time out"; mirror the convention
+    # used by ros2cli.helpers.wait_for.
+    if timeout < 0:
+        timeout = float('inf')
     ros_domain_id = get_ros_domain_id()
     node_args = argparse.Namespace(
         node_name_suffix=f'_daemon_{ros_domain_id}_{uuid.uuid4().hex}',
@@ -153,7 +159,7 @@ def serve(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
             pass
 
 
-def serve_and_close(server: LocalXMLRPCServer, *, timeout: int = 2 * 60 * 60):
+def serve_and_close(server: LocalXMLRPCServer, *, timeout: float = 2 * 60 * 60):
     try:
         serve(server, timeout=timeout)
     finally:
@@ -173,7 +179,9 @@ def main(*, argv=None):
              'ROS_DOMAIN_ID)')
     parser.add_argument(
         '--timeout', metavar='N', type=int, default=2 * 60 * 60,
-        help='Shutdown the daemon after N seconds of inactivity')
+        help='Shutdown the daemon after N seconds of inactivity. '
+             'A negative value disables the timeout, so the daemon '
+             'runs until explicitly stopped.')
     args = parser.parse_args(args=argv)
 
     # the arguments are only passed for visibility in e.g. the process list

--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -98,7 +98,7 @@ def shutdown_daemon(args, timeout=None):
     :param timeout: optional duration, in seconds, to wait
       until the daemon node is fully shut down. Non-positive
       durations will result in an indefinite wait.
-    :return: `True` if the the daemon was shut down,
+    :return: `True` if the daemon was shut down,
       `False` if it was already shut down.
     :raises: if it fails to shutdown the daemon.
     """
@@ -120,7 +120,7 @@ def shutdown_daemon(args, timeout=None):
         return True
 
 
-def spawn_daemon(args, timeout=None, debug=False):
+def spawn_daemon(args, timeout=None, debug=False, inactivity_timeout=2 * 60 * 60):
     """
     Spawn daemon node if it's not running.
 
@@ -136,7 +136,11 @@ def spawn_daemon(args, timeout=None, debug=False):
       durations will result in an indefinite wait.
     :param debug: if `True`, the daemon process will output
       to the current `stdout` and `stderr` streams.
-    :return: `True` if the the daemon was spawned,
+    :param inactivity_timeout: duration, in seconds, of inactivity
+      after which the spawned daemon shuts down. A negative value
+      disables the timeout, so the daemon runs until explicitly
+      stopped.
+    :return: `True` if the daemon was spawned,
       `False` if it was already running.
     :raises: if it fails to spawn the daemon.
     """
@@ -187,7 +191,8 @@ def spawn_daemon(args, timeout=None, debug=False):
             'rmw_implementation': rclpy.get_rmw_implementation_identifier()}
 
         daemonize(
-            functools.partial(daemon.serve_and_close, server),
+            functools.partial(
+                daemon.serve_and_close, server, timeout=inactivity_timeout),
             tags=tags, timeout=timeout, debug=debug)
     finally:
         server.server_close()

--- a/ros2cli/ros2cli/verb/daemon/start.py
+++ b/ros2cli/ros2cli/verb/daemon/start.py
@@ -23,9 +23,17 @@ class StartVerb(VerbExtension):
         parser.add_argument(
             '--debug', '-d', action='store_true',
             help='Print debug messages')
+        parser.add_argument(
+            '--timeout', metavar='N', type=int, default=2 * 60 * 60,
+            help='Shut down the daemon after N seconds of inactivity. '
+                 'A negative value disables the timeout, so the daemon '
+                 'runs until explicitly stopped.')
 
     def main(self, *, args):
-        if spawn_daemon(args, timeout=10.0, debug=args.debug):
+        if spawn_daemon(
+            args, timeout=10.0, debug=args.debug,
+            inactivity_timeout=args.timeout
+        ):
             print('The daemon has been started')
         else:
             print('The daemon is already running')

--- a/ros2cli/test/test_ros2cli_daemon.py
+++ b/ros2cli/test/test_ros2cli_daemon.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import time
 
 import pytest
@@ -26,6 +27,7 @@ from ros2cli.node.daemon import DaemonNode
 from ros2cli.node.daemon import is_daemon_running
 from ros2cli.node.daemon import shutdown_daemon
 from ros2cli.node.daemon import spawn_daemon
+from ros2cli.verb.daemon.start import StartVerb
 
 try:
     from rmw_test_fixture_implementation import rmw_test_isolation_start
@@ -316,3 +318,46 @@ def test_count_clients(daemon_node):
 
 def test_count_services(daemon_node):
     assert 1 == daemon_node.count_services(TEST_SERVICE_NAME)
+
+
+def _wait_until(predicate, timeout):
+    # Polling is_daemon_running() uses system.listMethods, which is not a
+    # timer-resetting RPC, so it never keeps the daemon alive artificially.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.2)
+    return predicate()
+
+
+def test_start_verb_exposes_timeout_argument():
+    parser = argparse.ArgumentParser()
+    StartVerb().add_arguments(parser, 'daemon')
+    # Default preserves the long-standing 2 hour inactivity timeout.
+    assert parser.parse_args([]).timeout == 2 * 60 * 60
+    # A negative value is accepted and means "never time out".
+    assert parser.parse_args(['--timeout', '-1']).timeout == -1
+
+
+def test_daemon_shuts_down_after_inactivity_timeout():
+    if is_daemon_running(args=[]):
+        assert shutdown_daemon(args=[], timeout=5.0)
+    assert spawn_daemon(args=[], timeout=5.0, inactivity_timeout=5)
+    assert _wait_until(lambda: is_daemon_running(args=[]), timeout=10.0), \
+        'daemon did not come up'
+    assert _wait_until(lambda: not is_daemon_running(args=[]), timeout=60.0), \
+        'daemon did not shut down after its inactivity timeout elapsed'
+
+
+def test_negative_inactivity_timeout_never_shuts_down():
+    if is_daemon_running(args=[]):
+        assert shutdown_daemon(args=[], timeout=5.0)
+    assert spawn_daemon(args=[], timeout=5.0, inactivity_timeout=-1)
+    try:
+        assert _wait_until(lambda: is_daemon_running(args=[]), timeout=10.0)
+        # Stays up well past any short inactivity window.
+        time.sleep(8.0)
+        assert is_daemon_running(args=[])
+    finally:
+        assert shutdown_daemon(args=[], timeout=5.0)


### PR DESCRIPTION
Fixes #1239.

The daemon's inactivity timeout was hard-coded to 2 hours. We run robots for days with a large number of nodes, and once the daemon has timed out an occasional ros2 CLI call respawns a node and triggers DDS discovery, which shows up as a CPU spike. This makes the timeout configurable so a single long-lived daemon can be kept around instead.

- `ros2 daemon start --timeout N` shuts the daemon down after N seconds of inactivity. The default is still 2 hours, so behavior is unchanged unless you ask for it.
- A negative value disables the timeout, so the daemon stays up until it is explicitly stopped (same convention as `helpers.wait_for`).
- `spawn_daemon()` gains an `inactivity_timeout` argument; the auto-spawn path keeps the 2 hour default.
- Also fixes `_ros2_daemon`'s existing `--timeout`: a negative value used to make the daemon exit immediately, now it disables the timeout.

This intentionally only affects daemons started explicitly; auto-spawned daemons keep the 2 hour default.

Added `test/test_daemon_timeout.py` covering the new argument and the short-timeout / never-timeout behavior.
