### PR TITLE
Update topic info verbose test for buffer backend output

### DIFF
--- a/ros2topic/test/test_cli.py
+++ b/ros2topic/test/test_cli.py
@@ -331,6 +331,7 @@ class TestROS2TopicCLI(unittest.TestCase):
                 f'Topic type hash: {STD_MSGS_STRING_TYPE_HASH_STR}',
                 re.compile(r'Endpoint type: (INVALID|PUBLISHER|SUBSCRIPTION)'),
                 re.compile(r'GID: [\w\.]+'),
+                'Buffer backends: <none>',
                 'QoS profile:',
                 re.compile(r'  Reliability: (RELIABLE|BEST_EFFORT|SYSTEM_DEFAULT|UNKNOWN)'),
                 re.compile(


### PR DESCRIPTION
## Description

Update the `ros2 topic info -v` CLI test expectation to include the new buffer backend line emitted in verbose endpoint output.

### Is this user-facing behavior change?

Yes. While the change in this pull request is for a test case, the underlying changes in other relevant packages add rosidl buffer backend information for each endpoint in `ros2 topic info -v`.

### Did you use Generative AI?

No.

### Additional Information

Relevant issue: #1245 