### PR TITLE
Fix ros2 interface show --no-comments leaking full-line comments (#769)

### DIFF
--- a/ros2interface/ros2interface/verb/show.py
+++ b/ros2interface/ros2interface/verb/show.py
@@ -56,7 +56,7 @@ class InterfaceTextLine:
         return self._raw_line_text
 
     def is_comment(self) -> bool:
-        return self._msg_spec and self._msg_spec.annotations['comment']
+        return self._raw_line_text.lstrip().startswith('#')
 
     def is_trailing_comment(self) -> bool:
         return (

--- a/ros2interface/test/test_cli.py
+++ b/ros2interface/test/test_cli.py
@@ -29,6 +29,8 @@ import launch_testing.tools
 
 import pytest
 
+from ros2interface.verb.show import InterfaceTextLine
+
 
 # Skip cli tests on Windows while they exhibit pathological behavior
 # https://github.com/ros2/build_farmer/issues/248
@@ -562,3 +564,20 @@ class TestROS2InterfaceCLI(unittest.TestCase):
             text=interface_command.output,
             strict=True
         )
+
+
+@pytest.mark.parametrize('line_text', [
+    '#',
+    '    #',
+    '# comment',
+    '    # comment',
+])
+def test_interface_text_line_is_comment(line_text):
+    line = InterfaceTextLine('test_pkg', 'Test', line_text)
+    assert line.is_comment()
+
+
+def test_interface_text_line_trailing_comment_is_not_full_line_comment():
+    line = InterfaceTextLine('test_pkg', 'Test', 'int32 value  # trailing comment')
+    assert not line.is_comment()
+    assert line.is_trailing_comment()


### PR DESCRIPTION
The is_comment() method only checked the rosidl_adapter parser result, which stores an empty list for comment-only lines, making is_comment() return False. Those lines then leaked through --no-comments.

Fix: check `self._raw_line_text.lstrip().startswith("#")` instead of relying on the parser. This catches bare `#`, indented `#`, `# comment`, and `    # comment`, while correctly not matching trailing comments like `int32 value  # comment`.

Added unit tests for is_comment() covering these cases.