### PR TITLE
Support 64-bit integers in daemon XML-RPC

### DIFF
--- a/ros2cli/ros2cli/xmlrpc/marshal/__init__.py
+++ b/ros2cli/ros2cli/xmlrpc/marshal/__init__.py
@@ -14,5 +14,13 @@
 
 # flake8: noqa: A005
 
+from xmlrpc.client import Marshaller
+
+from .generic import dump_int
+
+# Python's XML-RPC unmarshaller accepts the i8 extension, but the stock
+# marshaller rejects integers outside the signed 32-bit range.
+Marshaller.dispatch[int] = dump_int
+
 # Force rclpy specific xmlrpc (un)marshalling logic importation.
-from . import rclpy  # noqa: F401
+from . import rclpy  # noqa: E402,F401

--- a/ros2cli/ros2cli/xmlrpc/marshal/generic.py
+++ b/ros2cli/ros2cli/xmlrpc/marshal/generic.py
@@ -12,9 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from xmlrpc.client import MAXINT
+from xmlrpc.client import MININT
+
+
+I8_MIN = -(1 << 63)
+I8_MAX = (1 << 63) - 1
+
 
 def fullname(klass):
     return f'{klass.__module__}.{klass.__name__}'
+
+
+def dump_int(marshaller, value, write):
+    """Marshal Python integers using XML-RPC int or the standard i8 extension."""
+    if MININT <= value <= MAXINT:
+        tag = 'int'
+    elif I8_MIN <= value <= I8_MAX:
+        tag = 'i8'
+    else:
+        raise OverflowError('int exceeds XML-RPC i8 limits')
+    write(f'<value><{tag}>{value}</{tag}></value>\n')
 
 
 def end_any_with_slots(unmarshaller, data, type_):

--- a/ros2cli/test/test_xmlrpc_int64.py
+++ b/ros2cli/test/test_xmlrpc_int64.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
+from unittest.mock import patch
 from xmlrpc.client import dumps
 from xmlrpc.client import loads
 
 import pytest
 
+import ros2cli.daemon as daemon
+from ros2cli.node.daemon import DaemonNode
 import ros2cli.xmlrpc  # noqa: F401
+from ros2cli.xmlrpc.local_server import LocalXMLRPCServer
 
 
 @pytest.mark.parametrize('value', [
@@ -44,3 +49,27 @@ def test_int32_still_uses_standard_int_tag():
 def test_integer_outside_int64_range_is_rejected(value):
     with pytest.raises(OverflowError, match='XML-RPC i8 limits'):
         dumps((value,))
+
+
+def test_int64_round_trip_through_daemon_xmlrpc_client():
+    server = LocalXMLRPCServer(
+        ('127.0.0.1', 0),
+        logRequests=False,
+        requestHandler=daemon.RequestHandler,
+        allow_none=True,
+    )
+    server.register_function(lambda value: value, 'echo_int64')
+    server_url = daemon.get_xmlrpc_server_url(server.server_address)
+    server_thread = threading.Thread(target=server.handle_request)
+    server_thread.start()
+
+    try:
+        with patch.object(daemon, 'get_xmlrpc_server_url', return_value=server_url):
+            with DaemonNode(args=[]) as daemon_node:
+                value = 1 << 40
+                assert daemon_node.echo_int64(value) == value
+    finally:
+        server_thread.join(timeout=5.0)
+        server.server_close()
+
+    assert not server_thread.is_alive()

--- a/ros2cli/test/test_xmlrpc_int64.py
+++ b/ros2cli/test/test_xmlrpc_int64.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from xmlrpc.client import dumps
+from xmlrpc.client import loads
+
+import pytest
+
+import ros2cli.xmlrpc  # noqa: F401
+
+
+@pytest.mark.parametrize('value', [
+    -(1 << 63),
+    -(1 << 31) - 1,
+    1 << 31,
+    (1 << 63) - 1,
+])
+def test_int64_round_trip(value):
+    payload = dumps((value,))
+
+    assert '<i8>' in payload
+    assert loads(payload)[0] == (value,)
+
+
+def test_int32_still_uses_standard_int_tag():
+    payload = dumps((42,))
+
+    assert '<int>42</int>' in payload
+    assert loads(payload)[0] == (42,)
+
+
+@pytest.mark.parametrize('value', [-(1 << 63) - 1, 1 << 63])
+def test_integer_outside_int64_range_is_rejected(value):
+    with pytest.raises(OverflowError, match='XML-RPC i8 limits'):
+        dumps((value,))

--- a/ros2cli/test/test_xmlrpc_int64.py
+++ b/ros2cli/test/test_xmlrpc_int64.py
@@ -22,7 +22,6 @@ import pytest
 import ros2cli.daemon as daemon
 from ros2cli.node.daemon import DaemonNode
 import ros2cli.xmlrpc  # noqa: F401
-from ros2cli.xmlrpc.local_server import LocalXMLRPCServer
 
 
 @pytest.mark.parametrize('value', [
@@ -52,12 +51,9 @@ def test_integer_outside_int64_range_is_rejected(value):
 
 
 def test_int64_round_trip_through_daemon_xmlrpc_client():
-    server = LocalXMLRPCServer(
-        ('127.0.0.1', 0),
-        logRequests=False,
-        requestHandler=daemon.RequestHandler,
-        allow_none=True,
-    )
+    with patch.object(daemon, 'get_address', return_value=('127.0.0.1', 0)):
+        server = daemon.make_xmlrpc_server()
+    server.timeout = 1.0
     server.register_function(lambda value: value, 'echo_int64')
     server_url = daemon.get_xmlrpc_server_url(server.server_address)
     server_thread = threading.Thread(target=server.handle_request)


### PR DESCRIPTION
## Summary

Fixes #629.

Python's standard XML-RPC marshaller rejects integers outside the signed 32-bit range even though its unmarshaller supports the standard `i8` extension.

Register a custom integer marshaller that:
- preserves the normal `int` tag for signed 32-bit values
- uses `i8` for signed 64-bit values
- continues rejecting values outside signed 64-bit range

This allows daemon RPC payloads to carry 64-bit integer values without changing existing 32-bit output.

## Testing

Added focused round-trip coverage for:
- signed 32-bit values using `int`
- positive and negative values outside 32-bit using `i8`
- signed 64-bit boundaries
- rejection outside the signed 64-bit range

### Did you use Generative AI?

Yes. AI was used to assist with tests.