### PR TITLE
Fix ros2 interface show for msg files in subfolders (humble)

### DIFF
--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -13,8 +13,14 @@
 # limitations under the License.
 
 import argparse
+import os
 import sys
 import typing
+
+from ament_index_python.packages import \
+    get_package_share_directory, \
+    PackageNotFoundError
+from ament_index_python.resources import get_resource
 
 from ros2interface.api import type_completer
 from ros2interface.verb import VerbExtension
@@ -25,7 +31,6 @@ from rosidl_adapter.parser import \
     MessageSpecification, \
     parse_message_string, \
     SERVICE_REQUEST_RESPONSE_SEPARATOR
-from rosidl_runtime_py import get_interface_path
 
 
 class InterfaceTextLine:
@@ -108,9 +113,23 @@ def _get_interface_lines(interface_identifier: str) -> typing.Iterable[Interface
         raise ValueError(
             f"Invalid name '{interface_identifier}'. Expected three parts separated by '/'"
         )
-    pkg_name, _, msg_name = parts
+    pkg_name, msg_type, msg_name = parts
 
-    file_path = get_interface_path(interface_identifier)
+    try:
+        share_dir = get_package_share_directory(pkg_name)
+    except PackageNotFoundError:
+        raise LookupError(f"Unknown package '{pkg_name}'")
+
+    interfaces, _ = get_resource('rosidl_interfaces', pkg_name)
+    interfaces = interfaces.splitlines()
+
+    interface = [f for f in interfaces if f.endswith(msg_name + '.' + msg_type)]
+    if len(interface) == 0:
+        raise LookupError(
+            f"Interface '{msg_type}/{msg_name}' not found in package '{pkg_name}'"
+        )
+
+    file_path = os.path.join(share_dir, interface[0])
     with open(file_path) as file_handler:
         for line in file_handler:
             yield InterfaceTextLine(

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -479,7 +479,7 @@ class TestROS2InterfaceCLI(unittest.TestCase):
         assert interface_command.exit_code == 1
         assert launch_testing.tools.expect_output(
             expected_lines=[re.compile(
-                r"Could not find the interface '.+NotAMessageTypeName\.idl'"
+                r"Interface 'msg/NotAMessageTypeName' not found in package 'test_msgs'"
             )],
             text=interface_command.output,
             strict=True


### PR DESCRIPTION
## Summary

- Fix `ros2 interface show` for packages that install interface files under nested subdirectories (e.g. `msg-common/GenericObject.msg` in `mrpt_msgs`).
- Replace `rosidl_runtime_py.get_interface_path()` with lookup via the `rosidl_interfaces` ament index resource, matching the approach in #1205 (kilted backport).

Fixes #1186

## Problem

On Humble, `ros2 interface show mrpt_msgs/msg/GenericObject` fails with `InvalidResourceName: //` because `get_interface_path()` cannot resolve interfaces whose `.msg` files live outside the conventional `msg/<Name>.msg` layout.

## Solution

Use `ament_index_python.resources.get_resource('rosidl_interfaces', pkg_name)` to find the installed interface file path, then open it from the package share directory.

## Test plan

- [x] Reproduced failure on system Humble before fix:
  ```bash
  ros2 interface show mrpt_msgs/msg/GenericObject  # InvalidResourceName: //
  ```
- [x] Verified fix with overlay build:
  ```bash
  source install/setup.bash
  ros2 interface show mrpt_msgs/msg/GenericObject  # prints message definition
  ros2 interface show std_msgs/msg/String          # still works
  ```
- [x] Updated `test_show_not_an_interface` expected error message
- [x] `colcon build --packages-select ros2interface` succeeds
- [ ] Full `ros2interface` CLI test suite (requires `ros-humble-test-msgs` in CI)

## Related

Backport of the fix approach from #1205 to the `humble` branch.


Made with [Cursor](https://cursor.com)