### PR TITLE
Make ros2 topic delay precision configurable

### DIFF
--- a/ros2topic/ros2topic/verb/delay.py
+++ b/ros2topic/ros2topic/verb/delay.py
@@ -35,6 +35,7 @@ import rclpy
 
 from rclpy.time import Time
 
+from ros2cli.helpers import unsigned_int
 from ros2cli.node.direct import add_arguments as add_direct_node_arguments
 from ros2cli.node.direct import DirectNode
 from ros2cli.qos import add_qos_arguments
@@ -46,6 +47,7 @@ from ros2topic.api import TopicNameCompleter
 from ros2topic.verb import VerbExtension
 
 DEFAULT_WINDOW_SIZE = 10000
+DEFAULT_PRECISION = 3
 
 
 class DelayVerb(VerbExtension):
@@ -62,6 +64,10 @@ class DelayVerb(VerbExtension):
             '--window', '-w', dest='window_size', type=positive_int, default=DEFAULT_WINDOW_SIZE,
             help='window size, in # of messages, for calculating rate, '
                  'string to (default: %d)' % DEFAULT_WINDOW_SIZE)
+        parser.add_argument(
+            '--precision', type=unsigned_int, default=DEFAULT_PRECISION,
+            help='number of decimal places for average, minimum, and maximum delay '
+                 '(default: %(default)s)')
         add_direct_node_arguments(parser)
 
     def main(self, *, args):
@@ -72,13 +78,14 @@ def main(args):
     with DirectNode(args) as node:
         qos_profile = choose_qos(node.node, topic_name=args.topic_name, qos_args=args)
         return _rostopic_delay(
-            node.node, args.topic_name, qos_profile, window_size=args.window_size)
+            node.node, args.topic_name, qos_profile, window_size=args.window_size,
+            precision=args.precision)
 
 
 class ROSTopicDelay(object):
     """Receives messages for a topic and computes timestamp delay."""
 
-    def __init__(self, node, window_size):
+    def __init__(self, node, window_size, precision=DEFAULT_PRECISION):
         import threading
         self.lock = threading.Lock()
         self.last_msg_tn = 0
@@ -87,6 +94,7 @@ class ROSTopicDelay(object):
         self.delays = []
 
         self.window_size = window_size
+        self.precision = precision
 
         self._clock = node.get_clock()
 
@@ -156,17 +164,23 @@ class ROSTopicDelay(object):
             return
         delay, min_delta, max_delta, std_dev, window = ret
         # convert nanoseconds to seconds when print
-        print('average delay: %.3f\n\tmin: %.3fs max: %.3fs std dev: %.5fs window: %s'
-              % (delay * 1e-9, min_delta * 1e-9, max_delta * 1e-9, std_dev * 1e-9, window))
+        print(
+            f'average delay: {delay * 1e-9:.{self.precision}f}\n'
+            f'\tmin: {min_delta * 1e-9:.{self.precision}f}s '
+            f'max: {max_delta * 1e-9:.{self.precision}f}s '
+            f'std dev: {std_dev * 1e-9:.5f}s window: {window}')
 
 
-def _rostopic_delay(node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE):
+def _rostopic_delay(
+    node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE, precision=DEFAULT_PRECISION
+):
     """
     Periodically print the publishing delay of a topic to console until shutdown.
 
     :param topic: topic name, ``str``
     :param qos_profile: qos profile of the subscriber
     :param window_size: number of messages to average over, ``unsigned_int``
+    :param precision: number of decimal places for average/minimum/maximum delay, ``unsigned_int``
     :param blocking: pause delay until topic is published, ``bool``
     """
     # pause hz until topic is published
@@ -176,7 +190,7 @@ def _rostopic_delay(node, topic, qos_profile, window_size=DEFAULT_WINDOW_SIZE):
         node.destroy_node()
         return 1
 
-    rt = ROSTopicDelay(node, window_size)
+    rt = ROSTopicDelay(node, window_size, precision=precision)
     node.create_subscription(
         msg_class,
         topic,

--- a/ros2topic/test/test_delay_precision.py
+++ b/ros2topic/test/test_delay_precision.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Sylvester Kaczmarek
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ros2topic.verb.delay import ROSTopicDelay
+
+
+class _Node:
+
+    def get_clock(self):
+        return object()
+
+
+def _delay_output(capsys, precision=3):
+    delay = ROSTopicDelay(_Node(), window_size=10, precision=precision)
+    delay.delays = [1234567, 2345678]
+    delay.msg_tn = 1
+
+    delay.print_delay()
+
+    return capsys.readouterr().out
+
+
+def test_default_delay_precision(capsys):
+    output = _delay_output(capsys)
+
+    assert 'average delay: 0.002\n' in output
+    assert '\tmin: 0.001s max: 0.002s' in output
+    assert 'std dev: 0.00056s window: 2' in output
+
+
+def test_custom_delay_precision(capsys):
+    output = _delay_output(capsys, precision=6)
+
+    assert 'average delay: 0.001790\n' in output
+    assert '\tmin: 0.001235s max: 0.002346s' in output
+    assert 'std dev: 0.00056s window: 2' in output


### PR DESCRIPTION
## Summary

Addresses the output-precision part of #1214.

Add `--precision` to `ros2 topic delay` so users measuring millisecond-scale delays can request more decimal places for the average, minimum, and maximum values.

The default remains 3 decimal places, preserving existing output. Standard deviation keeps its existing 5-decimal formatting.

Example:

`ros2 topic delay /camera/image --precision 6`

## Testing

Added focused coverage for default and custom precision formatting.

### Did you use Generative AI?

Yes. AI was used to assist with tests.