### PR TITLE
Mjcarroll/windows socket exhaustion

### DIFF
--- a/ros2cli/ros2cli/node/daemon.py
+++ b/ros2cli/ros2cli/node/daemon.py
@@ -77,11 +77,10 @@ def is_daemon_running(args):
 
 def _is_daemon_address_free():
     # Mirror LocalXMLRPCServer.allow_reuse_address: SO_REUSEADDR on
-    # non-Windows so TIME_WAIT doesn't make us falsely report busy.
+    # all platforms so TIME_WAIT doesn't make us falsely report busy.
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            if os.name != 'nt':
-                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind(daemon.get_address())
         return True
     except socket.error as e:
@@ -140,6 +139,9 @@ def spawn_daemon(args, timeout=None, debug=False):
       `False` if it was already running.
     :raises: if it fails to spawn the daemon.
     """
+    if is_daemon_running(args):
+        return False
+
     # Acquire socket by instantiating XMLRPC server.
     try:
         server = daemon.make_xmlrpc_server()

--- a/ros2cli/ros2cli/xmlrpc/local_server.py
+++ b/ros2cli/ros2cli/xmlrpc/local_server.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import socket
 # Import SimpleXMLRPCRequestHandler to re-export it.
 from xmlrpc.server import SimpleXMLRPCRequestHandler  # noqa
@@ -33,11 +32,8 @@ def get_local_ipaddrs():
 class LocalXMLRPCServer(SimpleXMLRPCServer):
 
     # Allow re-binding even if another server instance was recently bound (i.e. we are still in
-    # TCP TIME_WAIT). This is already the default behavior on Windows, and further SO_REUSEADDR can
-    # lead to undefined behavior on Windows; see
-    # https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse.  # noqa
-    # So we don't set the option for Windows.
-    allow_reuse_address = False if os.name == 'nt' else True
+    # TCP TIME_WAIT).
+    allow_reuse_address = True
 
     def verify_request(self, request, client_address):
         if client_address[0] not in get_local_ipaddrs():

--- a/ros2cli/test/test_ros2cli_daemon.py
+++ b/ros2cli/test/test_ros2cli_daemon.py
@@ -130,6 +130,7 @@ def local_node():
         action_server.destroy()
         node.destroy_node()
 
+
 @pytest.fixture(scope='module')
 def daemon_node():
     if is_daemon_running(args=[]):

--- a/ros2cli/test/test_ros2cli_daemon.py
+++ b/ros2cli/test/test_ros2cli_daemon.py
@@ -116,16 +116,19 @@ def local_node():
             action_name=TEST_ACTION_NAME,
             execute_callback=noop_execute_callback
         )
-        action_server  # to avoid "assigned by never used" warning
         action_client = rclpy.action.ActionClient(
             node=node,
             action_type=test_msgs.action.Fibonacci,
             action_name=TEST_ACTION_NAME
         )
-        action_client  # to avoid "assigned by never used" warning
 
         yield node
 
+        # Teardown: explicitly destroy the node to make sure that any
+        # lingering middleware resources are freed (specifically sockets)
+        action_client.destroy()
+        action_server.destroy()
+        node.destroy_node()
 
 @pytest.fixture(scope='module')
 def daemon_node():

--- a/ros2cli/test/test_strategy.py
+++ b/ros2cli/test/test_strategy.py
@@ -21,19 +21,25 @@ from ros2cli.node.daemon import shutdown_daemon
 from ros2cli.node.daemon import spawn_daemon
 from ros2cli.node.strategy import NodeStrategy
 
-
 @pytest.fixture
 def enforce_no_daemon_is_running():
+    # Setup phase: enforce no daemon running
     if is_daemon_running(args=[]):
         assert shutdown_daemon(args=[], timeout=5.0)
     yield
-
+    # Teardown phase: enforce no daemon left over
+    if is_daemon_running(args=[]):
+        assert shutdown_daemon(args=[], timeout=5.0)
 
 @pytest.fixture
 def enforce_daemon_is_running():
+    # Setup phase: enforce the daemon is running
     if not is_daemon_running(args=[]):
         assert spawn_daemon(args=[], timeout=5.0)
     yield
+    # Teardown phase: enforce no daemon left over
+    if is_daemon_running(args=[]):
+        assert shutdown_daemon(args=[], timeout=5.0)
 
 
 def test_with_daemon_running(enforce_daemon_is_running):

--- a/ros2cli/test/test_strategy.py
+++ b/ros2cli/test/test_strategy.py
@@ -21,6 +21,7 @@ from ros2cli.node.daemon import shutdown_daemon
 from ros2cli.node.daemon import spawn_daemon
 from ros2cli.node.strategy import NodeStrategy
 
+
 @pytest.fixture
 def enforce_no_daemon_is_running():
     # Setup phase: enforce no daemon running
@@ -30,6 +31,7 @@ def enforce_no_daemon_is_running():
     # Teardown phase: enforce no daemon left over
     if is_daemon_running(args=[]):
         assert shutdown_daemon(args=[], timeout=5.0)
+
 
 @pytest.fixture
 def enforce_daemon_is_running():

--- a/ros2multicast/test/test_api.py
+++ b/ros2multicast/test/test_api.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import random
+import re
+import subprocess
 import sys
 import threading
 import time
@@ -22,24 +24,79 @@ import pytest
 from ros2multicast.api import receive
 from ros2multicast.api import send
 
+_MULTICAST_ADDRESS = re.compile(r'\b2(?:2[4-9]|3[0-9])(?:\.\d{1,3}){3}\b')
+_UDP_ENDPOINT = re.compile(r'^\s*(?:UDP|udp)\s+\S', re.MULTILINE)
+
+
+def _capture(argv):
+    try:
+        return subprocess.run(argv, capture_output=True, text=True, timeout=30).stdout
+    except (OSError, subprocess.SubprocessError):
+        return ''
+
+
+def _network_state():
+    """
+    Summarize the machine-wide network resources these tests draw on.
+
+    Both the UDP port pool and the multicast membership table are shared by every process
+    on the machine.  Once either is exhausted, binding and joining fail for everything on
+    the box, which is easy to mistake for a defect in the code under test.
+    See https://github.com/ros2/ros2cli/issues/1141.
+    """
+    if sys.platform.startswith('win'):
+        joins = _capture(['netsh', 'interface', 'ipv4', 'show', 'joins'])
+        endpoints = _capture(['netstat', '-ano', '-p', 'UDP'])
+        port_range = '+'.join(re.findall(
+            r':\s*(\d+)',
+            _capture(['netsh', 'int', 'ipv4', 'show', 'dynamicport', 'udp'])))
+    else:
+        joins = _capture(['netstat', '--groups', '--numeric'])
+        endpoints = _capture(['ss', '-uan'])
+        port_range = _capture(['sysctl', '-n', 'net.ipv4.ip_local_port_range']).strip()
+    return (
+        f'{len(_MULTICAST_ADDRESS.findall(joins))} multicast memberships, '
+        f'{len(_UDP_ENDPOINT.findall(endpoints))} udp endpoints open, '
+        f'dynamic port range: {port_range or "unknown"}'
+    )
+
+
+def _reraise(error):
+    """Re-raise a socket error, first recording the machine state that may have caused it."""
+    print(
+        f'ros2multicast socket operation failed ({error}); machine network state: '
+        f'{_network_state()}',
+        file=sys.stderr)
+    raise error
+
 
 def _send_receive(sent_data, rx_kwargs, tx_kwargs):
     received_data = None
+    rx_error = None
 
     def target():
-        nonlocal received_data
+        nonlocal received_data, rx_error
         try:
             received_data, _ = receive(**rx_kwargs)
         except TimeoutError:
             pass
+        except Exception as e:  # noqa: B902
+            # Stash it for the calling thread. Left unhandled here, pytest turns it into
+            # an unhandled-thread-exception warning, so the test either fails with a
+            # misleading assertion or passes when it should not.
+            rx_error = e
 
     t = threading.Thread(target=target)
     t.start()
     time.sleep(0.1)
     try:
         send(sent_data, **tx_kwargs)
+    except OSError as e:
+        _reraise(e)
     finally:
         t.join()
+    if rx_error is not None:
+        _reraise(rx_error)
     return received_data
 
 
@@ -86,13 +143,11 @@ def test_group_mismatch():
     try:
         assert _send_receive(sent_data, rx_kwargs, tx_kwargs) is None
     except OSError as e:
-        if sys.platform.startswith('win'):
-            if 10051 == e.winerror:
-                # TODO(sloretz) understand why this test fails this way in CI
-                # "A socket operation was attempted to an unreachable network"
-                pytest.skip('Unknown why this OSError occurs on Windows')
-        else:
-            raise
+        if sys.platform.startswith('win') and 10051 == e.winerror:
+            # TODO(sloretz) understand why this test fails this way in CI
+            # "A socket operation was attempted to an unreachable network"
+            pytest.skip('Unknown why this OSError occurs on Windows')
+        raise
 
 
 def test_port_mismatch():

--- a/ros2multicast/test/test_api.py
+++ b/ros2multicast/test/test_api.py
@@ -36,15 +36,17 @@ def _send_receive(sent_data, rx_kwargs, tx_kwargs):
     t = threading.Thread(target=target)
     t.start()
     time.sleep(0.1)
-    send(sent_data, **tx_kwargs)
-    t.join()
+    try:
+        send(sent_data, **tx_kwargs)
+    finally:
+        t.join()
     return received_data
 
 
 def test_api():
     sent_data = b'test_api'
 
-    rx_kwargs = {'timeout': 1.0}
+    rx_kwargs = {'timeout': 0.2}
     tx_kwargs = {}
 
     assert sent_data == _send_receive(sent_data, rx_kwargs, tx_kwargs)


### PR DESCRIPTION
## Description

A few fixes to try to clear up Windows socket exhaustion issues.

Fixes https://github.com/ros2/ros2cli/issues/1229

`ros2cli`:
- `spawn_daemon` returns early when a daemon is already running instead of racing to bind an address that is already taken.
- Use `SO_REUSEADDR` for the daemon address check and for `LocalXMLRPCServer` on Windows too, so a socket in `TIME_WAIT` is not reported as busy.
- Destroy the action client, action server and node in the `local_node` fixture, and shut down any daemon left behind by `test_strategy`, so tests stop leaking middleware sockets into the ones that follow.

`ros2multicast` — better reporting for https://github.com/ros2/ros2cli/issues/1141:
- The receive thread only handled `TimeoutError`, so any other error became a pytest unhandled-thread-exception warning. `test_api` then failed as `assert b'test_api' == None`, which says nothing about the cause, and `test_port_mismatch` could pass even though the receive never happened. The error is now re-raised on the calling thread.
- On Windows, `test_group_mismatch` fell through its conditional and discarded any `OSError` that was not 10051, so it passed. That is why it is absent from the failure list in #1141 while its three neighbours fail on the same error.
- Multicast joins and UDP binds draw on resources shared by every process on the machine, so these tests fail when something unrelated exhausts them. On failure the tests now record the multicast membership count, the number of open UDP endpoints and the dynamic port range, which should make a CI log enough to tell an exhausted agent from a defect here.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Assissted-by: Antigravity CLI (Gemini 3.5 Flash)
Assisted-by: Claude Code (Opus 5)

### Additional Information

The `ros2multicast` half does not fix #1141; it makes the next failure legible. Worth knowing while reading it: on Windows the UDP and TCP ephemeral pools are separate, and the UDP one defaults to 16384 ports from 49152. When it is exhausted, `bind(('', 0))` fails with `WSAENOBUFS` (10055) and an implicit bind fails with `WSAEINVAL` (10022), while TCP bind/listen/connect keep working. A socket bound to a fixed port still binds and joins fine in that state, so the 10055 reported in #1141 — which comes from `IP_ADD_MEMBERSHIP` after a successful fixed-port bind — is not plain port exhaustion.
