### PR TITLE
Keep leading '~' unquoted in zsh completion. (#1279)

### DIFF
--- a/ros2cli/completion/ros2-argcomplete.zsh
+++ b/ros2cli/completion/ros2-argcomplete.zsh
@@ -23,3 +23,52 @@ __ros2cli_completion_dir=${0:a:h}
 source "$__ros2cli_completion_dir/ros2-argcomplete.bash"
 # Cleanup
 unset __ros2cli_completion_dir
+
+# argcomplete's zsh completion function hands the candidates to _describe,
+# which quotes shell metacharacters when inserting a match into the command
+# line. A leading '~' is one of them, so `ros2 bag info ~/foo<TAB>` ends up as
+# `\~/foo`, which zsh no longer expands to the home directory.
+# See https://github.com/ros2/ros2cli/issues/1279 and
+# https://github.com/kislyuk/argcomplete/issues/503.
+#
+# This function does the same as argcomplete's, except that a leading '~' or
+# '~user' is moved out of the part being completed (the "ignored prefix"), so
+# it is left as typed while the rest of the path is still quoted as needed.
+_ros2_argcomplete() {
+  local IFS=$'\013'
+  local -a completions
+  completions=($(IFS="$IFS" \
+      COMP_LINE="$BUFFER" \
+      COMP_POINT="$CURSOR" \
+      _ARGCOMPLETE=1 \
+      _ARGCOMPLETE_SHELL="zsh" \
+      _ARGCOMPLETE_SUPPRESS_SPACE=1 \
+      __python_argcomplete_run ${words[1]}))
+  local -a nosort nospace
+  autoload -Uz is-at-least
+  if is-at-least 5.8; then
+    nosort=(-o nosort)
+  fi
+  # Do not append a space after a match ending in a continuation character.
+  if [[ "${completions-}" =~ ([^\\\\]): && "${match[1]}" =~ [=/:] ]]; then
+    nospace=(-S '')
+  fi
+  if [[ "$PREFIX" == '~'* ]]; then
+    local tilde="${PREFIX%%/*}"
+    local -a stripped
+    local completion
+    for completion in "${completions[@]}"; do
+      if [[ "${completion[1,${#tilde}]}" == "$tilde" ]]; then
+        stripped+=("${completion[${#tilde}+1,-1]}")
+      else
+        stripped+=("$completion")
+      fi
+    done
+    completions=("${stripped[@]}")
+    compset -P "${(b)tilde}"
+  fi
+  _describe "${words[1]}" completions "${nosort[@]}" "${nospace[@]}"
+}
+if (( ${+functions[__python_argcomplete_run]} )); then
+  compdef _ros2_argcomplete ros2
+fi


### PR DESCRIPTION
## Description

closes https://github.com/ros2/ros2cli/issues/1279

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

not really, only gets better.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Claude Code Fable 5
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
