### PR TITLE
Improve ros2 lifecycle set transition help

### DIFF
--- a/ros2lifecycle/ros2lifecycle/verb/set.py
+++ b/ros2lifecycle/ros2lifecycle/verb/set.py
@@ -40,7 +40,9 @@ class SetVerb(VerbExtension):
             '--include-hidden-nodes', action='store_true',
             help='Consider hidden nodes as well')
         parser.add_argument(
-            'transition', help='The lifecycle transition')
+            'transition',
+            help='The lifecycle transition. Use `ros2 lifecycle list NODE_NAME` '
+                 'to see transitions available from the current state')
         parser.add_argument(
             '--timeout', metavar='N', type=float,
             help='Maximum time to wait for response in seconds '


### PR DESCRIPTION
## Summary

Fixes #122.

Improve the `ros2 lifecycle set` transition argument help so users are pointed directly to `ros2 lifecycle list NODE_NAME`, which reports transitions available from the node's current state.

This avoids duplicating a static transition list in help text and uses the existing lifecycle query command.

## Validation

- Help-text-only change
- Branch is one signed commit and one file ahead of Rolling

### Did you use Generative AI?

Yes. AI was used to assist with tests.
