### PR TITLE
Add multicast options to ros2 doctor hello

### DIFF
--- a/ros2doctor/ros2doctor/verb/hello.py
+++ b/ros2doctor/ros2doctor/verb/hello.py
@@ -71,6 +71,12 @@ class HelloVerb(VerbExtension):
             '-pp', '--print-period', metavar='N', type=positive_float, default=1.0,
             help='Time period to print summary table (default: 1.0s)')
         parser.add_argument(
+            '--group', type=str, default=DEFAULT_GROUP,
+            help=f'Multicast group address (default: {DEFAULT_GROUP})')
+        parser.add_argument(
+            '--port', type=positive_int, default=DEFAULT_PORT,
+            help=f'Multicast port (default: {DEFAULT_PORT})')
+        parser.add_argument(
             '--ttl', type=positive_int,
             help='TTL for multicast send (default: None)')
         parser.add_argument(
@@ -83,8 +89,10 @@ class HelloVerb(VerbExtension):
         with DirectNode(args, node_name=NODE_NAME_PREFIX + '_node') as node:
             publisher = HelloPublisher(node, args.topic, summary_table)
             subscriber = HelloSubscriber(node, args.topic, summary_table)
-            sender = HelloMulticastUDPSender(summary_table, ttl=args.ttl)
-            receiver = HelloMulticastUDPReceiver(summary_table)
+            sender = HelloMulticastUDPSender(
+                summary_table, group=args.group, port=args.port, ttl=args.ttl)
+            receiver = HelloMulticastUDPReceiver(
+                summary_table, group=args.group, port=args.port)
             receiver_thread = threading.Thread(target=receiver.recv)
             receiver_thread.start()
 
@@ -108,14 +116,18 @@ class HelloVerb(VerbExtension):
                 while rclpy.ok():
                     current_time = clock.now()
                     if (current_time - prev_time) > print_period:
-                        summary_table.format_print_summary(args.topic, args.print_period)
+                        summary_table.format_print_summary(
+                            args.topic, args.print_period,
+                            group=args.group, port=args.port)
                         summary_table.reset()
                         prev_time = current_time
                     publisher.publish()
                     sender.send()
                     emit_rate.sleep()
                     if args.once:
-                        summary_table.format_print_summary(args.topic, args.print_period)
+                        summary_table.format_print_summary(
+                            args.topic, args.print_period,
+                            group=args.group, port=args.port)
                         break
             except KeyboardInterrupt:
                 pass

--- a/ros2doctor/ros2doctor/verb/hello.py
+++ b/ros2doctor/ros2doctor/verb/hello.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from argparse import ArgumentTypeError
+import ipaddress
 import os
 import re
 import socket
@@ -50,6 +51,16 @@ positive_float = positive(float)
 positive_int = positive(int)
 
 
+def multicast_address(string):
+    try:
+        address = ipaddress.IPv4Address(string)
+    except ipaddress.AddressValueError:
+        raise ArgumentTypeError('value must be an IPv4 multicast address') from None
+    if not address.is_multicast:
+        raise ArgumentTypeError('value must be an IPv4 multicast address')
+    return string
+
+
 class HelloVerb(VerbExtension):
     """
     Check network connectivity between multiple hosts.
@@ -71,7 +82,7 @@ class HelloVerb(VerbExtension):
             '-pp', '--print-period', metavar='N', type=positive_float, default=1.0,
             help='Time period to print summary table (default: 1.0s)')
         parser.add_argument(
-            '--group', type=str, default=DEFAULT_GROUP,
+            '--group', type=multicast_address, default=DEFAULT_GROUP,
             help=f'Multicast group address (default: {DEFAULT_GROUP})')
         parser.add_argument(
             '--port', type=positive_int, default=DEFAULT_PORT,

--- a/ros2doctor/test/test_cli.py
+++ b/ros2doctor/test/test_cli.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from argparse import ArgumentParser
+from argparse import Namespace
 import socket
 import unittest
 import unittest.mock as mock
@@ -25,6 +26,8 @@ import launch_testing.markers
 
 import pytest
 
+from ros2doctor.verb.hello import DEFAULT_GROUP
+from ros2doctor.verb.hello import DEFAULT_PORT
 from ros2doctor.verb.hello import HelloMulticastUDPReceiver
 from ros2doctor.verb.hello import HelloMulticastUDPSender
 from ros2doctor.verb.hello import HelloVerb
@@ -55,6 +58,36 @@ def _generate_expected_summary_table():
 
 
 class TestROS2DoctorCLI(unittest.TestCase):
+
+    def test_hello_single_host(self):
+        """Run HelloVerb for one emit period on a single host."""
+        args = Namespace()
+        args.topic = '/canyouhearme'
+        args.emit_period = 0.1
+        args.print_period = 1.0
+        args.group = DEFAULT_GROUP
+        args.port = DEFAULT_PORT
+        args.ttl = None
+        args.once = True
+        with mock.patch('socket.gethostname', return_value='!nv@lid-n*de-n4me'):
+            summary = SummaryTable()
+            hello_verb = HelloVerb()
+            hello_verb.main(args=args, summary_table=summary)
+            expected_summary = _generate_expected_summary_table()
+            self.assertEqual(summary._pub, expected_summary._pub)
+            self.assertEqual(summary._sub, expected_summary._sub)
+            self.assertEqual(summary._send, expected_summary._send)
+            self.assertEqual(summary._receive, expected_summary._receive)
+
+    def test_hello_rejects_invalid_multicast_groups(self):
+        """Reject invalid multicast group arguments."""
+        parser = ArgumentParser()
+        HelloVerb().add_arguments(parser, 'ros2 doctor hello')
+        for group in ['127.0.0.1', 'not-an-address', 'ff02::1']:
+            with self.subTest(group=group):
+                with self.assertRaises(SystemExit) as context:
+                    parser.parse_args(['--group', group])
+                self.assertEqual(context.exception.code, 2)
 
     def test_hello_single_host_custom_group_and_port(self):
         """Run HelloVerb with a custom multicast group and port."""

--- a/ros2doctor/test/test_cli.py
+++ b/ros2doctor/test/test_cli.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import Namespace
+from argparse import ArgumentParser
+import socket
 import unittest
 import unittest.mock as mock
 
@@ -24,6 +25,8 @@ import launch_testing.markers
 
 import pytest
 
+from ros2doctor.verb.hello import HelloMulticastUDPReceiver
+from ros2doctor.verb.hello import HelloMulticastUDPSender
 from ros2doctor.verb.hello import HelloVerb
 from ros2doctor.verb.hello import SummaryTable
 
@@ -53,20 +56,39 @@ def _generate_expected_summary_table():
 
 class TestROS2DoctorCLI(unittest.TestCase):
 
-    def test_hello_single_host(self):
-        """Run HelloVerb for one emit period on a single host."""
-        args = Namespace()
-        args.topic = '/canyouhearme'
-        args.emit_period = 0.1
-        args.print_period = 1.0
-        args.ttl = None
-        args.once = True
-        with mock.patch('socket.gethostname', return_value='!nv@lid-n*de-n4me'):
+    def test_hello_single_host_custom_group_and_port(self):
+        """Run HelloVerb with a custom multicast group and port."""
+        group = '225.0.0.2'
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.bind(('', 0))
+            port = sock.getsockname()[1]
+        parser = ArgumentParser()
+        hello_verb = HelloVerb()
+        hello_verb.add_arguments(parser, 'ros2 doctor hello')
+        args = parser.parse_args([
+            '--group', group, '--port', str(port), '--once'])
+        with mock.patch('socket.gethostname', return_value='!nv@lid-n*de-n4me'), \
+                mock.patch(
+                    'ros2doctor.verb.hello.HelloMulticastUDPSender',
+                    wraps=HelloMulticastUDPSender) as sender, \
+                mock.patch(
+                    'ros2doctor.verb.hello.HelloMulticastUDPReceiver',
+                    wraps=HelloMulticastUDPReceiver) as receiver, \
+                mock.patch.object(
+                    SummaryTable, 'format_print_summary',
+                    wraps=SummaryTable.format_print_summary,
+                    autospec=True) as format_print_summary:
             summary = SummaryTable()
-            hello_verb = HelloVerb()
             hello_verb.main(args=args, summary_table=summary)
             expected_summary = _generate_expected_summary_table()
             self.assertEqual(summary._pub, expected_summary._pub)
             self.assertEqual(summary._sub, expected_summary._sub)
             self.assertEqual(summary._send, expected_summary._send)
             self.assertEqual(summary._receive, expected_summary._receive)
+            sender.assert_called_once_with(
+                summary, group=args.group, port=args.port, ttl=args.ttl)
+            receiver.assert_called_once_with(
+                summary, group=args.group, port=args.port)
+            format_print_summary.assert_called_once_with(
+                summary, args.topic, args.print_period,
+                group=args.group, port=args.port)


### PR DESCRIPTION
## Description

Add optional `--group` and `--port` arguments to `ros2 doctor hello`. The selected values are used by the multicast sender and receiver and shown in the summary. Existing defaults remain unchanged.

This implements the multicast configuration part of #1077. The other enhancements in that issue are outside this PR.

### Is this user-facing behavior change?

Yes. Users can select the multicast group and port used by `ros2 doctor hello`.

### Additional Information

Post-review validation:

- `git diff --check origin/rolling...HEAD`
- `python3 -m py_compile ros2doctor/ros2doctor/verb/hello.py ros2doctor/test/test_cli.py`
- focused argument validation accepted `225.0.0.2` and rejected `127.0.0.1`, `not-an-address`, and `ff02::1`
- `ament_flake8` and `ament_pep257` passed on the changed files

The full ROS 2 package test suite was not rerun after the review update.