### PR TITLE
Add ros2 pkg depends verb

### DIFF
--- a/ros2pkg/ros2pkg/verb/depends.py
+++ b/ros2pkg/ros2pkg/verb/depends.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Miko Parkkinen.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python import get_package_share_directory
+from ament_index_python import PackageNotFoundError
+from catkin_pkg.package import parse_package
+
+from ros2pkg.api import package_name_completer
+from ros2pkg.verb import VerbExtension
+
+
+PACKAGE_NOT_FOUND = 'Package not found'
+PACKAGE_XML_NOT_FOUND = 'Package XML manifest not found'
+
+DEPENDENCY_ATTRIBUTES = (
+    'build_depends',
+    'buildtool_depends',
+    'build_export_depends',
+    'buildtool_export_depends',
+    'exec_depends',
+    'test_depends',
+    'doc_depends',
+)
+
+
+class DependsVerb(VerbExtension):
+    """Output the direct dependencies declared by a package."""
+
+    def add_arguments(self, parser, cli_name):
+        arg = parser.add_argument(
+            'package_name',
+            help='The package name')
+        arg.completer = package_name_completer
+
+    def main(self, *, args):
+        try:
+            package_share_dir = get_package_share_directory(args.package_name)
+        except PackageNotFoundError:
+            return PACKAGE_NOT_FOUND
+
+        package_xml = os.path.join(package_share_dir, 'package.xml')
+        if not os.path.isfile(package_xml):
+            return PACKAGE_XML_NOT_FOUND
+
+        package = parse_package(package_xml)
+        package.evaluate_conditions(os.environ)
+
+        dependencies = {
+            dependency.name
+            for attribute in DEPENDENCY_ATTRIBUTES
+            for dependency in getattr(package, attribute)
+            if dependency.evaluated_condition
+        }
+        for dependency in sorted(dependencies):
+            print(dependency)

--- a/ros2pkg/setup.py
+++ b/ros2pkg/setup.py
@@ -44,6 +44,7 @@ The package provides the pkg command for the ROS 2 command line tools.""",
         ],
         'ros2pkg.verb': [
             'create = ros2pkg.verb.create:CreateVerb',
+            'depends = ros2pkg.verb.depends:DependsVerb',
             'executables = ros2pkg.verb.executables:ExecutablesVerb',
             'list = ros2pkg.verb.list:ListVerb',
             'prefix = ros2pkg.verb.prefix:PrefixVerb',

--- a/ros2pkg/test/test_cli.py
+++ b/ros2pkg/test/test_cli.py
@@ -101,6 +101,36 @@ class TestROS2PkgCLI(unittest.TestCase):
             strict=True
         )
 
+    def test_package_dependencies(self):
+        with self.launch_pkg_command(arguments=['depends', 'ros2pkg']) as pkg_command:
+            assert pkg_command.wait_for_shutdown(timeout=2)
+        assert pkg_command.exit_code == launch_testing.asserts.EXIT_OK
+        assert pkg_command.output.splitlines() == [
+            'ament_copyright',
+            'ament_flake8',
+            'ament_index_python',
+            'ament_pep257',
+            'ament_xmllint',
+            'launch',
+            'launch_testing',
+            'launch_testing_ros',
+            'python3-catkin-pkg-modules',
+            'python3-empy',
+            'python3-pytest',
+            'python3-pytest-timeout',
+            'ros2cli',
+        ]
+
+    def test_not_a_package_dependencies(self):
+        with self.launch_pkg_command(arguments=['depends', 'not_a_package']) as pkg_command:
+            assert pkg_command.wait_for_shutdown(timeout=2)
+        assert pkg_command.exit_code == 1
+        assert launch_testing.tools.expect_output(
+            expected_lines=['Package not found'],
+            text=pkg_command.output,
+            strict=True
+        )
+
     def test_xml(self):
         with self.launch_pkg_command(arguments=['xml', 'ros2cli']) as pkg_command:
             assert pkg_command.wait_for_shutdown(timeout=2)

--- a/ros2pkg/test/test_depends.py
+++ b/ros2pkg/test/test_depends.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Miko Parkkinen.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import Namespace
+
+from ros2pkg.verb.depends import DependsVerb
+
+
+PACKAGE_XML = '''\
+<package format="3">
+  <name>test_package</name>
+  <version>0.0.0</version>
+  <description>Test package</description>
+  <maintainer email="test@example.com">Test</maintainer>
+  <license>Apache-2.0</license>
+  <depend>common_dependency</depend>
+  <buildtool_depend>buildtool_dependency</buildtool_depend>
+  <test_depend>test_dependency</test_depend>
+  <exec_depend condition="$DEPENDENCY_ENABLED == 1">enabled_dependency</exec_depend>
+  <exec_depend condition="$DEPENDENCY_ENABLED == 0">disabled_dependency</exec_depend>
+</package>
+'''
+
+
+def test_depends(tmp_path, monkeypatch, capsys):
+    (tmp_path / 'package.xml').write_text(PACKAGE_XML)
+    monkeypatch.setattr(
+        'ros2pkg.verb.depends.get_package_share_directory',
+        lambda package_name: str(tmp_path))
+    monkeypatch.setenv('DEPENDENCY_ENABLED', '1')
+
+    result = DependsVerb().main(args=Namespace(package_name='test_package'))
+
+    assert result is None
+    assert capsys.readouterr().out.splitlines() == [
+        'buildtool_dependency',
+        'common_dependency',
+        'enabled_dependency',
+        'test_dependency',
+    ]


### PR DESCRIPTION
## Description

Add `ros2 pkg depends <package_name>` to print the package's direct declared dependencies.

The verb reads the installed `package.xml`, evaluates dependency conditions against the current environment, and prints unique dependency names in sorted order. Recursive lookup and dependency-type filters are outside this PR.

Addresses #44

### Is this user-facing behavior change?

Yes. `ros2 pkg` now provides a `depends` verb for installed packages.

### Additional Information

Validation:

- focused unit and CLI tests: 2 passed
- `ros2pkg` tests excluding unavailable `xmllint`: 6 passed, 1 deselected
- copyright, flake8, and pep257: 3 passed
- `git diff --check`

`xmllint` was not available in the test environment. This PR does not change XML files.