### PR TITLE
Make topic CLI tests wait on command output

### DIFF
--- a/ros2topic/test/test_bw_delay_hz.py
+++ b/ros2topic/test/test_bw_delay_hz.py
@@ -42,6 +42,7 @@ from rclpy.qos import QoSCompatibility
 from rclpy.qos import QoSProfile
 from rclpy.qos import ReliabilityPolicy
 from rclpy.utilities import get_rmw_implementation_identifier
+from ros2cli.node.strategy import NodeStrategy
 
 
 # Skip cli tests on Windows while they exhibit pathological behavior
@@ -102,6 +103,15 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
         self.node.destroy_node()
         rclpy.shutdown(context=self.context)
 
+    def _wait_for_daemon_publishers(self, topics):
+        """Wait until the CLI daemon has discovered all publishers under test."""
+        with NodeStrategy(None) as node:
+            for _ in range(30):
+                self.executor.spin_once(timeout_sec=0.1)
+                if all(node.count_publishers(topic) > 0 for topic in topics):
+                    return
+        self.fail('Publishers were not discovered by the CLI daemon')
+
     def helper_verb_basic(self, launch_service, proc_info, proc_output, verb, success_regex):
         params = [
             (f'/clitest/topic/{verb}_basic', False, True),
@@ -156,15 +166,7 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
                     publisher.publish(msg)
 
                 publish_timer = self.node.create_timer(0.5, publish_message)
-
-                # Wait for the publisher to be discovered
-                publisher_count = 0
-                timeout_count = 0
-                while publisher_count == 0 and timeout_count < 10:
-                    self.executor.spin_once(timeout_sec=0.1)
-                    publisher_count = self.node.count_publishers(topic)
-                    timeout_count += 1
-                assert publisher_count > 0, 'Publisher was not discovered'
+                self._wait_for_daemon_publishers([topic])
 
                 try:
                     command_action = ExecuteProcess(
@@ -257,16 +259,7 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
             timer = self.node.create_timer(0.5, publish_message)
             timers.append(timer)
 
-        # Wait for all the publishers to be discovered
-        timeout_count = 0
-        all_discovered = False
-        while not all_discovered and timeout_count < 30:
-            self.executor.spin_once(timeout_sec=0.1)
-            all_discovered = all(
-                self.node.count_publishers(topic) > 0 for topic in topics
-            )
-            timeout_count += 1
-        assert all_discovered, 'Not all publishers were discovered'
+        self._wait_for_daemon_publishers(topics)
 
         try:
             command_action = ExecuteProcess(
@@ -356,17 +349,7 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
             publisher2.publish(msg)
 
         publish_timer = self.node.create_timer(0.5, publish_messages)
-
-        # Wait for the publishers to be discovered
-        timeout_count = 0
-        while timeout_count < 10:
-            self.executor.spin_once(timeout_sec=0.1)
-            if (self.node.count_publishers(topic1) > 0 and
-                    self.node.count_publishers(topic2) > 0):
-                break
-            timeout_count += 1
-        assert self.node.count_publishers(topic1) > 0, 'Publisher 1 was not discovered'
-        assert self.node.count_publishers(topic2) > 0, 'Publisher 2 was not discovered'
+        self._wait_for_daemon_publishers([topic1, topic2])
 
         try:
             command_action = ExecuteProcess(
@@ -422,16 +405,7 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
             timer = self.node.create_timer(0.5, publish_message)
             timers.append(timer)
 
-        # Wait for all the publishers to be discovered
-        timeout_count = 0
-        all_discovered = False
-        while not all_discovered and timeout_count < 30:
-            self.executor.spin_once(timeout_sec=0.1)
-            all_discovered = all(
-                self.node.count_publishers(topic) > 0 for topic in topics
-            )
-            timeout_count += 1
-        assert all_discovered, 'Not all publishers were discovered'
+        self._wait_for_daemon_publishers(topics)
 
         try:
             command_action = ExecuteProcess(

--- a/ros2topic/test/test_bw_delay_hz.py
+++ b/ros2topic/test/test_bw_delay_hz.py
@@ -42,7 +42,6 @@ from rclpy.qos import QoSCompatibility
 from rclpy.qos import QoSProfile
 from rclpy.qos import ReliabilityPolicy
 from rclpy.utilities import get_rmw_implementation_identifier
-from ros2cli.node.strategy import NodeStrategy
 
 
 # Skip cli tests on Windows while they exhibit pathological behavior
@@ -103,15 +102,6 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
         self.node.destroy_node()
         rclpy.shutdown(context=self.context)
 
-    def _wait_for_daemon_publishers(self, topics):
-        """Wait until the CLI daemon has discovered all publishers under test."""
-        with NodeStrategy(None) as node:
-            for _ in range(30):
-                self.executor.spin_once(timeout_sec=0.1)
-                if all(node.count_publishers(topic) > 0 for topic in topics):
-                    return
-        self.fail('Publishers were not discovered by the CLI daemon')
-
     def helper_verb_basic(self, launch_service, proc_info, proc_output, verb, success_regex):
         params = [
             (f'/clitest/topic/{verb}_basic', False, True),
@@ -166,7 +156,6 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
                     publisher.publish(msg)
 
                 publish_timer = self.node.create_timer(0.5, publish_message)
-                self._wait_for_daemon_publishers([topic])
 
                 try:
                     command_action = ExecuteProcess(
@@ -184,10 +173,24 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
                             filtered_rmw_implementation=get_rmw_implementation_identifier()
                         )
                     ) as command:
-                        # The future won't complete - we will hit the timeout
-                        self.executor.spin_until_future_complete(
-                            rclpy.task.Future(), timeout_sec=5
+                        incompatible_qos_warning = (
+                            "New publisher discovered on topic '{}', offering incompatible"
+                            ' QoS.'.format(topic)
                         )
+                        # Keep publishing while waiting on the command under test itself.
+                        # This avoids inferring its discovery state from a different node.
+                        for _ in range(150):
+                            self.executor.spin_once(timeout_sec=0.1)
+                            output = command.output or ''
+                            if compatible_qos:
+                                if re.search(success_regex, output, flags=re.MULTILINE):
+                                    break
+                            elif incompatible_qos_warning in output:
+                                break
+                        else:
+                            self.fail(
+                                f'{verb} CLI did not produce expected output within 15 seconds'
+                            )
                     command.wait_for_shutdown(timeout=10)
                     # Check results
                     if compatible_qos:
@@ -199,10 +202,9 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
                         assert command.output, (
                             f'{verb} CLI did not print incompatible QoS warning'
                         )
-                        assert ("New publisher discovered on topic '{}', offering incompatible"
-                                ' QoS.'.format(topic) in command.output), (
-                                f'{verb} CLI did not print expected incompatible QoS warning'
-                            )
+                        assert incompatible_qos_warning in command.output, (
+                            f'{verb} CLI did not print expected incompatible QoS warning'
+                        )
                 finally:
                     # Cleanup
                     self.node.destroy_timer(publish_timer)
@@ -259,7 +261,16 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
             timer = self.node.create_timer(0.5, publish_message)
             timers.append(timer)
 
-        self._wait_for_daemon_publishers(topics)
+        # Wait for all the publishers to be discovered
+        timeout_count = 0
+        all_discovered = False
+        while not all_discovered and timeout_count < 30:
+            self.executor.spin_once(timeout_sec=0.1)
+            all_discovered = all(
+                self.node.count_publishers(topic) > 0 for topic in topics
+            )
+            timeout_count += 1
+        assert all_discovered, 'Not all publishers were discovered'
 
         try:
             command_action = ExecuteProcess(
@@ -349,7 +360,17 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
             publisher2.publish(msg)
 
         publish_timer = self.node.create_timer(0.5, publish_messages)
-        self._wait_for_daemon_publishers([topic1, topic2])
+
+        # Wait for the publishers to be discovered
+        timeout_count = 0
+        while timeout_count < 10:
+            self.executor.spin_once(timeout_sec=0.1)
+            if (self.node.count_publishers(topic1) > 0 and
+                    self.node.count_publishers(topic2) > 0):
+                break
+            timeout_count += 1
+        assert self.node.count_publishers(topic1) > 0, 'Publisher 1 was not discovered'
+        assert self.node.count_publishers(topic2) > 0, 'Publisher 2 was not discovered'
 
         try:
             command_action = ExecuteProcess(
@@ -405,7 +426,16 @@ class TestROS2TopicBwDelayHz(unittest.TestCase):
             timer = self.node.create_timer(0.5, publish_message)
             timers.append(timer)
 
-        self._wait_for_daemon_publishers(topics)
+        # Wait for all the publishers to be discovered
+        timeout_count = 0
+        all_discovered = False
+        while not all_discovered and timeout_count < 30:
+            self.executor.spin_once(timeout_sec=0.1)
+            all_discovered = all(
+                self.node.count_publishers(topic) > 0 for topic in topics
+            )
+            timeout_count += 1
+        assert all_discovered, 'Not all publishers were discovered'
 
         try:
             command_action = ExecuteProcess(


### PR DESCRIPTION
## Description

Address the timing failure tracked in #1093 by waiting on the actual `ros2 topic bw`, `delay`, or `hz` process instead of using the publishing test node as a readiness signal.

The previous test called `self.node.count_publishers()` on the same node that had just created the publisher, so that check could succeed immediately without saying anything about what the fresh `DirectNode` inside the CLI process had discovered. My first revision tried to use the daemon as an independent observer; review correctly pointed out that this still did not prove the CLI node's state and also introduced an unwanted daemon lifecycle dependency.

The revised change removes `NodeStrategy` entirely. For the basic bw/delay/hz cases, the test now launches the real CLI command, keeps spinning the publisher executor, and waits up to 15 seconds for the command itself to produce the expected success output or incompatible-QoS warning. The wait remains bounded and fails if the command under test never reaches the expected state.

I do not have a local Zenoh reproduction result for this revised head, so I am not claiming that the build-farm failure is confirmed fixed. This change replaces the invalid readiness proxy with a condition observed from the command under test; Zenoh/build-farm validation is still needed.

Addresses #1093.

### Is this user-facing behavior change?

No. This only changes integration-test synchronization.

### Additional Information

The change is now limited to the basic bw/delay/hz path where #1093 reported the failure. The existing multi-topic and `--all` tests are left unchanged.

### Did you use Generative AI?

Yes. AI was used to assist with tests.