### PR TITLE
Test ros2 lifecycle output streams

### DIFF
--- a/ros2lifecycle/test/test_cli.py
+++ b/ros2lifecycle/test/test_cli.py
@@ -319,9 +319,10 @@ class TestROS2LifecycleCLI(unittest.TestCase):
                 '- configure [1]',
                 '- shutdown [5]'
             ],
-            text=lifecycle_command.output,
+            text=lifecycle_command.stderr,
             strict=False
         )
+        assert not lifecycle_command.stdout
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_set_nonexistent_lifecycle_node_state(self):
@@ -332,9 +333,10 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert lifecycle_command.exit_code == 1
         assert launch_testing.tools.expect_output(
             expected_lines=['Node not found'],
-            text=lifecycle_command.output,
+            text=lifecycle_command.stderr,
             strict=True
         )
+        assert not lifecycle_command.stdout
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_set_hidden_lifecycle_node_transition(self):
@@ -345,9 +347,10 @@ class TestROS2LifecycleCLI(unittest.TestCase):
         assert lifecycle_command.exit_code == 1
         assert launch_testing.tools.expect_output(
             expected_lines=['Node not found'],
-            text=lifecycle_command.output,
+            text=lifecycle_command.stderr,
             strict=True
         )
+        assert not lifecycle_command.stdout
 
     @launch_testing.markers.retry_on_failure(times=5, delay=1)
     def test_get_nonexistent_lifecycle_node_state(self):
@@ -428,9 +431,10 @@ class TestROS2LifecycleCLI(unittest.TestCase):
             assert lifecycle_command.exit_code == launch_testing.asserts.EXIT_OK
             assert launch_testing.tools.expect_output(
                 expected_lines=['Transitioning successful'],
-                text=lifecycle_command.output,
+                text=lifecycle_command.stdout,
                 strict=False
             )
+            assert not lifecycle_command.stderr
 
         with self.launch_lifecycle_command(
             arguments=['get', '--include-hidden-nodes', '/_hidden_test_lifecycle_node']


### PR DESCRIPTION
## Description

Verify that `ros2 lifecycle set` writes command errors to stderr and successful transitions to stdout. Also require the unused stream to remain empty so regressions cannot pass through combined process output.

Addresses #484

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

Validation:

* `python3 -m compileall -q ros2lifecycle/test/test_cli.py`
* `git diff --check origin/rolling...HEAD`

The full ROS integration test was not run locally because this environment does not contain ROS 2 or `colcon`.
