### PR TITLE
Add native PowerShell completion for ros2

### DIFF
--- a/ros2cli/completion/ros2-argcomplete.ps1
+++ b/ros2cli/completion/ros2-argcomplete.ps1
@@ -1,0 +1,20 @@
+Register-ArgumentCompleter -Native -CommandName ros2 -ScriptBlock {
+    param($wordToComplete, $commandLine, $cursorPosition)
+
+    # Native PowerShell completers pass the full command line as the second argument.
+    $completionFile = New-TemporaryFile
+    $env:ARGCOMPLETE_USE_TEMPFILES = 1
+    $env:_ARGCOMPLETE_STDOUT_FILENAME = $completionFile
+    $env:COMP_LINE = $commandLine
+    $env:COMP_POINT = $cursorPosition
+    $env:_ARGCOMPLETE = 1
+    $env:_ARGCOMPLETE_SUPPRESS_SPACE = 0
+    $env:_ARGCOMPLETE_IFS = "`n"
+    $env:_ARGCOMPLETE_SHELL = "powershell"
+    ros2 2>&1 | Out-Null
+
+    Get-Content $completionFile | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)
+    }
+    Remove-Item $completionFile, Env:\_ARGCOMPLETE_STDOUT_FILENAME, Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE, Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
+}

--- a/ros2cli/resource/package.dsv
+++ b/ros2cli/resource/package.dsv
@@ -1,3 +1,4 @@
 source;share/ros2cli/environment/ros2-argcomplete.bash
 source;share/ros2cli/environment/ros2-argcomplete.fish
+source;share/ros2cli/environment/ros2-argcomplete.ps1
 source;share/ros2cli/environment/ros2-argcomplete.zsh

--- a/ros2cli/setup.py
+++ b/ros2cli/setup.py
@@ -22,6 +22,7 @@ setup(
         ('share/ros2cli/environment', [
             'completion/ros2-argcomplete.bash',
             'completion/ros2-argcomplete.fish',
+            'completion/ros2-argcomplete.ps1',
             'completion/ros2-argcomplete.zsh',
         ]),
     ],

--- a/ros2cli/test/test_completion_scripts.py
+++ b/ros2cli/test/test_completion_scripts.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def _ros2cli_package_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_package_dsv_sources_powershell_completion():
+    package_dsv = _ros2cli_package_root() / 'resource' / 'package.dsv'
+
+    lines = package_dsv.read_text(encoding='utf-8').splitlines()
+
+    assert 'source;share/ros2cli/environment/ros2-argcomplete.ps1' in lines
+
+
+def test_powershell_completion_uses_full_command_line():
+    completion_script = _ros2cli_package_root() / 'completion' / 'ros2-argcomplete.ps1'
+
+    content = completion_script.read_text(encoding='utf-8')
+
+    assert 'Register-ArgumentCompleter -Native -CommandName ros2 -ScriptBlock {' in content
+    assert 'param($wordToComplete, $commandLine, $cursorPosition)' in content
+    assert '$env:COMP_LINE = $commandLine' in content


### PR DESCRIPTION
## Summary

- install a PowerShell `Register-ArgumentCompleter` hook for `ros2`
- source it through the package DSV environment hook
- forward the full command line and cursor position through argcomplete's native protocol
- add packaging and script-contract regression tests

## Why

ROS 2 installs completion hooks for POSIX shells, but Windows PowerShell users have no packaged `ros2` tab completion. This adds the missing native hook requested in #1235.

## Verification

- `python -m pytest ros2cli/test/test_completion_scripts.py -q` (2 passed)
- live `TabExpansion2` checks in Windows PowerShell and PowerShell Core
- `git show --check`

A full ROS 2 Windows installation smoke test was not available locally.

Fixes #1235