### PR TITLE
Remove fzf interactive selection for `ros2 service call`

### DIFF
--- a/ros2service/ros2service/verb/call.py
+++ b/ros2service/ros2service/verb/call.py
@@ -20,13 +20,10 @@ from rclpy.qos import QoSPresetProfiles
 from rclpy.qos import QoSProfile
 
 from ros2cli.helpers import collect_stdin
-from ros2cli.helpers import interactive_select
 from ros2cli.node import NODE_NAME_PREFIX
-from ros2cli.node.strategy import NodeStrategy
 from ros2cli.qos import add_qos_arguments
 from ros2cli.qos import profile_configure_short_keys
 
-from ros2service.api import get_service_names
 from ros2service.api import ServiceNameCompleter
 from ros2service.api import ServicePrototypeCompleter
 from ros2service.api import ServiceTypeCompleter
@@ -43,9 +40,8 @@ class CallVerb(VerbExtension):
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument(
-            'service_name', nargs='?',
-            help="Name of the ROS service to call to (e.g. '/add_two_ints'). "
-                 'If not provided, an interactive selection will be shown.')
+            'service_name',
+            help="Name of the ROS service to call to (e.g. '/add_two_ints')")
         arg.completer = ServiceNameCompleter(
             include_hidden_services_key='include_hidden_services')
         arg = parser.add_argument(
@@ -74,25 +70,6 @@ class CallVerb(VerbExtension):
         add_qos_arguments(parser, 'service client', 'services_default')
 
     def main(self, *, args):
-        # If no service name provided, launch interactive selection
-        if args.service_name is None:
-            with NodeStrategy(args) as node:
-                service_names = get_service_names(
-                    node=node,
-                    include_hidden_services=args.include_hidden_services)
-
-                if not service_names:
-                    return 'No services available to select from.'
-
-                selected_service = interactive_select(
-                    service_names,
-                    prompt='Select service to call:')
-
-                if selected_service is None:
-                    return None
-
-                args.service_name = selected_service
-
         if args.rate is not None and args.rate <= 0:
             raise RuntimeError('rate must be greater than zero')
         period = 1. / args.rate if args.rate else None


### PR DESCRIPTION
## Description

After upgrading to Lyrical, I found out that the feature introduced [here](https://github.com/ros2/ros2cli/pull/1151/changes#diff-df32ab2eb45331ee7853b55a731c9180dec5d5b99768dcc07e11e2d047593bdaR46) is not working as expected for `ros2service`.

When running `ros2 service call <service-name>`, fzf pulls out a list of service names although we already specified it:

<img width="1102" height="778" alt="image" src="https://github.com/user-attachments/assets/f15c14e2-0036-4a40-8c86-05e7b5f663fd" />

Also plain `ros2 service call` without a service name does not trigger the fzf list of service names:

```
ubuntu@dexory:/opt/auto_ws$ ros2 service call
usage: ros2 service call [-h] [-r N] [--timeout N] [--qos-profile {unknown,default,system_default,sensor_data,services_default,parameters,parameter_events,action_status_default,best_available,rosout_default}] [--qos-depth N]
                         [--qos-history {system_default,keep_last,keep_all,unknown}] [--qos-reliability {system_default,reliable,best_effort,unknown,best_available}]
                         [--qos-durability {system_default,transient_local,volatile,unknown,best_available}] [--qos-liveliness {system_default,automatic,manual_by_topic,unknown,best_available}]
                         [--qos-liveliness-lease-duration-seconds QOS_LIVELINESS_LEASE_DURATION_SECONDS]
                         service_name service_type [--stdin | values]
ros2 service call: error: the following arguments are required: service_name, service_type
```

Aside for the bug, I currently can't see a nice UX for `ros2 service call` with fzf because currently the command is executed directly after the fzf selection but for `ros2 service call` more often than not, the user wants to specify the values in the request which is currently not possible. This ties with https://github.com/ros2/ros2cli/issues/1184 

For this reason I propose we remove this functionality that does not work until we can find a clean fix and UX

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
